### PR TITLE
support sink rowdata filter 

### DIFF
--- a/src/main/java/com/starrocks/connector/flink/manager/StarRocksSinkManager.java
+++ b/src/main/java/com/starrocks/connector/flink/manager/StarRocksSinkManager.java
@@ -216,6 +216,8 @@ public class StarRocksSinkManager implements Serializable {
             String bufferKey = String.format("%s,%s", database, table);
             StarRocksSinkBufferEntity bufferEntity = bufferMap.computeIfAbsent(bufferKey, k -> new StarRocksSinkBufferEntity(database, table, sinkOptions.getLabelPrefix()));
             for (String record : records) {
+                if (record == null || record.length() == 0)
+                    continue;
                 byte[] bts = record.getBytes(StandardCharsets.UTF_8);
                 bufferEntity.addToBuffer(bts);
             }

--- a/src/main/java/com/starrocks/connector/flink/row/sink/StarRocksCsvSerializer.java
+++ b/src/main/java/com/starrocks/connector/flink/row/sink/StarRocksCsvSerializer.java
@@ -31,6 +31,9 @@ public class StarRocksCsvSerializer implements StarRocksISerializer {
 
     @Override
     public String serialize(Object[] values) {
+        if (values.length == 0)
+            return "";
+
         StringBuilder sb = new StringBuilder();
         int idx = 0;
         for (Object val : values) {

--- a/src/main/java/com/starrocks/connector/flink/row/sink/StarRocksGenericRowTransformer.java
+++ b/src/main/java/com/starrocks/connector/flink/row/sink/StarRocksGenericRowTransformer.java
@@ -50,6 +50,17 @@ public class StarRocksGenericRowTransformer<T> implements StarRocksIRowTransform
     public Object[] transform(T record, boolean supportUpsertDelete) {
         Object[] rowData = new Object[fieldNames.length + (supportUpsertDelete ? 1 : 0)];
         consumer.accept(rowData, record);
+
+        boolean isEmpty = true;
+        for (Object obj : rowData) {
+            if (obj != null) {
+                isEmpty = false;
+                break;
+            }
+        }
+        if (isEmpty)
+            return new Object[0];
+
         if (supportUpsertDelete && (record instanceof RowData)) {
             // set `__op` column
             rowData[rowData.length - 1] = StarRocksSinkOP.parse(((RowData)record).getRowKind()).ordinal();

--- a/src/main/java/com/starrocks/connector/flink/row/sink/StarRocksJsonSerializer.java
+++ b/src/main/java/com/starrocks/connector/flink/row/sink/StarRocksJsonSerializer.java
@@ -31,6 +31,9 @@ public class StarRocksJsonSerializer implements StarRocksISerializer {
 
     @Override
     public String serialize(Object[] values) {
+        if (values.length == 0)
+            return "";
+
         Map<String, Object> rowMap = new HashMap<>(values.length);
         int idx = 0;
         for (String fieldName : fieldNames) {


### PR DESCRIPTION
Suport sink rowdata filter:  accept function with return on StarRocksSinkRowBuilder。


With dynamic partition，we may get some data which the partition field value is out of start and end on properties settings。
For Example:
  1. Error data on log , `1754-08-31 06:48:43`
  2. Kafka consume lag


`The row is out of partition ranges. Please add a new partition..`