### PR TITLE
[Enhancement] Replace fastjson with jackson in stream-load-sdk

### DIFF
--- a/starrocks-stream-load-sdk/pom.xml
+++ b/starrocks-stream-load-sdk/pom.xml
@@ -17,6 +17,7 @@
         <httpclient.version>4.5.13</httpclient.version>
         <httpcore.version>4.4.15</httpcore.version>
         <fastjson.version>1.2.83</fastjson.version>
+        <fasterxml.version>2.12.4</fasterxml.version>
     </properties>
 
     <dependencies>
@@ -40,9 +41,21 @@
         </dependency>
 
         <dependency>
-            <groupId>com.alibaba</groupId>
-            <artifactId>fastjson</artifactId>
-            <version>${fastjson.version}</version>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${fasterxml.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${fasterxml.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${fasterxml.version}</version>
         </dependency>
 
         <dependency>
@@ -71,6 +84,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -85,7 +99,7 @@
                         <fileset>
                             <directory>./target/</directory>
                             <includes>
-                                <include>${artifactId}*.jar</include>
+                                <include>${project.artifactId}*.jar</include>
                             </includes>
                             <followSymlinks>false</followSymlinks>
                         </fileset>
@@ -95,6 +109,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
+                <version>2.4</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -124,10 +139,6 @@
                             <shadedClassifierName>jar-with-dependencies</shadedClassifierName>
                             <relocations>
                                 <relocation>
-                                    <pattern>com.alibaba</pattern>
-                                    <shadedPattern>com.starrocks.streamload.shade.com.alibaba</shadedPattern>
-                                </relocation>
-                                <relocation>
                                     <pattern>org.apache.hc</pattern>
                                     <shadedPattern>com.starrocks.streamload.shade.org.apache.hc</shadedPattern>
                                 </relocation>
@@ -138,6 +149,10 @@
                                 <relocation>
                                     <pattern>org.apache.commons</pattern>
                                     <shadedPattern>com.starrocks.streamload.shade.org.apache.commons</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.fasterxml.jackson</pattern>
+                                    <shadedPattern>com.starrocks.streamload.shade.com.fasterxml.jackson</shadedPattern>
                                 </relocation>
                             </relocations>
                             <artifactSet>
@@ -152,7 +167,7 @@
                                     <include>org.apache.httpcomponents:httpcore-nio</include>
                                     <include>org.apache.httpcomponents:httpclient</include>
                                     <include>org.apache.httpcomponents:httpasyncclient</include>
-                                    <include>com.alibaba:fastjson</include>
+                                    <include>com.fasterxml.jackson.core:*</include>
                                 </includes>
                             </artifactSet>
                             <filters>

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/DefaultStreamLoadManager.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/DefaultStreamLoadManager.java
@@ -1,6 +1,5 @@
 package com.starrocks.data.load.stream;
 
-import com.alibaba.fastjson.JSON;
 import com.starrocks.data.load.stream.properties.StreamLoadProperties;
 import com.starrocks.data.load.stream.properties.StreamLoadTableProperties;
 import org.slf4j.Logger;
@@ -275,7 +274,7 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
         }
 
         if (response.getException() != null) {
-            log.error("Stream load failed, body : " + JSON.toJSONString(response.getBody()), response.getException());
+            log.error("Stream load failed", response.getException());
             this.e = response.getException();
         }
 
@@ -366,7 +365,6 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
             log.info("Stream load manger close, current bytes : {}, flush rows : {}" +
                             ", numberTotalRows : {}, numberLoadRows : {}, loadMetrics: {}",
                     currentCacheBytes.get(), totalFlushRows.get(), numberTotalRows.get(), numberLoadRows.get(), loadMetrics);
-            printRegionDetails();
             manager.interrupt();
             streamLoader.close();
         }
@@ -425,15 +423,5 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
         // For starrocks <= 2.2, stream load does not support to send json format data
         // using http chunk, so should use BatchTableRegion
         return version.getMajor() < 2 || (version.getMajor() == 2 && version.getMinor() <= 2);
-    }
-
-    private void printRegionDetails() {
-        StringBuilder builder = new StringBuilder();
-
-        for (TableRegion region : regions.values()) {
-            builder.append(JSON.toJSONString(region));
-        }
-
-        log.info("Regions details : {}", builder);
     }
 }

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/StreamLoadDataFormat.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/StreamLoadDataFormat.java
@@ -1,5 +1,7 @@
 package com.starrocks.data.load.stream;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 
@@ -51,6 +53,15 @@ public interface StreamLoadDataFormat {
             return delimiter;
         }
 
+        @JsonValue
+        @Override
+        public String toString() {
+            return "CsvFormat{" +
+                    "first=" + new String(EMPTY_DELIMITER) +
+                    ", delimiter=" + new String(delimiter) +
+                    ", end=" + new String(delimiter) +
+                    '}';
+        }
     }
 
     class JSONFormat implements StreamLoadDataFormat, Serializable {
@@ -73,5 +84,14 @@ public interface StreamLoadDataFormat {
             return end;
         }
 
+        @JsonValue
+        @Override
+        public String toString() {
+            return "JsonFormat{" +
+                    "first=" + new String(first) +
+                    ", delimiter=" + new String(delimiter) +
+                    ", end=" + new String(end) +
+                    '}';
+        }
     }
 }

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/StreamLoadStrategy.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/StreamLoadStrategy.java
@@ -1,6 +1,5 @@
 package com.starrocks.data.load.stream;
 
