### PR TITLE
Starrocks SinkFunction does not support input for StarRocksSinkRowDataWithMeta entity class

### DIFF
--- a/src/main/java/com/starrocks/connector/flink/StarRocksSink.java
+++ b/src/main/java/com/starrocks/connector/flink/StarRocksSink.java
@@ -58,7 +58,7 @@ public class StarRocksSink {
      * @param sinkOptions            StarRocksSinkOptions as the document listed, such as jdbc-url, load-url, batch size and maximum retries
      * @return SinkFunction          SinkFunction that could be add to a stream.
      */
-    public static SinkFunction<String> sink(StarRocksSinkOptions sinkOptions) {
+    public static <T> SinkFunction<T> sink(StarRocksSinkOptions sinkOptions) {
         return new StarRocksDynamicSinkFunction<>(sinkOptions);
     }
 


### PR DESCRIPTION
When multiple tables write to starRocks，The return value of the starRockssink.sink ()  must be a String。
![image](https://user-images.githubusercontent.com/84952208/168555982-35ddf944-f718-4944-9da5-49b70ee2cb14.png)
