### PR TITLE
[Bugfix] Remove http prefix when probing transaction load

### DIFF
--- a/src/main/java/com/starrocks/connector/flink/table/sink/SinkFunctionFactory.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/SinkFunctionFactory.java
@@ -62,7 +62,7 @@ public class SinkFunctionFactory {
             throw new RuntimeException("Can't find an available host in " + sinkOptions.getLoadUrlList());
         }
 
-        String beginUrlStr = "http://" + StreamLoadConstants.getBeginUrl(host);
+        String beginUrlStr = StreamLoadConstants.getBeginUrl(host);
         HttpPost httpPost = new HttpPost(beginUrlStr);
         httpPost.addHeader(HttpHeaders.AUTHORIZATION,
                 StreamLoadUtils.getBasicAuthHeader(sinkOptions.getUsername(), sinkOptions.getPassword()));


### PR DESCRIPTION
## What type of PR is this：
- [ ] bugfix
- [ ] feature
- [X] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

## Problem Summary(Required) ：
Remove http prefix when probing transaction load, and `SinkFunctionFactoryTest#testIsStarRocksSupportTransactionLoad` should pass

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
