### PR TITLE
[Enhancement] Make transaction stream load default timeout to 600s

### DIFF
--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/DefaultStreamLoader.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/DefaultStreamLoader.java
@@ -210,7 +210,7 @@ public class DefaultStreamLoader implements StreamLoader, Serializable {
     protected void initDefaultHeaders(StreamLoadProperties properties) {
         Map<String, String> headers = new HashMap<>(properties.getHeaders());
         if (!headers.containsKey("timeout")) {
-            headers.put("timeout", "120");
+            headers.put("timeout", "600");
         }
         headers.put(HttpHeaders.AUTHORIZATION, StreamLoadUtils.getBasicAuthHeader(properties.getUsername(), properties.getPassword()));
         headers.put(HttpHeaders.EXPECT, "100-continue");


### PR DESCRIPTION
The default timeout for transaction stream load is 120 seconds. But it's normal to set Flink checkpoint interval to minutes, so the Flink job will easily fail because of transaction timeout. This PR suggest to increase the default timeout to 600s which is also the StarRocks' [default value](https://github.com/StarRocks/starrocks/blob/main/fe/fe-core/src/main/java/com/starrocks/common/Config.java#L750).
The timeout message likes 
```
com.starrocks.data.load.stream.exception.StreamLoadFailException: {
    "TxnId": 33823381,
    "Label": "502c2770-cd48-423d-b6b7-9d8f9a59e41a",
    "Status": "Fail",
    "Message": "timeout by txn manager",
    "NumberTotalRows": 1637,
    "NumberLoadedRows": 1637,
    "NumberFilteredRows": 0,
    "NumberUnselectedRows": 0,
    "LoadBytes": 4284214,
    "LoadTimeMs": 120294,
    "BeginTxnTimeMs": 0,
    "StreamLoadPlanTimeMs": 7,
    "ReadDataTimeMs": 9,
    "WriteDataTimeMs": 120278,
    "CommitAndPublishTimeMs": 0
}
```
