### PR TITLE
[Enhancement] Support to retry for normal stream load

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -420,6 +420,7 @@ limitations under the License.
                     </licenseFamilies>
                     <excludes>
                         <exclude>src/test/resources/data/**</exclude>
+                        <exclude>**/dependency-reduced-pom.xml</exclude>
                         <exclude>**/target/**</exclude>
                         <exclude>README.md</exclude>
                         <exclude>.github/**</exclude>

--- a/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksDynamicTableSinkFactory.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksDynamicTableSinkFactory.java
@@ -63,6 +63,7 @@ public class StarRocksDynamicTableSinkFactory implements DynamicTableSinkFactory
         optionalOptions.add(StarRocksSinkOptions.SINK_BATCH_MAX_ROWS);
         optionalOptions.add(StarRocksSinkOptions.SINK_BATCH_FLUSH_INTERVAL);
         optionalOptions.add(StarRocksSinkOptions.SINK_MAX_RETRIES);
+        optionalOptions.add(StarRocksSinkOptions.SINK_RETRY_INTERVAL);
         optionalOptions.add(StarRocksSinkOptions.SINK_SEMANTIC);
         optionalOptions.add(StarRocksSinkOptions.SINK_BATCH_OFFER_TIMEOUT);
         optionalOptions.add(StarRocksSinkOptions.SINK_METRIC_HISTOGRAM_WINDOW_SIZE);

--- a/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksSinkOptions.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksSinkOptions.java
@@ -105,6 +105,10 @@ public class StarRocksSinkOptions implements Serializable {
 
     public static final ConfigOption<Integer> SINK_MAX_RETRIES = ConfigOptions.key("sink.max-retries")
             .intType().defaultValue(3).withDescription("Max flushing retry times of the row batch.");
+
+    public static final ConfigOption<Integer> SINK_RETRY_INTERVAL = ConfigOptions.key("sink.retry.interval-ms")
+            .intType().defaultValue(10000).withDescription("Interval in milliseconds between tries.");
+
     public static final ConfigOption<Long> SINK_BATCH_OFFER_TIMEOUT = ConfigOptions.key("sink.buffer-flush.enqueue-timeout-ms")
             .longType().defaultValue(600000L).withDescription("Offer to flushQueue timeout in millisecond.");
     public static final ConfigOption<Integer> SINK_METRIC_HISTOGRAM_WINDOW_SIZE = ConfigOptions.key("sink.metric.histogram-window-size")
@@ -199,6 +203,10 @@ public class StarRocksSinkOptions implements Serializable {
 
     public int getSinkMaxRetries() {
         return tableOptions.get(SINK_MAX_RETRIES);
+    }
+
+    public int getRetryIntervalMs() {
+        return tableOptions.get(SINK_RETRY_INTERVAL);
     }
 
     public long getSinkMaxFlushInterval() {
@@ -482,6 +490,9 @@ public class StarRocksSinkOptions implements Serializable {
                 .password(getPassword())
                 .version(sinkTable.getVersion())
                 .expectDelayTime(getSinkMaxFlushInterval())
+                // TODO not support retry currently
+                .maxRetries(0)
+                .retryIntervalInMs(getRetryIntervalMs())
                 .addHeaders(getSinkStreamLoadProperties());
 
         for (StreamLoadTableProperties tableProperties : tablePropertiesList) {

--- a/starrocks-stream-load-sdk/pom.xml
+++ b/starrocks-stream-load-sdk/pom.xml
@@ -156,6 +156,7 @@
                     </licenseFamilies>
                     <excludes>
                         <exclude>**/target/**</exclude>
+                        <exclude>dependency-reduced-pom.xml</exclude>
                     </excludes>
                 </configuration>
             </plugin>

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/BatchTableRegion.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/BatchTableRegion.java
@@ -248,7 +248,7 @@ public class BatchTableRegion implements TableRegion {
     }
 
     @Override
-    public void callback(Throwable e) {
+    public void fail(Throwable e) {
         manager.callback(e);
     }
 
@@ -304,7 +304,7 @@ public class BatchTableRegion implements TableRegion {
             flip();
             setResult(streamLoader.send(this));
         } catch (Exception e) {
-            callback(e);
+            fail(e);
         }
     }
 

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/Chunk.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/Chunk.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.starrocks.data.load.stream;
+
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * A chunk is the http body that will be sent in one http request. Multiple rows
+ * will be assembled as a chunk in csv or json format. So the chunk size includes
+ * the rows' size and the delimiters' size.
+ */
+public class Chunk {
+
+    private final StreamLoadDataFormat format;
+    private final LinkedList<byte[]> buffer;
+    private AtomicLong rowBytes;
+    private AtomicLong chunkBytes;
+
+    public Chunk(StreamLoadDataFormat format) {
+        this.format = format;
+        this.buffer = new LinkedList<>();
+        this.rowBytes = new AtomicLong();
+        this.chunkBytes = new AtomicLong();
+        chunkBytes.addAndGet(format.first().length);
+        chunkBytes.addAndGet(format.end().length);
+    }
+
+    public void addRow(byte[] data) {
+        rowBytes.addAndGet(data.length);
+        chunkBytes.addAndGet(data.length + (buffer.isEmpty() ?  0 : format.delimiter().length));
+        buffer.add(data);
+    }
+
+    public int numRows() {
+        return buffer.size();
+    }
+
+    public long rowBytes() {
+        return rowBytes.get();
+    }
+
+    public long chunkBytes() {
+        return chunkBytes.get();
+    }
+
+    public Iterator<byte[]> iterator() {
+        return new DataIterator();
+    }
+
+    enum ItemType {
+        NONE,
+        FIRST,
+        ROW,
+        DELIMITER,
+        END
+    }
+
+    // Iterates the chunk including rows and delimiters
+    private class DataIterator implements Iterator<byte[]> {
+
+        private final Iterator<byte[]> rowIterator;
+        private int totalItems;
+        private ItemType nextItemType;
+
+        public DataIterator() {
+            this.totalItems = 2 + buffer.size() + (buffer.size() - 1);
+            this.rowIterator = buffer.iterator();
+            this.nextItemType = ItemType.FIRST;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return totalItems > 0;
+        }
+
+        @Override
+        public byte[] next() {
+            byte[] item;
+            switch (nextItemType) {
+                case FIRST:
+                    item = format.first();
+                    nextItemType = rowIterator.hasNext() ? ItemType.ROW : ItemType.END;
+                    break;
+                case ROW:
+                    item = rowIterator.next();
+                    nextItemType = rowIterator.hasNext() ? ItemType.DELIMITER : ItemType.END;
+                    break;
+                case DELIMITER:
+                    item = format.delimiter();
+                    nextItemType = ItemType.ROW;
+                    break;
+                case  END:
+                    item = format.end();
+                    nextItemType = ItemType.NONE;
+                    break;
+                default:
+                    throw new UnsupportedOperationException("Should not switch to type " + nextItemType);
+            }
+            totalItems -= 1;
+            return item;
+        }
+    }
+}

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/Chunk.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/Chunk.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright 2021-present StarRocks, Inc. All rights reserved.
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/Chunk.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/Chunk.java
@@ -31,8 +31,8 @@ public class Chunk {
 
     private final StreamLoadDataFormat format;
     private final LinkedList<byte[]> buffer;
-    private AtomicLong rowBytes;
-    private AtomicLong chunkBytes;
+    private final AtomicLong rowBytes;
+    private final AtomicLong chunkBytes;
 
     public Chunk(StreamLoadDataFormat format) {
         this.format = format;
@@ -59,6 +59,10 @@ public class Chunk {
 
     public long chunkBytes() {
         return chunkBytes.get();
+    }
+
+    public long estimateChunkSize(byte[] data) {
+        return chunkBytes.get() + data.length + format.delimiter().length;
     }
 
     public Iterator<byte[]> iterator() {

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/StreamLoader.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/StreamLoader.java
@@ -32,6 +32,8 @@ public interface StreamLoader {
     boolean begin(TableRegion region);
     Future<StreamLoadResponse> send(TableRegion region);
 
+    Future<StreamLoadResponse> send(TableRegion region, int delayMs);
+
     boolean prepare(StreamLoadSnapshot.Transaction transaction);
     boolean commit(StreamLoadSnapshot.Transaction transaction);
     boolean rollback(StreamLoadSnapshot.Transaction transaction);

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/StreamTableRegion.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/StreamTableRegion.java
@@ -263,7 +263,7 @@ public class StreamTableRegion implements TableRegion, Serializable {
     }
 
     @Override
-    public void callback(Throwable e) {
+    public void fail(Throwable e) {
         manager.callback(e);
     }
 
@@ -311,7 +311,7 @@ public class StreamTableRegion implements TableRegion, Serializable {
             setResult(streamLoader.send(this));
             return true;
         } catch (Exception e) {
-            callback(e);
+            fail(e);
         }
 
         return false;

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/TableRegion.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/TableRegion.java
@@ -20,8 +20,10 @@
 
 package com.starrocks.data.load.stream;
 
+import com.starrocks.data.load.stream.http.StreamLoadEntity;
 import com.starrocks.data.load.stream.http.StreamLoadEntityMeta;
 import com.starrocks.data.load.stream.properties.StreamLoadTableProperties;
+import org.apache.http.HttpEntity;
 
 import java.util.concurrent.Future;
 
@@ -53,7 +55,7 @@ public interface TableRegion {
     boolean cancel();
 
     void callback(StreamLoadResponse response);
-    void callback(Throwable e);
+    void fail(Throwable e);
     void complete(StreamLoadResponse response);
 
     void setResult(Future<?> result);
@@ -61,4 +63,8 @@ public interface TableRegion {
 
     boolean isReadable();
     boolean isFlushing();
+
+    default HttpEntity getHttpEntity() {
+        return new StreamLoadEntity(this, getProperties().getDataFormat(), getEntityMeta());
+    }
 }

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/properties/StreamLoadProperties.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/properties/StreamLoadProperties.java
@@ -87,7 +87,8 @@ public class StreamLoadProperties implements Serializable {
     private final float regionBufferRatio;
     private final float youngThreshold;
     private final float oldThreshold;
-
+    private final int maxRetries;
+    private final int retryIntervalInMs;
     private final Map<String, String> headers;
 
     private StreamLoadProperties(Builder builder) {
@@ -118,6 +119,9 @@ public class StreamLoadProperties implements Serializable {
         this.regionBufferRatio = builder.regionBufferRatio;
         this.youngThreshold = builder.youngThreshold;
         this.oldThreshold = builder.oldThreshold;
+
+        this.maxRetries = builder.maxRetries;
+        this.retryIntervalInMs = builder.retryIntervalInMs;
 
         this.headers = Collections.unmodifiableMap(builder.headers);
     }
@@ -218,6 +222,14 @@ public class StreamLoadProperties implements Serializable {
         return oldThreshold;
     }
 
+    public int getMaxRetries() {
+        return maxRetries;
+    }
+
+    public int getRetryIntervalInMs() {
+        return retryIntervalInMs;
+    }
+
     public Map<String, String> getHeaders() {
         return headers;
     }
@@ -253,7 +265,8 @@ public class StreamLoadProperties implements Serializable {
         private float regionBufferRatio = 0.6F;
         private float youngThreshold = 0.1F;
         private float oldThreshold = 0.9F;
-
+        private int maxRetries = 0;
+        private int retryIntervalInMs = 10000;
         private Map<String, String> headers = new HashMap<>();
 
         public Builder jdbcUrl(String jdbcUrl) {
@@ -403,6 +416,16 @@ public class StreamLoadProperties implements Serializable {
 
         public Builder addHeader(String name, String value) {
             headers.put(name, value);
+            return this;
+        }
+
+        public Builder maxRetries(int maxRetries) {
+            this.maxRetries = maxRetries;
+            return this;
+        }
+
+        public Builder retryIntervalInMs(int retryIntervalInMs) {
+            this.retryIntervalInMs = retryIntervalInMs;
             return this;
         }
 

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/ChunkHttpEntity.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/ChunkHttpEntity.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.starrocks.data.load.stream.v2;
+
+import com.starrocks.data.load.stream.Chunk;
+import org.apache.http.Header;
+import org.apache.http.HttpHeaders;
+import org.apache.http.entity.AbstractHttpEntity;
+import org.apache.http.entity.ContentType;
+import org.apache.http.message.BasicHeader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public class ChunkHttpEntity extends AbstractHttpEntity {
+
+    private static final Logger log = LoggerFactory.getLogger(ChunkHttpEntity.class);
+
+    protected static final int OUTPUT_BUFFER_SIZE = 2048;
+    private static final Header CONTENT_TYPE =
+            new BasicHeader(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_OCTET_STREAM.toString());
+    private final String tableUniqueKey;
+    private final InputStream content;
+    private final long contentLength;
+
+    public ChunkHttpEntity(String tableUniqueKey, Chunk chunk) {
+        this.tableUniqueKey = tableUniqueKey;
+        this.content = new ChunkInputStream(chunk);
+        this.contentLength = chunk.chunkBytes();
+    }
+
+    @Override
+    public boolean isRepeatable() {
+        return false;
+    }
+
+    @Override
+    public boolean isChunked() {
+        return false;
+    }
+
+    @Override
+    public long getContentLength() {
+        return contentLength;
+    }
+
+    @Override
+    public Header getContentType() {
+        return CONTENT_TYPE;
+    }
+
+    @Override
+    public Header getContentEncoding() {
+        return null;
+    }
+
+    @Override
+    public InputStream getContent() {
+        return content;
+    }
+
+    @Override
+    public void writeTo(OutputStream outputStream) throws IOException {
+        long total = 0;
+        try (InputStream inputStream = this.content) {
+            final byte[] buffer = new byte[OUTPUT_BUFFER_SIZE];
+            int l;
+            while ((l = inputStream.read(buffer)) != -1) {
+                total += l;
+                outputStream.write(buffer, 0, l);
+            }
+        }
+        log.info("Entity write end, uniqueKey: {}, contentLength : {}, total : {}",
+                tableUniqueKey, contentLength, total);
+    }
+
+    @Override
+    public boolean isStreaming() {
+        return true;
+    }
+}

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/ChunkHttpEntity.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/ChunkHttpEntity.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright 2021-present StarRocks, Inc. All rights reserved.
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/ChunkInputStream.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/ChunkInputStream.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright 2021-present StarRocks, Inc. All rights reserved.
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/ChunkInputStream.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/ChunkInputStream.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.starrocks.data.load.stream.v2;
+
+import com.starrocks.data.load.stream.Chunk;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Iterator;
+
+public class ChunkInputStream extends InputStream {
+
+    private final Chunk chunk;
+    private final Iterator<byte[]> itemIterator;
+    private byte[] currentItem;
+    private int currentPos;
+
+    public ChunkInputStream(Chunk chunk) {
+        this.chunk = chunk;
+        this.itemIterator = chunk.iterator();
+    }
+
+    @Override
+    public int read() throws IOException {
+        byte[] bytes = new byte[1];
+        int ws = read(bytes);
+        if (ws == -1) {
+            return -1;
+        }
+        return bytes[0];
+    }
+
+    @Override
+    public int read(byte[] buf) throws IOException {
+        return read(buf, 0, buf.length);
+    }
+
+    @Override
+    public int read(byte[] buf, int off, int len) throws IOException {
+        if (!itemIterator.hasNext() && currentItem == null) {
+            return -1;
+        }
+
+        byte[] item = currentItem;
+        int pos = currentPos;
+        int readBytes = 0;
+        while (readBytes < len && (item != null || itemIterator.hasNext())) {
+            if (item == null ) {
+                item = itemIterator.next();
+                pos = 0;
+            }
+
+            int size = Math.min(len - readBytes, item.length - pos);
+            System.arraycopy(item, pos, buf, off + readBytes, size);
+            readBytes += size;
+            pos += size;
+
+            if (pos == item.length) {
+                item = null;
+                pos = 0;
+            }
+        }
+
+        currentItem = item;
+        currentPos = pos;
+
+        return readBytes;
+    }
+}

--- a/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/ChunkHttpEntityTest.java
+++ b/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/ChunkHttpEntityTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.starrocks.data.load.stream;
+
+import com.starrocks.data.load.stream.v2.ChunkHttpEntity;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+
+import static com.starrocks.data.load.stream.ChunkInputStreamTest.genChunk;
+import static org.junit.Assert.assertArrayEquals;
+
+public class ChunkHttpEntityTest {
+
+    @Test
+    public void testWrite() throws Exception {
+        ChunkInputStreamTest.ChunkMeta chunkMeta = genChunk();
+        ChunkHttpEntity entity = new ChunkHttpEntity("test", chunkMeta.chunk);
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        entity.writeTo(outputStream);
+        assertArrayEquals(chunkMeta.expectedData, outputStream.toByteArray());
+    }
+}

--- a/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/ChunkHttpEntityTest.java
+++ b/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/ChunkHttpEntityTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright 2021-present StarRocks, Inc. All rights reserved.
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/ChunkInputStreamTest.java
+++ b/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/ChunkInputStreamTest.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.starrocks.data.load.stream;
+
+import com.starrocks.data.load.stream.v2.ChunkInputStream;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.util.Iterator;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ChunkInputStreamTest {
+
+    @Test
+    public void testReadOneByteEachTime() throws Exception {
+        ChunkMeta chunkMeta = genChunk();
+        Chunk chunk = chunkMeta.chunk;
+        byte[] actualData = new byte[(int) chunk.chunkBytes()];
+        try (ChunkInputStream inputStream = new ChunkInputStream(chunk)) {
+            int pos = 0;
+            while (pos < actualData.length) {
+                int len = inputStream.read(actualData, pos, 1);
+                if (len == -1) {
+                    break;
+                }
+                assertEquals(1, len);
+                pos += len;
+            }
+            assertArrayEquals(chunkMeta.expectedData, actualData);
+        }
+    }
+
+    @Test
+    public void testReadAllOnce() throws Exception {
+        ChunkMeta chunkMeta = genChunk();
+        Chunk chunk = chunkMeta.chunk;
+        byte[] actualData = new byte[(int) chunk.chunkBytes()];
+        try (ChunkInputStream inputStream = new ChunkInputStream(chunk)) {
+            int len = inputStream.read(actualData, 0, actualData.length);
+            assertEquals(actualData.length, len);
+            assertArrayEquals(chunkMeta.expectedData, actualData);
+        }
+    }
+
+    @Test
+    public void testReadRandomBytesEacheTime() throws Exception {
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        ChunkMeta chunkMeta = genChunk();
+        Chunk chunk = chunkMeta.chunk;
+        byte[] actualData = new byte[(int) chunk.chunkBytes()];
+        try (ChunkInputStream inputStream = new ChunkInputStream(chunk)) {
+            int pos = 0;
+            while (pos < actualData.length) {
+                int maxLen = random.nextInt(actualData.length - pos) + 1;
+                int len = inputStream.read(actualData, pos, maxLen);
+                if (len == -1) {
+                    break;
+                }
+                assertTrue(len > 0 && len <= maxLen);
+                pos += len;
+            }
+            assertArrayEquals(chunkMeta.expectedData, actualData);
+        }
+    }
+
+    public static ChunkMeta genChunk() {
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        Chunk chunk = new Chunk(StreamLoadDataFormat.CSV);
+        for (int i = 0; i < 1000; i++) {
+            int len = random.nextInt( 100) + 1;
+            byte[] row = new byte[len];
+            random.nextBytes(row);
+            chunk.addRow(row);
+        }
+
+        byte[] expectedData = new byte[(int) chunk.chunkBytes()];
+        ByteBuffer buffer = ByteBuffer.wrap(expectedData);
+        Iterator<byte[]> iterator = chunk.iterator();
+        while (iterator.hasNext()) {
+            byte[] item = iterator.next();
+            buffer.put(item);
+        }
+
+        return new ChunkMeta(chunk, expectedData);
+    }
+
+    public static class ChunkMeta {
+        Chunk chunk;
+        byte[] expectedData;
+
+        public ChunkMeta(Chunk chunk, byte[] expectedData) {
+            this.chunk = chunk;
+            this.expectedData = expectedData;
+        }
+    }
+}

--- a/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/ChunkInputStreamTest.java
+++ b/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/ChunkInputStreamTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright 2021-present StarRocks, Inc. All rights reserved.
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/ChunkTest.java
+++ b/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/ChunkTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.starrocks.data.load.stream;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ChunkTest {
+
+    @Test
+    public void testCsvChunk() {
+        testChunkBase(StreamLoadDataFormat.CSV);
+    }
+
+    @Test
+    public void testJsonChunk() {
+        testChunkBase(StreamLoadDataFormat.JSON);
+    }
+
+    private void testChunkBase(StreamLoadDataFormat format) {
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        long expectedChunkBytes = format.first().length + format.end().length;
+        long expectedRowBytes = 0;
+        List<byte[]> expectedData = new ArrayList<>();
+        expectedData.add(format.first());
+        Chunk chunk = new Chunk(format);
+        int numRows = 100;
+        for (int i = 0; i < numRows; i++) {
+            int len = random.nextInt( 10) + 1;
+            byte[] row = new byte[len];
+            random.nextBytes(row);
+
+            if (i > 0) {
+                expectedData.add(format.delimiter());
+                expectedChunkBytes += format.delimiter().length;
+            }
+            chunk.addRow(row);
+            expectedData.add(row);
+            expectedChunkBytes += row.length;
+            expectedRowBytes += row.length;
+
+            assertEquals(i + 1, chunk.numRows());
+            assertEquals(expectedRowBytes, chunk.rowBytes());
+            assertEquals(expectedChunkBytes, chunk.chunkBytes());
+        }
+        expectedData.add(format.end());
+
+        Iterator<byte[]> expectedIterator = expectedData.iterator();
+        Iterator<byte[]> actualIterator = chunk.iterator();
+        while (expectedIterator.hasNext()) {
+            assertTrue(actualIterator.hasNext());
+            byte[] expectedItem = expectedIterator.next();
+            byte[] actualItem = actualIterator.next();
+            assertArrayEquals(expectedItem, actualItem);
+        }
+        assertFalse(actualIterator.hasNext());
+    }
+}

--- a/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/ChunkTest.java
+++ b/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/ChunkTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright 2021-present StarRocks, Inc. All rights reserved.
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Support to retry for normal stream load if it failed. Currently the retry for transaction stream load is not supported.  The advantage of transaction load is to save memory usage. It splits data into batches, and release the memory for each batch after sending it to StarRocks. If support to retry, need to buffer all data in memory before the last batch success, and the memory usage will not be reduced. this will lose the advantage of transaction stream load


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

