### PR TITLE
Fix flink sql upsert delete

### DIFF
--- a/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksSinkOptions.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksSinkOptions.java
@@ -113,6 +113,7 @@ public class StarRocksSinkOptions implements Serializable {
     private final Map<String, String> tableOptionsMap;
     private StarRocksSinkSemantic sinkSemantic;
     private boolean supportUpsertDelete;
+    private String[] tableSchemaFieldNames;
 
     private final List<StreamLoadTableProperties> tablePropertiesList = new ArrayList<>();
 
@@ -133,6 +134,15 @@ public class StarRocksSinkOptions implements Serializable {
         validateStreamLoadUrl();
         validateSinkSemantic();
         validateParamsRange();
+    }
+
+    public void setTableSchemaFieldNames(String[] fieldNames) {
+        this.tableSchemaFieldNames = new String[fieldNames.length];
+        System.arraycopy(fieldNames, 0, tableSchemaFieldNames, 0, fieldNames.length);
+    }
+
+    public String[] getTableSchemaFieldNames() {
+        return tableSchemaFieldNames;
     }
 
     public String getJdbcUrl() {
@@ -383,6 +393,21 @@ public class StarRocksSinkOptions implements Serializable {
 
         if (hasColumnMappingProperty()) {
             defaultTablePropertiesBuilder.columns(streamLoadProps.get("columns"));
+        } else if (getTableSchemaFieldNames() != null) {
+            if (dataFormat instanceof StreamLoadDataFormat.CSVFormat
+                    || (!sinkTable.isOpAutoProjectionInJson() && supportUpsertDelete())) {
+
+                String[] columns;
+                if (supportUpsertDelete()) {
+                    columns = new String[getTableSchemaFieldNames().length + 1];
+                    System.arraycopy(getTableSchemaFieldNames(), 0, columns, 0, getTableSchemaFieldNames().length);
+                    columns[getTableSchemaFieldNames().length] = "__op";
+                } else {
+                    columns = getTableSchemaFieldNames();
+                }
+
+                defaultTablePropertiesBuilder.columns(columns);
+            }
         }
 
         StreamLoadProperties.Builder builder = StreamLoadProperties.builder()

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/DefaultStreamLoader.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/DefaultStreamLoader.java
@@ -236,20 +236,6 @@ public class DefaultStreamLoader implements StreamLoader, Serializable {
 
             httpPut.setHeaders(defaultHeaders);
 
-            // TODO move to properties
-            if (!httpPut.containsHeader("columns")
-                    && tableProperties.getColumns() != null
-                    && (dataFormat instanceof StreamLoadDataFormat.CSVFormat
-                        || (!properties.isOpAutoProjectionInJson() && tableProperties.isEnableUpsertDelete()))) {
-                String cols = Arrays.stream(tableProperties.getColumns())
-                        .map(f -> String.format("`%s`", f.trim().replace("`", "")))
-                        .collect(Collectors.joining(","));
-                if (cols.length() > 0 && tableProperties.isEnableUpsertDelete()) {
-                    cols += String.format(",%s", "__op");
-                }
-                httpPut.addHeader("columns", cols);
-            }
-
             for (Map.Entry<String, String> entry : tableProperties.getProperties().entrySet()) {
                 httpPut.removeHeaders(entry.getKey());
                 httpPut.addHeader(entry.getKey(), entry.getValue());


### PR DESCRIPTION
Fix #129 

When use flink sql transfer to sr from cdc, and not set sink.properties.columns. the Flink Tableschema columns are not sync to set StreamLoadTableProperties columns in sdk.