### PR TITLE
[Bugfix] Always close StarRocksSourceDataReader and check keepAliveMin is valid

### DIFF
--- a/src/main/java/com/starrocks/connector/flink/table/source/StarRocksDynamicSourceFunction.java
+++ b/src/main/java/com/starrocks/connector/flink/table/source/StarRocksDynamicSourceFunction.java
@@ -14,12 +14,11 @@
 
 package com.starrocks.connector.flink.table.source;
 
+import com.google.common.base.Strings;
+import com.starrocks.connector.flink.table.source.struct.ColumnRichInfo;
 import com.starrocks.connector.flink.table.source.struct.QueryBeXTablets;
 import com.starrocks.connector.flink.table.source.struct.QueryInfo;
 import com.starrocks.connector.flink.table.source.struct.SelectColumn;
-import com.starrocks.connector.flink.table.source.struct.ColumnRichInfo;
-
-import com.google.common.base.Strings;
 import org.apache.flink.api.common.typeinfo.TypeHint;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
@@ -28,12 +27,17 @@ import org.apache.flink.metrics.Counter;
 import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.data.RowData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class StarRocksDynamicSourceFunction extends RichParallelSourceFunction<RowData> implements ResultTypeQueryable<RowData> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(StarRocksDynamicSourceFunction.class);
 
     private final StarRocksSourceOptions sourceOptions;
     private QueryInfo queryInfo;
@@ -45,6 +49,7 @@ public class StarRocksDynamicSourceFunction extends RichParallelSourceFunction<R
     private StarRocksSourceQueryType queryType;
 
     private transient Counter counterTotalScannedRows;
+    private transient AtomicBoolean dataReaderClosed;
     private static final String TOTAL_SCANNED_ROWS = "totalScannedRows";
 
     public StarRocksDynamicSourceFunction(TableSchema flinkSchema, StarRocksSourceOptions sourceOptions) {
@@ -125,10 +130,10 @@ public class StarRocksDynamicSourceFunction extends RichParallelSourceFunction<R
         return sqlSb.toString();
     }
 
