### PR TITLE
[Enhancement] Remove useless stack trace log for sink V1

### DIFF
--- a/src/main/java/com/starrocks/connector/flink/manager/StarRocksSinkManager.java
+++ b/src/main/java/com/starrocks/connector/flink/manager/StarRocksSinkManager.java
@@ -389,10 +389,6 @@ public class StarRocksSinkManager implements Serializable {
 
     private void checkFlushException() {
         if (flushException != null) {
-            StackTraceElement[] stack = Thread.currentThread().getStackTrace();
-            for (int i = 0; i < stack.length; i++) {
-                LOG.info(stack[i].getClassName() + "." + stack[i].getMethodName() + " line:" + stack[i].getLineNumber());
-            }
             throw new RuntimeException("Writing records to StarRocks failed.", flushException);
         }
     }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
StarRocksSinkManager#checkFlushException will log current stack trace. It's not useful for troubleshooting, but occupies much of disk space if failover is frequent, so remove this log.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

