### PR TITLE
[Enhancement] Support to configure 100-continue wait timeout

### DIFF
--- a/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksDynamicTableSinkFactory.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksDynamicTableSinkFactory.java
@@ -68,6 +68,7 @@ public class StarRocksDynamicTableSinkFactory implements DynamicTableSinkFactory
         optionalOptions.add(StarRocksSinkOptions.SINK_PARALLELISM);
         optionalOptions.add(StarRocksSinkOptions.SINK_LABEL_PREFIX);
         optionalOptions.add(StarRocksSinkOptions.SINK_CONNECT_TIMEOUT);
+        optionalOptions.add(StarRocksSinkOptions.SINK_WAIT_FOR_CONTINUE_TIMEOUT);
         optionalOptions.add(StarRocksSinkOptions.SINK_IO_THREAD_COUNT);
         optionalOptions.add(StarRocksSinkOptions.SINK_CHUNK_LIMIT);
         optionalOptions.add(StarRocksSinkOptions.SINK_SCAN_FREQUENCY);

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/properties/StreamLoadProperties.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/properties/StreamLoadProperties.java
@@ -11,6 +11,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
+import static org.apache.http.protocol.HttpRequestExecutor.DEFAULT_WAIT_FOR_CONTINUE;
+
 public class StreamLoadProperties implements Serializable {
     private final String jdbcUrl;
     private final String[] loadUrls;
@@ -50,6 +52,7 @@ public class StreamLoadProperties implements Serializable {
      */
     private final int connectTimeout;
     private final int socketTimeout;
+    private final int waitForContinueTimeoutMs;
     private final int ioThreadCount;
 
     // default strategy settings
@@ -88,6 +91,7 @@ public class StreamLoadProperties implements Serializable {
 
         this.connectTimeout = builder.connectTimeout;
         this.socketTimeout = builder.socketTimeout;
+        this.waitForContinueTimeoutMs = builder.waitForContinueTimeoutMs;
         this.ioThreadCount = builder.ioThreadCount;
 
         this.writingThreshold = builder.writingThreshold;
@@ -166,6 +170,10 @@ public class StreamLoadProperties implements Serializable {
         return connectTimeout;
     }
 
+    public int getWaitForContinueTimeoutMs() {
+        return waitForContinueTimeoutMs;
+    }
+
     public int getSocketTimeout() {
         return socketTimeout;
     }
@@ -218,6 +226,7 @@ public class StreamLoadProperties implements Serializable {
 
         private int connectTimeout = 60000;
         private int socketTimeout;
+        private int waitForContinueTimeoutMs = DEFAULT_WAIT_FOR_CONTINUE;
         private int ioThreadCount = Runtime.getRuntime().availableProcessors();
 
         private long writingThreshold = 50L;
@@ -315,6 +324,15 @@ public class StreamLoadProperties implements Serializable {
                 throw new IllegalArgumentException("connectTimeout `" + connectTimeout + "ms` set failed, must range in [100, 60000]");
             }
             this.connectTimeout = connectTimeout;
+            return this;
+        }
+
+        public Builder waitForContinueTimeoutMs(int waitForContinueTimeoutMs) {
+            if (waitForContinueTimeoutMs < DEFAULT_WAIT_FOR_CONTINUE || waitForContinueTimeoutMs > 60000) {
+                throw new IllegalArgumentException("waitForContinueTimeoutMs `" + waitForContinueTimeoutMs +
+                        "ms` set failed, must be in range in [100, 60000]");
+            }
+            this.waitForContinueTimeoutMs = waitForContinueTimeoutMs;
             return this;
         }
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
HTTP request for load need carry the header `Expect` with the value `100-continue` (see [doc](https://docs.starrocks.io/en-us/latest/sql-reference/sql-statements/data-manipulation/STREAM%20LOAD#syntax) for the detail). HTTP client will deal with the request in the following steps
1. send the header to StarRocks' FE
2. wait for the response from FE to redirect to StarRocks' BE
3. send the header and body  to BE

In step 2,  the client will send the body to FE if not receive the response in some time (default 3000 ms), and the logic is only valid when the request is 100-continue.(see [HttpRequestExecutor#doSendRequest](https://github.com/apache/httpcomponents-core/blob/rel/v4.4.6/httpcore/src/main/java/org/apache/http/protocol/HttpRequestExecutor.java#L192) for the detail). This could happen if FE responds slowly for some reasons. It's possible that the client receives the redirect response after sending the body, and it will go to step 3 as normal. In step 3, the client will first check whether the body of request can be sent repeatedly, and if not, the client will return the redirect response to the user directly. For transaction stream load (sink.version = v2), we define a custom [StreamLoadEntity](https://github.com/StarRocks/starrocks-connector-for-apache-flink/blob/main/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/http/StreamLoadEntity.java) to send the body which can reduce memory cost, but it's not repeatable, and has been sent in step 2, so [DefaultStreamLoader#send](https://github.com/StarRocks/starrocks-connector-for-apache-flink/blob/main/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/DefaultStreamLoader.java#L227) will receive a redirect response, and throw the exception below. For stream load(sink.version = v1), use [ByteArrayEntity](https://github.com/apache/httpcomponents-core/blob/rel/v4.4.6/httpcore/src/main/java/org/apache/http/entity/ByteArrayEntity.java) to send the body, and it's repeatable, so it's not sensitive to the delay as V2.
<img width="1920" alt="image" src="https://user-images.githubusercontent.com/11382970/229758413-a811be16-9f96-460f-8a23-0ee5d7db1273.png">

If the problem happens, the user should first find the reason why the response is slow, and the reason can be FE gc, network dealy, Flink gc, or others. From the connector side, we could provide an option to configure the 100-continue wait timeout so that the connector can tolerate the jitter. 

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

