### PR TITLE
[Bugfix] Fail to delete data when using json format

### DIFF
--- a/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksDynamicSinkFunctionV2.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksDynamicSinkFunctionV2.java
@@ -65,11 +65,13 @@ public class StarRocksDynamicSinkFunctionV2<T> extends StarRocksDynamicSinkFunct
         this.sinkOptions = sinkOptions;
         this.rowTransformer = rowTransformer;
         rowTransformer.setTableSchema(schema);
-        this.serializer = StarRocksSerializerFactory.createSerializer(sinkOptions, schema.getFieldNames());
         StarRocksSinkTable sinkTable = StarRocksSinkTable.builder()
                 .sinkOptions(sinkOptions)
                 .build();
         sinkTable.validateTableStructure(sinkOptions, schema);
+        // StarRocksJsonSerializer depends on SinkOptions#supportUpsertDelete which is decided in
+        // StarRocksSinkTable#validateTableStructure, so create serializer after validating table structure
+        this.serializer = StarRocksSerializerFactory.createSerializer(sinkOptions, schema.getFieldNames());
         this.sinkManager = new StarRocksSinkManagerV2(sinkOptions.getProperties());
     }
 

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/DefaultStreamLoadManager.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/DefaultStreamLoadManager.java
@@ -1,9 +1,8 @@
 package com.starrocks.data.load.stream;
 
+import com.alibaba.fastjson.JSON;
 import com.starrocks.data.load.stream.properties.StreamLoadProperties;
 import com.starrocks.data.load.stream.properties.StreamLoadTableProperties;
-
-import com.alibaba.fastjson.JSON;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,6 +25,8 @@ import java.util.concurrent.locks.LockSupport;
 import java.util.concurrent.locks.ReentrantLock;
 
 public class DefaultStreamLoadManager implements StreamLoadManager, Serializable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultStreamLoadManager.class);
 
     enum State {
         ACTIVE,
@@ -193,6 +194,10 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
         TableRegion region = getCacheRegion(uniqueKey, database, table);
         for (String row : rows) {
             AssertNotException();
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Write uniqueKey {}, database {}, table {}, row {}",
+                        uniqueKey == null ? "null" : uniqueKey, database, table, row);
+            }
             int bytes = region.write(row.getBytes(StandardCharsets.UTF_8));
             if (currentCacheBytes.addAndGet(bytes) >= maxCacheBytes) {
                 int idx = 0;


### PR DESCRIPTION
## What type of PR is this：
- [x] bugfix
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #155 

## Problem Summary(Required) ：
Fail to delete data when using json format to load data to primary key table. The reason is that `StarRocksJsonSerializer` is created before `SinkOptions#supportUpsertDelete()` is decided so that the serializer will not add `__op` column to the json, and StarRocks will treat it as an upsert


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
