### PR TITLE
[Improvement] Implement balanced writes to StarRocks each node

### DIFF
--- a/src/main/java/com/starrocks/connector/flink/manager/StarRocksStreamLoadVisitor.java
+++ b/src/main/java/com/starrocks/connector/flink/manager/StarRocksStreamLoadVisitor.java
@@ -182,12 +182,14 @@ public class StarRocksStreamLoadVisitor implements Serializable {
     private String getAvailableHost() {
         List<String> hostList = sinkOptions.getLoadUrlList();
         long tmp = pos + hostList.size();
-        for (; pos < tmp; pos++) {
-            String host = new StringBuilder("http://").append(hostList.get((int) (pos % hostList.size()))).toString();
+        while (pos < tmp) {
+            String host = "http://" + hostList.get((int) (pos % hostList.size()));
             if (tryHttpConnection(host)) {
+                pos++;
                 return host;
             }
         }
+
         return null;
     }
 

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/DefaultStreamLoader.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/DefaultStreamLoader.java
@@ -301,13 +301,16 @@ public class DefaultStreamLoader implements StreamLoader, Serializable {
     protected String getAvailableHost() {
         String[] hosts = properties.getLoadUrls();
         int size = hosts.length;
-        for (long pos = availableHostPos; pos < pos + size; pos++) {
+        long pos = availableHostPos;
+        while (pos < pos + size) {
             String host = "http://" + hosts[(int) (pos % size)];
             if (testHttpConnection(host)) {
+                pos++;
                 availableHostPos = pos;
                 return host;
             }
         }
+
         return null;
     }
 


### PR DESCRIPTION
In production, we find that all writes are on a single node, which would result in a high load on a single node.
So implement balanced writes to StarRocks each node.

