### PR TITLE
[Enhancement] multi queue and thread to flush.

### DIFF
--- a/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksDynamicTableSinkFactory.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksDynamicTableSinkFactory.java
@@ -61,6 +61,7 @@ public class StarRocksDynamicTableSinkFactory implements DynamicTableSinkFactory
         optionalOptions.add(StarRocksSinkOptions.SINK_BATCH_MAX_ROWS);
         optionalOptions.add(StarRocksSinkOptions.SINK_BATCH_FLUSH_INTERVAL);
         optionalOptions.add(StarRocksSinkOptions.SINK_MAX_RETRIES);
+        optionalOptions.add(StarRocksSinkOptions.SINK_FlUSH_THREADS);
         optionalOptions.add(StarRocksSinkOptions.SINK_SEMANTIC);
         optionalOptions.add(StarRocksSinkOptions.SINK_BATCH_OFFER_TIMEOUT);
         optionalOptions.add(StarRocksSinkOptions.SINK_PARALLELISM);

--- a/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksSinkOptions.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksSinkOptions.java
@@ -85,6 +85,8 @@ public class StarRocksSinkOptions implements Serializable {
             .longType().defaultValue(300000L).withDescription("Flush interval of the row batch in millisecond.");
     public static final ConfigOption<Integer> SINK_MAX_RETRIES = ConfigOptions.key("sink.max-retries")
             .intType().defaultValue(3).withDescription("Max flushing retry times of the row batch.");
+    public static final ConfigOption<Integer> SINK_FlUSH_THREADS = ConfigOptions.key("sink.flush-threads")
+            .intType().defaultValue(32).withDescription("Flush thread nums for waiting write queue.");
     public static final ConfigOption<Long> SINK_BATCH_OFFER_TIMEOUT = ConfigOptions.key("sink.buffer-flush.enqueue-timeout-ms")
             .longType().defaultValue(600000L).withDescription("Offer to flushQueue timeout in millisecond.");
     public static final ConfigOption<Integer> SINK_METRIC_HISTOGRAM_WINDOW_SIZE = ConfigOptions.key("sink.metric.histogram-window-size")
@@ -154,6 +156,10 @@ public class StarRocksSinkOptions implements Serializable {
 
     public int getSinkMaxRetries() {
         return tableOptions.get(SINK_MAX_RETRIES);
+    }
+
+    public int getSinkFlushThreads() {
+        return tableOptions.get(SINK_FlUSH_THREADS);
     }
 
     public long getSinkMaxFlushInterval() {

--- a/src/test/java/com/starrocks/connector/flink/manager/sink/StarRocksSinkManagerTest.java
+++ b/src/test/java/com/starrocks/connector/flink/manager/sink/StarRocksSinkManagerTest.java
@@ -180,6 +180,27 @@ public class StarRocksSinkManagerTest extends StarRocksSinkBaseTest {
     }
 
     @Test
+    public void testMultiThreadFlush() throws Exception {
+        mockTableStructure();
+        mockStarRocksVersion(null);
+        mockSuccessResponse();
+        String exMsg = "";
+        try {
+            StarRocksSinkManager mgr = new StarRocksSinkManager(OPTIONS, TABLE_SCHEMA);
+            mgr.startAsyncFlushing();
+            mgr.startScheduler();
+            for (int i = 0; i < 10000 ; i++) {
+                mgr.writeRecords("db","table_"+i, "");
+            }
+            mgr.close();
+        } catch (Exception e) {
+            exMsg = e.getMessage();
+            throw e;
+        }
+        assertEquals(0, exMsg.length());
+    }
+
+    @Test
     public void testFlush() throws Exception {
         mockTableStructure();
         mockStarRocksVersion(null);


### PR DESCRIPTION
Currently, only have one flush thread to poll a single LinkedBlockingDeque in a single TaskManager, but when multi or full databases and tables synchronization,  a single capacity of LinkedBlockingDeque can affect end-to-end latency because all bufferKey will be queueing to sequence sent to StarRocks. 
So that patch implements multi threads poll queue to send request, and build multi queues to guarantee the same bufferKey(`database.table`) entry same queue, avoiding the same bufferKey being out-of-order sent request.