### PR TITLE
[Bug Fix] Flink 1.13 exactly-once data repeat

### DIFF
--- a/src/main/java/com/starrocks/connector/flink/manager/StarRocksSinkManager.java
+++ b/src/main/java/com/starrocks/connector/flink/manager/StarRocksSinkManager.java
@@ -280,7 +280,10 @@ public class StarRocksSinkManager implements Serializable {
             }
             try {
                 LOG.info("StarRocks Sink is about to close.");
-                flush(null, true);
+                if (!StarRocksSinkSemantic.EXACTLY_ONCE.equals(sinkOptions.getSemantic()) || !sinkOptions.getClearDataOnClose()) {
+                    flush(null, true);
+                }
+                this.bufferMap.clear();
             } catch (Exception e) {
                 throw new RuntimeException("Writing records to StarRocks failed.", e);
             } finally {

--- a/src/main/java/com/starrocks/connector/flink/manager/StarRocksStreamLoadVisitor.java
+++ b/src/main/java/com/starrocks/connector/flink/manager/StarRocksStreamLoadVisitor.java
@@ -26,7 +26,8 @@ import com.starrocks.connector.flink.row.sink.StarRocksDelimiterParser;
 import com.starrocks.connector.flink.row.sink.StarRocksSinkOP;
 import com.starrocks.connector.flink.table.sink.StarRocksSinkOptions;
 
-import java.util.HashMap;
+import java.util.*;
+
 import org.apache.commons.codec.binary.Base64;
 import org.apache.http.HttpEntity;
 import org.apache.http.client.config.RequestConfig;
@@ -42,9 +43,6 @@ import org.apache.http.util.EntityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -181,12 +179,16 @@ public class StarRocksStreamLoadVisitor implements Serializable {
     }
 
     private String getAvailableHost() {
-        List<String> hostList = sinkOptions.getLoadUrlList();
+        List<String> hostList = new ArrayList<>(sinkOptions.getLoadUrlList());
         long tmp = pos + hostList.size();
+        Random random = new Random();
         for (; pos < tmp; pos++) {
-            String host = new StringBuilder("http://").append(hostList.get((int) (pos % hostList.size()))).toString();
+            int index = random.nextInt(hostList.size());
+            String host = new StringBuilder("http://").append(hostList.get(index)).toString();
             if (tryHttpConnection(host)) {
                 return host;
+            } else {
+                hostList.remove(index);
             }
         }
         return null;

--- a/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksSinkOptions.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksSinkOptions.java
@@ -64,6 +64,8 @@ public class StarRocksSinkOptions implements Serializable {
         .intType().defaultValue(1000).withDescription("Timeout in millisecond for connecting to the `load-url`.");
     public static final ConfigOption<String> SINK_SEMANTIC = ConfigOptions.key("sink.semantic")
         .stringType().defaultValue(StarRocksSinkSemantic.AT_LEAST_ONCE.getName()).withDescription("Fault tolerance guarantee. `at-least-once` or `exactly-once`");
+    public static final ConfigOption<Boolean> SINK_CLEAR_DATA_ON_CLOSE = ConfigOptions.key("sink.clear-data-on-close")
+            .booleanType().defaultValue(true).withDescription("On exactly-once semantic. if set to `true`,The close method clears all data to prevent data duplication.");
     public static final ConfigOption<Long> SINK_BATCH_MAX_SIZE = ConfigOptions.key("sink.buffer-flush.max-bytes")
         .longType().defaultValue(90L * MEGA_BYTES_SCALE).withDescription("Max data bytes of the flush.");
     public static final ConfigOption<Long> SINK_BATCH_MAX_ROWS = ConfigOptions.key("sink.buffer-flush.max-rows")
@@ -170,6 +172,10 @@ public class StarRocksSinkOptions implements Serializable {
 
     public Integer getSinkParallelism() {
         return tableOptions.getOptional(SINK_PARALLELISM).orElse(null);
+    }
+
+    public boolean getClearDataOnClose() {
+        return tableOptions.get(SINK_CLEAR_DATA_ON_CLOSE).booleanValue();
     }
 
     public static Builder builder() {


### PR DESCRIPTION
With precision semantics, the connector does not need to call flush in the close method.
Because flink fails, it rolls back to the last checkpoint, at which point the data is recalculated.
If you do not clear the data, data duplication will occur.