### PR TITLE
[Enhancement] Support to configure whether to use transaction stream load for at-least-once

### DIFF
--- a/src/main/java/com/starrocks/connector/flink/table/sink/SinkFunctionFactory.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/SinkFunctionFactory.java
@@ -67,7 +67,7 @@ public class SinkFunctionFactory {
         httpPost.addHeader(HttpHeaders.AUTHORIZATION,
                 StreamLoadUtils.getBasicAuthHeader(sinkOptions.getUsername(), sinkOptions.getPassword()));
         httpPost.setConfig(RequestConfig.custom().setExpectContinueEnabled(true).setRedirectsEnabled(true).build());
-        LOG.info("Transaction load probe post {}", httpPost);
+        LOG.debug("Transaction load probe post {}", httpPost);
 
         HttpClientBuilder clientBuilder = HttpClients.custom()
                 .setRedirectStrategy(new DefaultRedirectStrategy() {

--- a/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksDynamicTableSinkFactory.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksDynamicTableSinkFactory.java
@@ -66,6 +66,7 @@ public class StarRocksDynamicTableSinkFactory implements DynamicTableSinkFactory
         optionalOptions.add(StarRocksSinkOptions.SINK_SEMANTIC);
         optionalOptions.add(StarRocksSinkOptions.SINK_BATCH_OFFER_TIMEOUT);
         optionalOptions.add(StarRocksSinkOptions.SINK_METRIC_HISTOGRAM_WINDOW_SIZE);
+        optionalOptions.add(StarRocksSinkOptions.SINK_AT_LEAST_ONCE_USE_TRANSACTION_LOAD);
         optionalOptions.add(StarRocksSinkOptions.SINK_PARALLELISM);
         optionalOptions.add(StarRocksSinkOptions.SINK_LABEL_PREFIX);
         optionalOptions.add(StarRocksSinkOptions.SINK_CONNECT_TIMEOUT);

--- a/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksSinkOptions.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksSinkOptions.java
@@ -80,7 +80,7 @@ public class StarRocksSinkOptions implements Serializable {
     public static final ConfigOption<Integer> SINK_CONNECT_TIMEOUT = ConfigOptions.key("sink.connect.timeout-ms")
             .intType().defaultValue(1000).withDescription("Timeout in millisecond for connecting to the `load-url`.");
     public static final ConfigOption<Integer> SINK_WAIT_FOR_CONTINUE_TIMEOUT = ConfigOptions.key("sink.wait-for-continue.timeout-ms")
-            .intType().defaultValue(10000).withDescription("Timeout in millisecond to wait for 100-continue response for http client.");
+            .intType().defaultValue(30000).withDescription("Timeout in millisecond to wait for 100-continue response for http client.");
     public static final ConfigOption<Integer> SINK_IO_THREAD_COUNT = ConfigOptions.key("sink.io.thread-count")
             .intType().defaultValue(2).withDescription("Stream load thread count");
 
@@ -216,7 +216,7 @@ public class StarRocksSinkOptions implements Serializable {
         if (waitForContinueTimeoutMs < DEFAULT_WAIT_FOR_CONTINUE) {
             return DEFAULT_WAIT_FOR_CONTINUE;
         }
-        return Math.min(waitForContinueTimeoutMs, 60000);
+        return Math.min(waitForContinueTimeoutMs, 600000);
     }
 
     public int getIoThreadCount() {

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/DefaultStreamLoader.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/DefaultStreamLoader.java
@@ -25,7 +25,6 @@ import org.slf4j.LoggerFactory;
 import java.io.Serializable;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Transaction stream load is not always perfect for at-least-once. For example, it will open a long-running transaction, and is more easy to reach the limit of the max running transactions. So provide an option to use the normal stream load for at-least-once.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

