### PR TITLE
Fix object can not be serialized error in sink

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,10 +75,26 @@ limitations under the License.
         <!-- Table ecosystem -->
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-table-planner-blink_${scala.version}</artifactId>
+            <artifactId>flink-table-common</artifactId>
             <version>${flink.version}</version>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-api-java</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-api-java-bridge_${scala.version}</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-clients_${scala.version}</artifactId>
@@ -353,20 +369,6 @@ limitations under the License.
                     <goals>
                         <goal>jar</goal>
                     </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.5</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
                     </execution>
                 </executions>
             </plugin>

--- a/src/main/java/com/starrocks/connector/flink/manager/StarRocksSinkManager.java
+++ b/src/main/java/com/starrocks/connector/flink/manager/StarRocksSinkManager.java
@@ -46,7 +46,6 @@ import com.starrocks.connector.flink.table.sink.StarRocksSinkSemantic;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.util.ExecutorThreadFactory;
-import org.apache.flink.calcite.shaded.com.google.common.collect.Lists;
 import org.apache.flink.table.api.TableColumn;
 import org.apache.flink.table.api.constraints.UniqueConstraint;
 
@@ -113,19 +112,19 @@ public class StarRocksSinkManager implements Serializable {
         this.starrocksQueryVisitor = new StarRocksQueryVisitor(jdbcConnProvider, sinkOptions.getDatabaseName(), sinkOptions.getTableName());
         // validate table structure
         typesMap = new HashMap<>();
-        typesMap.put("bigint", Lists.newArrayList(LogicalTypeRoot.BIGINT, LogicalTypeRoot.INTEGER, LogicalTypeRoot.BINARY));
-        typesMap.put("largeint", Lists.newArrayList(LogicalTypeRoot.DECIMAL, LogicalTypeRoot.BIGINT, LogicalTypeRoot.INTEGER, LogicalTypeRoot.BINARY));
-        typesMap.put("char", Lists.newArrayList(LogicalTypeRoot.CHAR, LogicalTypeRoot.VARCHAR));
-        typesMap.put("date", Lists.newArrayList(LogicalTypeRoot.DATE, LogicalTypeRoot.VARCHAR));
-        typesMap.put("datetime", Lists.newArrayList(LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE, LogicalTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE, LogicalTypeRoot.VARCHAR));
-        typesMap.put("decimal", Lists.newArrayList(LogicalTypeRoot.DECIMAL, LogicalTypeRoot.BIGINT, LogicalTypeRoot.INTEGER, LogicalTypeRoot.DOUBLE, LogicalTypeRoot.FLOAT));
-        typesMap.put("double", Lists.newArrayList(LogicalTypeRoot.DOUBLE, LogicalTypeRoot.BIGINT, LogicalTypeRoot.INTEGER));
-        typesMap.put("float", Lists.newArrayList(LogicalTypeRoot.FLOAT, LogicalTypeRoot.INTEGER));
-        typesMap.put("int", Lists.newArrayList(LogicalTypeRoot.INTEGER, LogicalTypeRoot.BINARY));
-        typesMap.put("tinyint", Lists.newArrayList(LogicalTypeRoot.TINYINT, LogicalTypeRoot.INTEGER, LogicalTypeRoot.BINARY, LogicalTypeRoot.BOOLEAN));
-        typesMap.put("smallint", Lists.newArrayList(LogicalTypeRoot.SMALLINT, LogicalTypeRoot.INTEGER, LogicalTypeRoot.BINARY));
-        typesMap.put("varchar", Lists.newArrayList(LogicalTypeRoot.VARCHAR, LogicalTypeRoot.ARRAY, LogicalTypeRoot.MAP, LogicalTypeRoot.ROW));
-        typesMap.put("string", Lists.newArrayList(LogicalTypeRoot.CHAR, LogicalTypeRoot.VARCHAR, LogicalTypeRoot.ARRAY, LogicalTypeRoot.MAP, LogicalTypeRoot.ROW));
+        typesMap.put("bigint", Arrays.asList(LogicalTypeRoot.BIGINT, LogicalTypeRoot.INTEGER, LogicalTypeRoot.BINARY));
+        typesMap.put("largeint", Arrays.asList(LogicalTypeRoot.DECIMAL, LogicalTypeRoot.BIGINT, LogicalTypeRoot.INTEGER, LogicalTypeRoot.BINARY));
+        typesMap.put("char", Arrays.asList(LogicalTypeRoot.CHAR, LogicalTypeRoot.VARCHAR));
+        typesMap.put("date", Arrays.asList(LogicalTypeRoot.DATE, LogicalTypeRoot.VARCHAR));
+        typesMap.put("datetime", Arrays.asList(LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE, LogicalTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE, LogicalTypeRoot.VARCHAR));
+        typesMap.put("decimal", Arrays.asList(LogicalTypeRoot.DECIMAL, LogicalTypeRoot.BIGINT, LogicalTypeRoot.INTEGER, LogicalTypeRoot.DOUBLE, LogicalTypeRoot.FLOAT));
+        typesMap.put("double", Arrays.asList(LogicalTypeRoot.DOUBLE, LogicalTypeRoot.BIGINT, LogicalTypeRoot.INTEGER));
+        typesMap.put("float", Arrays.asList(LogicalTypeRoot.FLOAT, LogicalTypeRoot.INTEGER));
+        typesMap.put("int", Arrays.asList(LogicalTypeRoot.INTEGER, LogicalTypeRoot.BINARY));
+        typesMap.put("tinyint", Arrays.asList(LogicalTypeRoot.TINYINT, LogicalTypeRoot.INTEGER, LogicalTypeRoot.BINARY, LogicalTypeRoot.BOOLEAN));
+        typesMap.put("smallint", Arrays.asList(LogicalTypeRoot.SMALLINT, LogicalTypeRoot.INTEGER, LogicalTypeRoot.BINARY));
+        typesMap.put("varchar", Arrays.asList(LogicalTypeRoot.VARCHAR, LogicalTypeRoot.ARRAY, LogicalTypeRoot.MAP, LogicalTypeRoot.ROW));
+        typesMap.put("string", Arrays.asList(LogicalTypeRoot.CHAR, LogicalTypeRoot.VARCHAR, LogicalTypeRoot.ARRAY, LogicalTypeRoot.MAP, LogicalTypeRoot.ROW));
         validateTableStructure(flinkSchema);
         String version = this.starrocksQueryVisitor.getStarRocksVersion();
         this.starrocksStreamLoadVisitor = new StarRocksStreamLoadVisitor(

--- a/src/main/java/com/starrocks/connector/flink/row/sink/StarRocksDelimiterParser.java
+++ b/src/main/java/com/starrocks/connector/flink/row/sink/StarRocksDelimiterParser.java
@@ -14,9 +14,9 @@
 
 package com.starrocks.connector.flink.row.sink;
 
-import java.io.StringWriter;
+import org.apache.flink.shaded.guava18.com.google.common.base.Strings;
 
-import org.apache.flink.calcite.shaded.com.google.common.base.Strings;
+import java.io.StringWriter;
 
 public class StarRocksDelimiterParser {
 

--- a/src/main/java/com/starrocks/connector/flink/row/sink/StarRocksTableRowTransformer.java
+++ b/src/main/java/com/starrocks/connector/flink/row/sink/StarRocksTableRowTransformer.java
@@ -35,8 +35,6 @@ import com.alibaba.fastjson.serializer.SerializeWriter;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.calcite.shaded.com.google.common.collect.Maps;
-import org.apache.flink.calcite.shaded.com.google.common.collect.Lists;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.data.ArrayData;
 import org.apache.flink.table.data.DecimalData;
@@ -56,6 +54,9 @@ import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.TimestampType;
+
+import org.apache.flink.shaded.guava18.com.google.common.collect.Lists;
+import org.apache.flink.shaded.guava18.com.google.common.collect.Maps;
 
 public class StarRocksTableRowTransformer implements StarRocksIRowTransformer<RowData> {
 
@@ -145,7 +146,7 @@ public class StarRocksTableRowTransformer implements StarRocksIRowTransformer<Ro
                 return convertNestedMap(record.getMap(pos), type);
             case ROW:
                 RowType rType = (RowType)type;
-                Map<String, Object> m = Maps.newHashMap();
+                Map<String, Object> m = new HashMap<>();
                 RowData row = record.getRow(pos, rType.getFieldCount());
                 rType.getFields().parallelStream().forEach(f -> m.put(f.getName(), typeConvertion(f.getType(), row, rType.getFieldIndex(f.getName()))));
                 return m;

--- a/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksDynamicSinkFunction.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksDynamicSinkFunction.java
@@ -29,9 +29,11 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.binary.NestedRowData;
 import org.apache.flink.types.RowKind;
 import org.apache.flink.util.InstantiationUtil;
+
+import org.apache.flink.shaded.guava18.com.google.common.base.Strings;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.apache.flink.calcite.shaded.com.google.common.base.Strings;
 import net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.alter.Alter;

--- a/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksSinkOptions.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksSinkOptions.java
@@ -92,7 +92,8 @@ public class StarRocksSinkOptions implements Serializable {
 
     public StarRocksSinkOptions(ReadableConfig options, Map<String, String> optionsMap) {
         this.tableOptions = options;
-        this.tableOptionsMap = optionsMap;
+        // Can not promise the input parameter optionsMap is serializable. Use the HashMap to copy the data.
+        this.tableOptionsMap = new HashMap<>(optionsMap);
         parseSinkStreamLoadProperties();
         this.validate();
     }

--- a/src/main/java/com/starrocks/connector/flink/table/source/StarRocksDynamicSourceFunction.java
+++ b/src/main/java/com/starrocks/connector/flink/table/source/StarRocksDynamicSourceFunction.java
@@ -22,13 +22,14 @@ import com.starrocks.connector.flink.table.source.struct.SelectColumn;
 import org.apache.flink.api.common.typeinfo.TypeHint;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
-import org.apache.flink.calcite.shaded.com.google.common.base.Strings;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
 import org.apache.flink.table.api.TableSchema;
 
 import org.apache.flink.table.data.RowData;
+
+import org.apache.flink.shaded.guava18.com.google.common.base.Strings;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/starrocks/connector/flink/tools/ExecuteSQL.java
+++ b/src/main/java/com/starrocks/connector/flink/tools/ExecuteSQL.java
@@ -18,9 +18,10 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import org.apache.flink.api.java.utils.MultipleParameterTool;
-import org.apache.flink.calcite.shaded.com.google.common.base.Strings;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.TableEnvironment;
+
+import org.apache.flink.shaded.guava18.com.google.common.base.Strings;
 
 public class ExecuteSQL {
     public static void main(String[] args) throws Exception {

--- a/src/test/java/com/starrocks/connector/flink/manager/sink/StarRocksSinkManagerTest.java
+++ b/src/test/java/com/starrocks/connector/flink/manager/sink/StarRocksSinkManagerTest.java
@@ -14,12 +14,10 @@
 
 package com.starrocks.connector.flink.manager.sink;
 
-import java.util.ArrayList;
-import org.apache.flink.api.java.tuple.Tuple3;
-import org.apache.flink.calcite.shaded.com.google.common.base.Strings;
-import org.apache.flink.calcite.shaded.com.google.common.collect.Lists;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableSchema.Builder;
+
+import org.apache.flink.shaded.guava18.com.google.common.collect.Lists;
 
 import org.junit.Test;
 

--- a/src/test/java/com/starrocks/connector/flink/row/sink/StarRocksGenericRowTransformerTest.java
+++ b/src/test/java/com/starrocks/connector/flink/row/sink/StarRocksGenericRowTransformerTest.java
@@ -15,7 +15,9 @@
 package com.starrocks.connector.flink.row.sink;
 
 import org.apache.flink.api.common.functions.RuntimeContext;
-import org.apache.flink.calcite.shaded.com.google.common.base.Strings;
+
+import org.apache.flink.shaded.guava18.com.google.common.base.Strings;
+
 import org.junit.Test;
 
 import mockit.Injectable;

--- a/src/test/java/com/starrocks/connector/flink/row/sink/StarRocksTableRowTransformerTest.java
+++ b/src/test/java/com/starrocks/connector/flink/row/sink/StarRocksTableRowTransformerTest.java
@@ -16,7 +16,6 @@ package com.starrocks.connector.flink.row.sink;
 
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.calcite.shaded.com.google.common.base.Strings;
 import org.junit.Test;
 
 import mockit.Injectable;
@@ -32,14 +31,14 @@ import java.util.Map;
 
 import com.alibaba.fastjson.JSON;
 import com.starrocks.connector.flink.StarRocksSinkBaseTest;
-import com.starrocks.connector.flink.row.sink.StarRocksSerializerFactory;
-import com.starrocks.connector.flink.row.sink.StarRocksTableRowTransformer;
 
 import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
+
+import org.apache.flink.shaded.guava18.com.google.common.base.Strings;
 
 public class StarRocksTableRowTransformerTest extends StarRocksSinkBaseTest {
 

--- a/src/test/java/com/starrocks/connector/flink/table/sink/StarRocksStreamLoadVisitorTest.java
+++ b/src/test/java/com/starrocks/connector/flink/table/sink/StarRocksStreamLoadVisitorTest.java
@@ -14,19 +14,12 @@
 
 package com.starrocks.connector.flink.table.sink;
 
-import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.api.java.tuple.Tuple3;
-import org.apache.flink.calcite.shaded.com.google.common.collect.Lists;
-import org.apache.http.HttpEntity;
-import org.apache.http.entity.ByteArrayEntity;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 import com.starrocks.connector.flink.StarRocksSinkBaseTest;
 import com.starrocks.connector.flink.manager.StarRocksSinkBufferEntity;


### PR DESCRIPTION
Fix problem below and modify some code style
```
org.apache.flink.api.common.InvalidProgramException: [] is not serializable. The object probably contains or references non serializable fields.
#### 	at org.apache.flink.api.java.ClosureCleaner.clean(ClosureCleaner.java:164)
#### 	at org.apache.flink.api.java.ClosureCleaner.clean(ClosureCleaner.java:132)
#### 	at org.apache.flink.api.java.ClosureCleaner.clean(ClosureCleaner.java:132)
#### 	at org.apache.flink.api.java.ClosureCleaner.clean(ClosureCleaner.java:132)
#### 	at org.apache.flink.api.java.ClosureCleaner.clean(ClosureCleaner.java:132)
#### 	at org.apache.flink.api.java.ClosureCleaner.clean(ClosureCleaner.java:132)
#### 	at org.apache.flink.api.java.ClosureCleaner.clean(ClosureCleaner.java:132)
#### 	at org.apache.flink.api.java.ClosureCleaner.clean(ClosureCleaner.java:132)
#### 	at org.apache.flink.api.java.ClosureCleaner.clean(ClosureCleaner.java:132)
#### 	at org.apache.flink.api.java.ClosureCleaner.clean(ClosureCleaner.java:132)
#### 	at org.apache.flink.api.java.ClosureCleaner.clean(ClosureCleaner.java:132)
#### 	at org.apache.flink.api.java.ClosureCleaner.clean(ClosureCleaner.java:132)
#### 	at org.apache.flink.api.java.ClosureCleaner.clean(ClosureCleaner.java:132)
#### 	at org.apache.flink.api.java.ClosureCleaner.clean(ClosureCleaner.java:69)
#### 	at org.apache.flink.streaming.api.environment.StreamExecutionEnvironment.clean(StreamExecutionEnvironment.java:2072)
#### 	at org.apache.flink.table.planner.plan.nodes.exec.common.CommonExecSinkBase.createSinkFunctionTransformation(CommonExecSinkBase.java:170)
#### 	at org.apache.flink.table.planner.plan.nodes.exec.common.CommonExecSink.createSinkTransformation(CommonExecSink.java:139)
#### 	at org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink.translateToPlanInternal(StreamExecSink.java:134)
#### 	at org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase.translateToPlan(ExecNodeBase.java:231)
#### 	at org.apache.flink.table.planner.delegation.StreamPlanner$$anonfun$1.apply(StreamPlanner.scala:70)
#### 	at org.apache.flink.table.planner.delegation.StreamPlanner$$anonfun$1.apply(StreamPlanner.scala:69)
#### 	at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
#### 	at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
#### 	at scala.collection.Iterator$class.foreach(Iterator.scala:891)
#### 	at scala.collection.AbstractIterator.foreach(Iterator.scala:1334)
#### 	at scala.collection.IterableLike$class.foreach(IterableLike.scala:72)
#### 	at scala.collection.AbstractIterable.foreach(Iterable.scala:54)
#### 	at scala.collection.TraversableLike$class.map(TraversableLike.scala:234)
#### 	at scala.collection.AbstractTraversable.map(Traversable.scala:104)
#### 	at org.apache.flink.table.planner.delegation.StreamPlanner.translateToPlan(StreamPlanner.scala:69)
#### 	at org.apache.flink.table.planner.delegation.StreamExecutor.createStreamGraph(StreamExecutor.java:52)
#### 	at org.apache.flink.table.planner.delegation.PlannerBase.createStreamGraph(PlannerBase.scala:655)
#### 	at org.apache.flink.table.planner.delegation.StreamPlanner.explainExecNodeGraphInternal(StreamPlanner.scala:164)
#### 	at org.apache.flink.table.planner.delegation.StreamPlanner.explainExecNodeGraph(StreamPlanner.scala:157)
#### 	at org.apache.flink.table.sqlserver.execution.OperationExecutorImpl.validate(OperationExecutorImpl.java:399)
#### 	at org.apache.flink.table.sqlserver.execution.OperationExecutorImpl.validateAndGeneratePlan(OperationExecutorImpl.java:372)
#### 	at org.apache.flink.table.sqlserver.execution.DelegateOperationExecutor.lambda$validateAndGeneratePlan$25(DelegateOperationExecutor.java:233)
#### 	at java.security.AccessController.doPrivileged(Native Method)
#### 	at javax.security.auth.Subject.doAs(Subject.java:422)
#### 	at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1729)
#### 	at org.apache.flink.table.sqlserver.context.SqlServerSecurityContext.runSecured(SqlServerSecurityContext.java:72)
#### 	at org.apache.flink.table.sqlserver.execution.DelegateOperationExecutor.wrapClassLoader(DelegateOperationExecutor.java:275)
#### 	at org.apache.flink.table.sqlserver.execution.DelegateOperationExecutor.lambda$wrapExecutor$30(DelegateOperationExecutor.java:296)
#### 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
#### 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1147)
#### 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:622)
#### 	at java.lang.Thread.run(Thread.java:834)
#### Caused by: java.io.NotSerializableException: com.google.protobuf.LazyStringArrayList
#### 	at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1184)
#### 	at java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:348)
#### 	at org.apache.flink.util.InstantiationUtil.serializeObject(InstantiationUtil.java:632)
#### 	at org.apache.flink.api.java.ClosureCleaner.clean(ClosureCleaner.java:143)
#### 	... 46 more
```