### PR TITLE
[Bugfix] Initialize StarRocksDynamicSinkFunctionV2#legacyData in initializeState() to avoid NPE

### DIFF
--- a/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksDynamicSinkFunctionV2.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksDynamicSinkFunctionV2.java
@@ -1,5 +1,6 @@
 package com.starrocks.connector.flink.table.sink;
 
+import com.google.common.base.Strings;
 import com.starrocks.connector.flink.manager.StarRocksSinkBufferEntity;
 import com.starrocks.connector.flink.manager.StarRocksSinkManagerV2;
 import com.starrocks.connector.flink.manager.StarRocksSinkTable;
@@ -8,8 +9,6 @@ import com.starrocks.connector.flink.row.sink.StarRocksISerializer;
 import com.starrocks.connector.flink.row.sink.StarRocksSerializerFactory;
 import com.starrocks.connector.flink.table.data.StarRocksRowData;
 import com.starrocks.data.load.stream.StreamLoadSnapshot;
-
-import com.google.common.base.Strings;
 import net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.alter.Alter;
@@ -58,8 +57,7 @@ public class StarRocksDynamicSinkFunctionV2<T> extends StarRocksDynamicSinkFunct
     @Deprecated
     private transient ListState<Map<String, StarRocksSinkBufferEntity>> legacyState;
     @Deprecated
-    private final transient List<StarRocksSinkBufferEntity> legacyData = new ArrayList<>();
-
+    private transient List<StarRocksSinkBufferEntity> legacyData;
 
     public StarRocksDynamicSinkFunctionV2(StarRocksSinkOptions sinkOptions,
                                           TableSchema schema,
@@ -241,6 +239,7 @@ public class StarRocksDynamicSinkFunctionV2<T> extends StarRocksDynamicSinkFunct
                 }
             }
 
+            legacyData = new ArrayList<>();
             for (Map<String, StarRocksSinkBufferEntity> entry : legacyState.get()) {
                 legacyData.addAll(entry.values());
             }
@@ -287,7 +286,7 @@ public class StarRocksDynamicSinkFunctionV2<T> extends StarRocksDynamicSinkFunct
     }
 
     private void flushLegacyData() {
-        if (legacyData.isEmpty()) {
+        if (legacyData == null || legacyData.isEmpty()) {
             return;
         }
 


### PR DESCRIPTION
## What type of PR is this：
- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
`StarRocksDynamicSinkFunctionV2#legacyData` is transient, and should be initialized in `StarRocksDynamicSinkFunctionV2#initializeState()`, otherwise NPE will be thrown when accessing it

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
