### PR TITLE
[Enhancement] Enable strip_outer_array and ignore_json_size by default

### DIFF
--- a/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksSinkOptions.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksSinkOptions.java
@@ -476,6 +476,17 @@ public class StarRocksSinkOptions implements Serializable {
             }
         }
 
+        Map<String, String> streamLoadProperties = new HashMap<>(getSinkStreamLoadProperties());
+        // By default, using json format should enable strip_outer_array and ignore_json_size,
+        // which will simplify the configurations
+        if (dataFormat instanceof StreamLoadDataFormat.JSONFormat) {
+            if (!streamLoadProperties.containsKey("strip_outer_array")) {
+                streamLoadProperties.put("strip_outer_array", "true");
+            }
+            if (!streamLoadProperties.containsKey("ignore_json_size")) {
+                streamLoadProperties.put("ignore_json_size", "true");
+            }
+        }
         StreamLoadProperties.Builder builder = StreamLoadProperties.builder()
                 .loadUrls(getLoadUrlList().toArray(new String[0]))
                 .jdbcUrl(getJdbcUrl())
@@ -493,7 +504,7 @@ public class StarRocksSinkOptions implements Serializable {
                 // TODO not support retry currently
                 .maxRetries(0)
                 .retryIntervalInMs(getRetryIntervalMs())
-                .addHeaders(getSinkStreamLoadProperties());
+                .addHeaders(streamLoadProperties);
 
         for (StreamLoadTableProperties tableProperties : tablePropertiesList) {
             builder.addTableProperties(tableProperties);

--- a/src/test/java/com/starrocks/connector/flink/it/sink/StarRocksSinkITTest.java
+++ b/src/test/java/com/starrocks/connector/flink/it/sink/StarRocksSinkITTest.java
@@ -394,6 +394,12 @@ public class StarRocksSinkITTest extends StarRocksSinkITTestBase {
         );
     }
 
+    @Test
+    public void testJsonFormat() throws Exception {
+        testConfigurationBase(
+                Collections.singletonMap("sink.properties.format", "json"), env -> null);
+    }
+
     private void testConfigurationBase(Map<String, String> options, Function<StreamExecutionEnvironment, Void> setFlinkEnv) throws Exception {
         String tableName = createPkTable("testAtLeastOnceBase");
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

By default, using json format should enable strip_outer_array and ignore_json_size which can improve the ease of use

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

