### PR TITLE
[Bugfix] Fix dead loop of getAvailableHost() when load url is wrong

### DIFF
--- a/src/main/java/com/starrocks/connector/flink/manager/StarRocksStreamLoadVisitor.java
+++ b/src/main/java/com/starrocks/connector/flink/manager/StarRocksStreamLoadVisitor.java
@@ -187,8 +187,8 @@ public class StarRocksStreamLoadVisitor implements Serializable {
             if (host != null && !host.startsWith("http")) {
                 host = "http://" + host;
             }
+            pos++;
             if (tryHttpConnection(host)) {
-                pos++;
                 return host;
             }
         }

--- a/src/test/resources/log4j2-test.properties
+++ b/src/test/resources/log4j2-test.properties
@@ -18,11 +18,11 @@
 
 # Set root logger level to OFF to not flood build logs
 # set manually to INFO for debugging purposes
-rootLogger.level=WARN
+rootLogger.level=INFO
 rootLogger.appenderRef.test.ref = TestLogger
 
 appender.testlogger.name = TestLogger
 appender.testlogger.type = CONSOLE
 appender.testlogger.target = SYSTEM_ERR
 appender.testlogger.layout.type = PatternLayout
-appender.testlogger.layout.pattern = %-4r [%t] %-5p %c - %m%n
+appender.testlogger.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS} %-5p %-60c %x - %m%n

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/DefaultStreamLoader.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/DefaultStreamLoader.java
@@ -300,10 +300,11 @@ public class DefaultStreamLoader implements StreamLoader, Serializable {
         String[] hosts = properties.getLoadUrls();
         int size = hosts.length;
         long pos = availableHostPos;
-        while (pos < pos + size) {
+        long tmp = pos + size;
+        while (pos < tmp) {
             String host = hosts[(int) (pos % size)];
+            pos++;
             if (testHttpConnection(host)) {
-                pos++;
                 availableHostPos = pos;
                 return host;
             }


### PR DESCRIPTION
## What type of PR is this：
- [X] bugfix
- [ ] feature
- [ ] enhancement
- [ ] refactor
- [ ] others

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

## Problem Summary(Required) ：
`DefaultStreamLoader#getAvailableHost()` and `StarRocksStreamLoadVisitor#getAvailableHost()` will go into dead loop if the load url is wrong and can't be connected

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] I have added user document for my new feature or new function