-import com.alibaba.fastjson.JSON;
 import com.starrocks.data.load.stream.properties.StreamLoadProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,7 +34,7 @@ public interface StreamLoadStrategy extends Serializable {
             this.cacheLimitBytes = cacheMaxBytes * 0.8F;
             this.writingThreshold = properties.getWritingThreshold();
             this.regionBufferRatio = properties.getRegionBufferRatio();
-            log.info("Load Strategy properties : {}", JSON.toJSONString(this));
+            log.info("Load Strategy properties : {}", this);
         }
 
         @Override
@@ -92,6 +91,18 @@ public interface StreamLoadStrategy extends Serializable {
 
         public float getRegionBufferRatio() {
             return regionBufferRatio;
+        }
+
+        @Override
+        public String toString() {
+            return "DefaultLoadStrategy{" +
+                    "oldAge=" + oldAge +
+                    ", youngAge=" + youngAge +
+                    ", cacheMaxBytes=" + cacheMaxBytes +
+                    ", writingThreshold=" + writingThreshold +
+                    ", regionBufferRatio=" + regionBufferRatio +
+                    ", cacheLimitBytes=" + cacheLimitBytes +
+                    '}';
         }
     }
 }

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/StreamLoadUtils.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/StreamLoadUtils.java
@@ -1,7 +1,7 @@
 package com.starrocks.data.load.stream;
 
-import com.alibaba.fastjson.JSON;
-import com.alibaba.fastjson.JSONObject;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpHeaders;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -73,9 +73,12 @@ public class StreamLoadUtils {
             String responseBody = EntityUtils.toString(response.getEntity());
             LOG.debug("Transaction load probe response {}", responseBody);
 
-            JSONObject bodyJson = JSON.parseObject(responseBody);
-            String status = bodyJson.getString("status");
-            String msg = bodyJson.getString("msg");
+            ObjectMapper mapper = new ObjectMapper();
+            JsonNode node = mapper.readTree(responseBody);
+            JsonNode statusNode = node.get("status");
+            String status = statusNode == null ? null : statusNode.asText();
+            JsonNode msgNode = node.get("msg");
+            String msg = msgNode == null ? null : msgNode.asText();
 
             // If StarRocks does not support transaction load, FE's NotFoundAction#executePost
             // will be called where you can know how the response json is constructed

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/properties/StreamLoadProperties.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/properties/StreamLoadProperties.java
@@ -1,6 +1,6 @@
 package com.starrocks.data.load.stream.properties;
 
-import com.alibaba.fastjson.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.starrocks.data.load.stream.StarRocksVersion;
 import com.starrocks.data.load.stream.StreamLoadUtils;
 
@@ -17,7 +17,7 @@ public class StreamLoadProperties implements Serializable {
     private final String jdbcUrl;
     private final String[] loadUrls;
     private final String username;
-    @JSONField(serialize = false)
+    @JsonIgnore
     private final String password;
     private final String version;
     // can be null

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/StreamLoadManagerV2.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/StreamLoadManagerV2.java
@@ -18,7 +18,6 @@
 
 package com.starrocks.data.load.stream.v2;
 
-import com.alibaba.fastjson.JSON;
 import com.starrocks.data.load.stream.DefaultStreamLoader;
 import com.starrocks.data.load.stream.EnvUtils;
 import com.starrocks.data.load.stream.LoadMetrics;
@@ -283,7 +282,7 @@ public class StreamLoadManagerV2 implements StreamLoadManager, Serializable {
         }
 
         if (response.getException() != null) {
-            LOG.error("Stream load failed, body : " + JSON.toJSONString(response.getBody()), response.getException());
+            LOG.error("Stream load failed", response.getException());
             this.e = response.getException();
         }
 

--- a/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/StreamLoadResponseTest.java
+++ b/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/StreamLoadResponseTest.java
@@ -1,6 +1,8 @@
 package com.starrocks.data.load.stream;
 
-import com.alibaba.fastjson.JSON;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -8,7 +10,7 @@ import org.junit.Test;
 public class StreamLoadResponseTest {
 
     @Test
-    public void testDeserialize() {
+    public void testDeserialize() throws Exception {
         String entityContent = "{\n" +
                 "    \"TxnId\": 22736752,\n" +
                 "    \"Label\": \"119d4ca5-a920-4dbb-84ad-64e062a449c5\",\n" +
@@ -27,8 +29,13 @@ public class StreamLoadResponseTest {
                 "    \"CommitAndPublishTimeMs\": 86\n" +
                 "}";
 
+        ObjectMapper objectMapper = new ObjectMapper();
+        // StreamLoadResponseBody does not contain all fields returned by StarRocks
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        // filed names in StreamLoadResponseBody are case-insensitive
+        objectMapper.configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true);
         StreamLoadResponse.StreamLoadResponseBody responseBody =
-                JSON.parseObject(entityContent, StreamLoadResponse.StreamLoadResponseBody.class);
+                objectMapper.readValue(entityContent, StreamLoadResponse.StreamLoadResponseBody.class);
 
         Assert.assertNotNull(responseBody.getStreamLoadPlanTimeMs());
     }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Spark/Flink both use jackson to serialize/deserialize json, so it's possible to reuse the jackson jar from the frameworks if the sdk also uses jackson rather than fastjson, and the sdk will be smaller and there is no need to shade for json dependency. This pr replaces the fastjson with jackson.


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