-
     @Override
     public void open(Configuration parameters) throws Exception {
         super.open(parameters);
+        this.dataReaderClosed = new AtomicBoolean(false);
         this.counterTotalScannedRows = getRuntimeContext().getMetricGroup().counter(TOTAL_SCANNED_ROWS);
 
         int subTaskId = getRuntimeContext().getIndexOfThisSubtask();
@@ -161,11 +166,23 @@ public class StarRocksDynamicSourceFunction extends RichParallelSourceFunction<R
 
     @Override
     public void cancel() {
-        this.dataReaderList.parallelStream().forEach(dataReader -> {
-            if (dataReader != null) {
-                dataReader.close();
-            }
-        });
+        internalClose();
+    }
+
+    @Override
+    public void close() {
+        internalClose();
+    }
+
+    private void internalClose() {
+        if (dataReaderClosed.compareAndSet(false, true)) {
+            LOG.info("Close reader");
+            this.dataReaderList.parallelStream().forEach(dataReader -> {
+                if (dataReader != null) {
+                    dataReader.close();
+                }
+            });
+        }
     }
 
     @Override

--- a/src/main/java/com/starrocks/connector/flink/table/source/StarRocksDynamicSourceFunction.java
+++ b/src/main/java/com/starrocks/connector/flink/table/source/StarRocksDynamicSourceFunction.java
@@ -176,7 +176,7 @@ public class StarRocksDynamicSourceFunction extends RichParallelSourceFunction<R
 
     private void internalClose() {
         if (dataReaderClosed.compareAndSet(false, true)) {
-            LOG.info("Close reader");
+            LOG.info("Close readers");
             this.dataReaderList.parallelStream().forEach(dataReader -> {
                 if (dataReader != null) {
                     dataReader.close();

--- a/src/main/java/com/starrocks/connector/flink/table/source/StarRocksSourceBeReader.java
+++ b/src/main/java/com/starrocks/connector/flink/table/source/StarRocksSourceBeReader.java
@@ -15,10 +15,10 @@
 package com.starrocks.connector.flink.table.source;
 
 import com.starrocks.connector.flink.row.source.StarRocksSourceFlinkRows;
+import com.starrocks.connector.flink.table.source.struct.ColumnRichInfo;
 import com.starrocks.connector.flink.table.source.struct.Const;
 import com.starrocks.connector.flink.table.source.struct.SelectColumn;
 import com.starrocks.connector.flink.table.source.struct.StarRocksSchema;
-import com.starrocks.connector.flink.table.source.struct.ColumnRichInfo;
 import com.starrocks.shade.org.apache.thrift.TException;
 import com.starrocks.shade.org.apache.thrift.protocol.TBinaryProtocol;
 import com.starrocks.shade.org.apache.thrift.protocol.TProtocol;
@@ -31,7 +31,6 @@ import com.starrocks.thrift.TScanOpenParams;
 import com.starrocks.thrift.TScanOpenResult;
 import com.starrocks.thrift.TStarrocksExternalService;
 import com.starrocks.thrift.TStatusCode;
-
 import org.apache.flink.table.data.GenericRowData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -76,9 +75,9 @@ public class StarRocksSourceBeReader implements StarRocksSourceDataReader, Seria
                 throw new RuntimeException("Not find be node info from the be port mappping list");
             }
             beNodeInfo = mappingMap.get(beNodeInfo);
-            LOG.info("query data from be by using be-hostname");
+            LOG.info("query data from be by using be-hostname {}", beNodeInfo);
         } else {
-            LOG.info("query data from be by using be-ip");
+            LOG.info("query data from be by using be-ip {}", beNodeInfo);
         }
         String[] beNode = beNodeInfo.split(":");
         String ip = beNode[0].trim();
@@ -113,7 +112,8 @@ public class StarRocksSourceBeReader implements StarRocksSourceDataReader, Seria
             params.setProperties(sourceOptions.getProperties());    
         }
         // params.setLimit(sourceOptions.getLimit());
-        params.setKeep_alive_min((short) sourceOptions.getKeepAliveMin());
+        short keepAliveMin = (short) Math.min(Short.MAX_VALUE, sourceOptions.getKeepAliveMin());
+        params.setKeep_alive_min(keepAliveMin);
         params.setQuery_timeout(sourceOptions.getQueryTimeout());
         params.setMem_limit(sourceOptions.getMemLimit());
         LOG.info("open Scan params.mem_limit {} B", params.getMem_limit());

--- a/src/main/java/com/starrocks/connector/flink/table/source/StarRocksSourceBeReader.java
+++ b/src/main/java/com/starrocks/connector/flink/table/source/StarRocksSourceBeReader.java
@@ -133,6 +133,8 @@ public class StarRocksSourceBeReader implements StarRocksSourceDataReader, Seria
         }
         this.srSchema = StarRocksSchema.genSchema(result.getSelected_columns());
         this.contextId = result.getContext_id();
+        LOG.info("Open scanner for {}:{} with context id {}, and there are {} tablets {}",
+                IP, PORT, contextId, tablets.size(), tablets);
     }
 
     public void startToRead() {
@@ -189,11 +191,13 @@ public class StarRocksSourceBeReader implements StarRocksSourceDataReader, Seria
 
     @Override
     public void close() {
+        LOG.info("Close reader for {}:{} with context id {}", IP, PORT, contextId);
         TScanCloseParams tScanCloseParams = new TScanCloseParams();
         tScanCloseParams.setContext_id(this.contextId);
         try {
             this.client.close_scanner(tScanCloseParams);
         } catch (TException e) {
+            LOG.error("Failed to close reader {}:{} with context id {}", IP, PORT, contextId, e);
             throw new RuntimeException(e.getMessage());
         }
     }


### PR DESCRIPTION
## What type of PR is this：
- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
1. `StarRocksDynamicSourceFunction` does not close `StarRocksSourceDataReader` if flink job finishes normally, which will not close the connection with BE
2. check the configuration for `keepAliveMin` does not overflow when converting `int` to `short`

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
