### PR TITLE
[Enhancement] Optimize the performance of sink V2

### DIFF
--- a/src/main/java/com/starrocks/connector/flink/manager/StarRocksSinkManagerV2.java
+++ b/src/main/java/com/starrocks/connector/flink/manager/StarRocksSinkManagerV2.java
@@ -12,6 +12,8 @@ import java.io.Serializable;
 
 public class StarRocksSinkManagerV2 extends DefaultStreamLoadManager implements Serializable {
 
+    private static final long serialVersionUID = 1L;
+
     private StarRocksSinkRuntimeContext runtimeContext;
 
     public StarRocksSinkManagerV2(StreamLoadProperties properties) {

--- a/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksDynamicSinkFunctionV2.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksDynamicSinkFunctionV2.java
@@ -168,6 +168,7 @@ public class StarRocksDynamicSinkFunctionV2<T> extends StarRocksDynamicSinkFunct
             rowTransformer.setRuntimeContext(getRuntimeContext());
         }
         notifyCheckpointComplete(Long.MAX_VALUE);
+        log.info("Open sink function v2");
     }
 
     @Override

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/BatchTableRegion.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/BatchTableRegion.java
@@ -20,7 +20,7 @@ public class BatchTableRegion implements TableRegion {
         COMMIT
     }
 
-    private static final Logger log = LoggerFactory.getLogger(StreamTableRegion.class);
+    private static final Logger log = LoggerFactory.getLogger(BatchTableRegion.class);
 
     private final StreamLoadManager manager;
     private final StreamLoader streamLoader;

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/DefaultStreamLoadManager.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/DefaultStreamLoadManager.java
@@ -68,6 +68,12 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
     private final Queue<TableRegion> prepareQ = new LinkedList<>();
     private final Queue<TableRegion> commitQ = new LinkedList<>();
 
+    /**
+     * Whether write() has triggered a flush after currentCacheBytes > maxCacheBytes.
+     * This flag is set true after the flush is triggered in writer(), and set false
+     * after the flush completed in callback(). During this period, there is no need
+     * to re-trigger a flush.
+     */
     private transient AtomicBoolean writeTriggerFlush;
     private transient LoadMetrics loadMetrics;
 

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/DefaultStreamLoadManager.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/DefaultStreamLoadManager.java
@@ -169,7 +169,6 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
 
                     if (!flushingCommit && currentCacheBytes.get() >= maxCacheBytes) {
                         TableRegion maxFlushRegion = commitQ.stream()
-                                .filter(TableRegion::isFlushing)
                                 .max((r1, r2) -> {
                                     if (r1.getFlushBytes() != r2.getFlushBytes()) {
                                         return Long.compare(r2.getFlushBytes(), r1.getFlushBytes());
@@ -373,11 +372,7 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
                 region = regions.get(uniqueKey);
                 if (region == null) {
                     StreamLoadTableProperties tableProperties = properties.getTableProperties(uniqueKey);
-                    if (useBatchTableRegion(tableProperties.getDataFormat(), properties.isEnableTransaction(), properties.getStarRocksVersion())) {
-                        region = new BatchTableRegion(uniqueKey, database, table, this, tableProperties, streamLoader);
-                    } else {
-                        region = new StreamTableRegion(uniqueKey, database, table, this, tableProperties, streamLoader);
-                    }
+                    region = new BatchTableRegion(uniqueKey, database, table, this, tableProperties, streamLoader);
                     regions.put(uniqueKey, region);
                     waitQ.offer(region);
                 }

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/LoadMetrics.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/LoadMetrics.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.starrocks.data.load.stream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+public class LoadMetrics {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LoadMetrics.class);
+
+    private final long startTimeNano;
+    private final AtomicLong numberOfSuccessLoad = new AtomicLong();
+    private final AtomicLong totalSuccessLoadBytes = new AtomicLong();
+    private final AtomicLong totalSuccessLoadRows = new AtomicLong();
+    private final AtomicLong totalSuccessLoadTimeNano = new AtomicLong();
+    private final AtomicLong numberOfFailedLoad = new AtomicLong();
+
+    public LoadMetrics() {
+        this.startTimeNano = System.nanoTime();
+    }
+
+    public void updateSuccessLoad(StreamLoadResponse response) {
+        numberOfSuccessLoad.incrementAndGet();
+        if (response.getFlushBytes() != null) {
+            totalSuccessLoadBytes.addAndGet(response.getFlushBytes());
+        }
+        if (response.getFlushRows() != null) {
+            totalSuccessLoadRows.addAndGet(response.getFlushRows());
+        }
+        if (response.getCostNanoTime() != null) {
+            totalSuccessLoadTimeNano.addAndGet(response.getCostNanoTime());
+        }
+    }
+
+    public void updateFailedLoad() {
+        numberOfFailedLoad.incrementAndGet();
+    }
+
+    @Override
+    public String toString() {
+        return "LoadMetrics{" +
+                "startTimeNano=" + startTimeNano +
+                ", totalRunningTimeNano=" + (System.nanoTime() - startTimeNano) +
+                ", numberOfSuccessLoad=" + numberOfSuccessLoad +
+                ", totalSuccessLoadBytes=" + totalSuccessLoadBytes +
+                ", totalSuccessLoadRows=" + totalSuccessLoadRows +
+                ", totalSuccessLoadTimeNano=" + totalSuccessLoadTimeNano +
+                ", numberOfFailedLoad=" + numberOfFailedLoad +
+                '}';
+    }
+}

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/io/StreamLoadStream.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/io/StreamLoadStream.java
@@ -59,10 +59,7 @@ public class StreamLoadStream extends InputStream {
 
         int size = len - off;
         int ws = Math.min(size, buffer.remaining());
-
-        for (int pos = off; pos < off + ws; pos++) {
-            b[pos] = buffer.get();
-        }
+        buffer.get(b, off, ws);
 
         return ws;
     }


### PR DESCRIPTION
## What type of PR is this：
- [ ] bugfix
- [ ] feature
- [X] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

## Problem Summary(Required) ：
When using at-least-once + json, V2 is much slower than V1 (commit cbbe1f10f7e05f47952a095ff9ad138549026c5c). This PR will optimize the performance in the following aspects
* opt1: use `BatchTableRegion` rather than `StreamTableRegion`, because `BlockingQueue` in `StreamTableRegion` costs too much. V1 uses a similar batch method
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/11382970/217755749-abcbca50-5d8e-4c94-869f-bf49254224e5.png">

* opt2: make write and stream load concurrently which is same as V1
* opt3: let `StreamLoadStream` uses `HeapByteBuffer.get` (backed by `System.arrayCopy`) to make data copy more efficiently
 

## Test Result
`V2/V1` denotes the ratio of time to ingest the same amount  of data
| Opt      | V2 / V1 |
| ----------- | ----------- |
| base      | 2.07       |
| opt 1      | 1.66        |
| opt 1+2      |   1.07 |
| opt 1+2+3      | 1.00 |

  

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
