### PR TITLE
[Bugfix] Don't add first/end new line delimiter for csv

### DIFF
--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/StreamLoadDataFormat.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/StreamLoadDataFormat.java
@@ -13,6 +13,7 @@ public interface StreamLoadDataFormat {
 
     class CSVFormat implements StreamLoadDataFormat, Serializable {
 
+        private static final byte[] EMPTY_DELIMITER = new byte[0];
         private static final String DEFAULT_LINE_DELIMITER = "\n";
         private final byte[] delimiter;
 
@@ -30,7 +31,7 @@ public interface StreamLoadDataFormat {
 
         @Override
         public byte[] first() {
-            return null;
+            return EMPTY_DELIMITER;
         }
 
         @Override
@@ -40,7 +41,7 @@ public interface StreamLoadDataFormat {
 
         @Override
         public byte[] end() {
-            return null;
+            return EMPTY_DELIMITER;
         }
 
     }

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/StreamLoadDataFormat.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/StreamLoadDataFormat.java
@@ -13,11 +13,11 @@ public interface StreamLoadDataFormat {
 
     class CSVFormat implements StreamLoadDataFormat, Serializable {
 
-        private static final byte[] NEW_LINE = "\n".getBytes(StandardCharsets.UTF_8);
+        private static final String DEFAULT_LINE_DELIMITER = "\n";
         private final byte[] delimiter;
 
         public CSVFormat() {
-            this("\n");
+            this(DEFAULT_LINE_DELIMITER);
         }
 
         public CSVFormat(String rowDelimiter) {
@@ -30,7 +30,7 @@ public interface StreamLoadDataFormat {
 
         @Override
         public byte[] first() {
-            return NEW_LINE;
+            return null;
         }
 
         @Override
@@ -40,7 +40,7 @@ public interface StreamLoadDataFormat {
 
         @Override
         public byte[] end() {
-            return NEW_LINE;
+            return null;
         }
 
     }


### PR DESCRIPTION
## What type of PR is this：
- [X] bugfix
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

## Problem Summary(Required) ：
CSV will always add first/end new line delimiter , and it will lead to wrong result if a none new-line delimiter is specified

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
