### PR TITLE
[Bugfix] Can't load data to StarRocks json column

### DIFF
--- a/src/main/java/com/starrocks/connector/flink/manager/StarRocksSinkTable.java
+++ b/src/main/java/com/starrocks/connector/flink/manager/StarRocksSinkTable.java
@@ -2,8 +2,8 @@ package com.starrocks.connector.flink.manager;
 
 import com.starrocks.connector.flink.connection.StarRocksJdbcConnectionOptions;
 import com.starrocks.connector.flink.connection.StarRocksJdbcConnectionProvider;
+import com.starrocks.connector.flink.table.StarRocksDataType;
 import com.starrocks.connector.flink.table.sink.StarRocksSinkOptions;
-
 import org.apache.flink.table.api.TableColumn;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.constraints.UniqueConstraint;
@@ -53,6 +53,10 @@ public class StarRocksSinkTable {
 
     public boolean isOpAutoProjectionInJson() {
         return version == null || version.length() > 0 && !version.trim().startsWith("1.");
+    }
+
+    public Map<String, StarRocksDataType> getFieldMapping() {
+        return starRocksQueryVisitor.getFieldMapping();
     }
 
     public void validateTableStructure(StarRocksSinkOptions sinkOptions, TableSchema flinkSchema) {

--- a/src/main/java/com/starrocks/connector/flink/row/sink/StarRocksTableRowTransformer.java
+++ b/src/main/java/com/starrocks/connector/flink/row/sink/StarRocksTableRowTransformer.java
@@ -14,8 +14,6 @@
 
 package com.starrocks.connector.flink.row.sink;
 
-import com.starrocks.connector.flink.table.StarRocksDataType;
-
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.serializer.JSONSerializer;
 import com.alibaba.fastjson.serializer.ObjectSerializer;
@@ -23,6 +21,7 @@ import com.alibaba.fastjson.serializer.SerializeConfig;
 import com.alibaba.fastjson.serializer.SerializeWriter;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.starrocks.connector.flink.table.StarRocksDataType;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -140,6 +139,12 @@ public class StarRocksTableRowTransformer implements StarRocksIRowTransformer<Ro
                 if ((starRocksDataType == StarRocksDataType.JSON ||
                         starRocksDataType == StarRocksDataType.UNKNOWN)
                     && (sValue.charAt(0) == '{' || sValue.charAt(0) == '[')) {
+                    // The json string need to be converted to a json object, and to the json string
+                    // again via JSON.toJSONString in StarRocksJsonSerializer#serialize. Otherwise,
+                    // the final json string in stream load will not be correct. For example, the received
+                    // string is "{"a": 1, "b": 2}", and if input it to JSON.toJSONString directly, the
+                    // result will be "{\"a\": 1, \"b\": 2}" which will not be recognized as a json in
+                    // StarRocks
                     return JSON.parse(sValue);
                 }
                 return sValue;

--- a/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksDynamicSinkFunctionV2.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksDynamicSinkFunctionV2.java
@@ -64,7 +64,6 @@ public class StarRocksDynamicSinkFunctionV2<T> extends StarRocksDynamicSinkFunct
                                           StarRocksIRowTransformer<T> rowTransformer) {
         this.sinkOptions = sinkOptions;
         this.rowTransformer = rowTransformer;
-        rowTransformer.setTableSchema(schema);
         StarRocksSinkTable sinkTable = StarRocksSinkTable.builder()
                 .sinkOptions(sinkOptions)
                 .build();
@@ -72,6 +71,8 @@ public class StarRocksDynamicSinkFunctionV2<T> extends StarRocksDynamicSinkFunct
         // StarRocksJsonSerializer depends on SinkOptions#supportUpsertDelete which is decided in
         // StarRocksSinkTable#validateTableStructure, so create serializer after validating table structure
         this.serializer = StarRocksSerializerFactory.createSerializer(sinkOptions, schema.getFieldNames());
+        rowTransformer.setStarRocksColumns(sinkTable.getFieldMapping());
+        rowTransformer.setTableSchema(schema);
         this.sinkManager = new StarRocksSinkManagerV2(sinkOptions.getProperties());
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] bugfix
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #159 

## Problem Summary(Required) ：
Can't map a Flink `String` column(json string) to StarRocks  `JSON` column. The reason is that `StarRocksDynamicSinkFunctionV2` does not set `StarRocksTableRowTransformer#columns`, and `StarRocksTableRowTransformer#typeConvertion` will not check whether the received data is a json string, and can't map it to StarRocks `JSON`.


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
