### PR TITLE
[Bugfix] The returned result for transaction rollback should be "OK"

### DIFF
--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/TransactionStreamLoader.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/TransactionStreamLoader.java
@@ -289,7 +289,7 @@ public class TransactionStreamLoader extends DefaultStreamLoader {
                 throw new StreamLoadFailException(errMsg);
             }
 
-            if (StreamLoadConstants.RESULT_STATUS_SUCCESS.equals(status)) {
+            if (StreamLoadConstants.RESULT_STATUS_SUCCESS.equals(status) || StreamLoadConstants.RESULT_STATUS_OK.equals(status)) {
                 return true;
             }
             log.error("Transaction rollback failed, db: {}, table: {}, label : {}",


### PR DESCRIPTION
## What type of PR is this：
- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
According to the [doc](https://docs.starrocks.io/en-us/latest/loading/Stream_Load_transaction_interface#return-result-4), the returned response for a successful rollback of transaction stream load should be 
```
{
    "TxnId": 1,
    "Label": "a25eca8b-7b48-4c87-9ea7-0cbdd913e77d",
    "Status": "OK",
    "Message": ""
}
```
The `Status` field is `OK`, but currently `TransactionStreamLoader#rollback` thinks it's `Success`, and will treat a successful  rollback as a failure.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

