### PR TITLE
[Bugfix] Not use http chunk to send json format data for starrocks<=2.2

### DIFF
--- a/starrocks-stream-load-sdk/pom.xml
+++ b/starrocks-stream-load-sdk/pom.xml
@@ -43,6 +43,13 @@
             <artifactId>fastjson</artifactId>
             <version>${fastjson.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/StarRocksVersion.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/StarRocksVersion.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.starrocks.data.load.stream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/** Representation of starrocks version. */
+public class StarRocksVersion implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final Logger LOG = LoggerFactory.getLogger(StarRocksVersion.class);
+
+    // The pattern of the official starrocks release should be link <major>.<minor>.<patch> such as 2.3.4
+    private static final Pattern PATTERN = Pattern.compile("^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+).*");
+
+    private int major;
+    private int minor;
+    private int patch;
+
+    public int getMajor() {
+        return major;
+    }
+
+    public int getMinor() {
+        return minor;
+    }
+
+    public int getPatch() {
+        return patch;
+    }
+
+    @Override
+    public String toString() {
+        return "StarRocksVersion{" +
+                "major=" + major +
+                ", minor=" + minor +
+                ", patch=" + patch +
+                '}';
+    }
+
+    /** Parse the version string, and return null if it's not a valid version pattern */
+    public static StarRocksVersion parse(String versionStr) {
+        if (versionStr == null) {
+            return null;
+        }
+
+        try {
+            Matcher match = PATTERN.matcher(versionStr.trim());
+            if (match.matches()) {
+                StarRocksVersion version = new StarRocksVersion();
+                version.major = Integer.parseInt(match.group("major"));
+                version.minor = Integer.parseInt(match.group("minor"));
+                version.patch = Integer.parseInt(match.group("patch"));
+                LOG.info("Successful to parse starrocks version {}, {}", versionStr, version);
+                return version;
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to parse starrocks version {}", versionStr, e);
+        }
+        LOG.info("Fail to parse starrocks version {}", versionStr);
+        return null;
+    }
+}

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/properties/StreamLoadProperties.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/properties/StreamLoadProperties.java
@@ -1,6 +1,7 @@
 package com.starrocks.data.load.stream.properties;
 
 import com.alibaba.fastjson.annotation.JSONField;
+import com.starrocks.data.load.stream.StarRocksVersion;
 import com.starrocks.data.load.stream.StreamLoadUtils;
 
 import java.io.Serializable;
@@ -17,6 +18,8 @@ public class StreamLoadProperties implements Serializable {
     @JSONField(serialize = false)
     private final String password;
     private final String version;
+    // can be null
+    private final StarRocksVersion starRocksVersion;
 
     private final String labelPrefix;
 
@@ -70,6 +73,7 @@ public class StreamLoadProperties implements Serializable {
         this.username = builder.username;
         this.password = builder.password;
         this.version = builder.version;
+        this.starRocksVersion = StarRocksVersion.parse(version);
 
         this.enableTransaction = builder.enableTransaction;
 
@@ -116,6 +120,10 @@ public class StreamLoadProperties implements Serializable {
 
     public String getVersion() {
         return version;
+    }
+
+    public StarRocksVersion getStarRocksVersion() {
+        return starRocksVersion;
     }
 
     public boolean isOpAutoProjectionInJson() {

--- a/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/DefaultStreamLoadManagerTest.java
+++ b/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/DefaultStreamLoadManagerTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.starrocks.data.load.stream;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/** Tests for {@link DefaultStreamLoadManager}. */
+public class DefaultStreamLoadManagerTest {
+
+    @Test
+    public void testUseBatchTableRegion() {
+        StarRocksVersion version_19 = StarRocksVersion.parse("1.9.0");
+        StarRocksVersion version_22 = StarRocksVersion.parse("2.2.4");
+        StarRocksVersion version_24 = StarRocksVersion.parse("2.4.1");
+
+        // verify csv format
+        assertFalse(DefaultStreamLoadManager.useBatchTableRegion(
+                StreamLoadDataFormat.CSV, false, version_19));
+        assertFalse(DefaultStreamLoadManager.useBatchTableRegion(
+                StreamLoadDataFormat.CSV, false, version_22));
+        assertFalse(DefaultStreamLoadManager.useBatchTableRegion(
+                StreamLoadDataFormat.CSV, false, version_24));
+        assertFalse(DefaultStreamLoadManager.useBatchTableRegion(
+                StreamLoadDataFormat.CSV, false, null));
+        assertFalse(DefaultStreamLoadManager.useBatchTableRegion(
+                StreamLoadDataFormat.CSV, true, version_19));
+        assertFalse(DefaultStreamLoadManager.useBatchTableRegion(
+                StreamLoadDataFormat.CSV, true, version_22));
+        assertFalse(DefaultStreamLoadManager.useBatchTableRegion(
+                StreamLoadDataFormat.CSV, true, version_24));
+        assertFalse(DefaultStreamLoadManager.useBatchTableRegion(
+                StreamLoadDataFormat.CSV, true, null));
+
+        // verify json format
+        assertTrue(DefaultStreamLoadManager.useBatchTableRegion(
+                StreamLoadDataFormat.JSON, false, version_19));
+        assertTrue(DefaultStreamLoadManager.useBatchTableRegion(
+                StreamLoadDataFormat.JSON, false, version_22));
+        assertFalse(DefaultStreamLoadManager.useBatchTableRegion(
+                StreamLoadDataFormat.JSON, false, version_24));
+        assertFalse(DefaultStreamLoadManager.useBatchTableRegion(
+                StreamLoadDataFormat.JSON, false, null));
+        assertTrue(DefaultStreamLoadManager.useBatchTableRegion(
+                StreamLoadDataFormat.JSON, true, version_19));
+        assertTrue(DefaultStreamLoadManager.useBatchTableRegion(
+                StreamLoadDataFormat.JSON, true, version_22));
+        assertTrue(DefaultStreamLoadManager.useBatchTableRegion(
+                StreamLoadDataFormat.JSON, true, version_24));
+        assertTrue(DefaultStreamLoadManager.useBatchTableRegion(
+                StreamLoadDataFormat.JSON, true, version_19));
+        assertTrue(DefaultStreamLoadManager.useBatchTableRegion(
+                StreamLoadDataFormat.JSON, true, version_22));
+        assertTrue(DefaultStreamLoadManager.useBatchTableRegion(
+                StreamLoadDataFormat.JSON, true, null));
+
+    }
+}

--- a/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/StarRocksVersionTest.java
+++ b/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/StarRocksVersionTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.starrocks.data.load.stream;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/** Tests for {@link StarRocksVersion}. */
+public class StarRocksVersionTest {
+
+    @Test
+    public void testParse() {
+        verify(null, false, -1, -1, -1);
+        verify("unknown", false, -1, -1, -1);
+        verify("2.1", false, -1, -1, -1);
+        verify("2.3.4", true, 2, 3, 4);
+        verify(" 2.3.4 ", true, 2, 3, 4);
+    }
+
+    private void verify(String versionStr, boolean success, int major, int minor, int patch) {
+        StarRocksVersion version = StarRocksVersion.parse(versionStr);
+        if (!success) {
+            assertNull(version);
+        } else {
+            assertEquals(major, version.getMajor());
+            assertEquals(minor, version.getMinor());
+            assertEquals(patch, version.getPatch());
+        }
+    }
+}


### PR DESCRIPTION
## What type of PR is this：
- [x] bugfix
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

## Problem Summary(Required) ：
SR <= 2.2 does not support to ingest json format data via http chunk, otherwise the stream load will fail with the error message "all partitions have no load data". This pr will choose the way to send json format data according to starrocks' version. For SR <= 2.2, not use http chunk (`BatchTableRegion`), otherwise use the chunk mode (`StreamTableRegion`).

![image](https://user-images.githubusercontent.com/11382970/210684293-e6007b5f-da89-4a0e-8abd-da236a87ef51.png)
  

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
