### PR TITLE
[Bugfix] Fix fastjson classloader leaked

### DIFF
--- a/src/main/java/com/starrocks/connector/flink/manager/StarRocksSinkManager.java
+++ b/src/main/java/com/starrocks/connector/flink/manager/StarRocksSinkManager.java
@@ -18,6 +18,7 @@ import com.starrocks.connector.flink.connection.StarRocksJdbcConnectionOptions;
 import com.starrocks.connector.flink.connection.StarRocksJdbcConnectionProvider;
 import com.starrocks.connector.flink.table.sink.StarRocksSinkOptions;
 import com.starrocks.connector.flink.table.sink.StarRocksSinkSemantic;
+import com.starrocks.connector.flink.tools.JsonWrapper;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Histogram;
@@ -141,7 +142,7 @@ public class StarRocksSinkManager implements Serializable {
         );
     }
 
-    public void setRuntimeContext(RuntimeContext runtimeCtx) {
+    public void open(RuntimeContext runtimeCtx, JsonWrapper jsonWrapper) {
         startTimeNano = System.nanoTime();
         totalFlushBytes = runtimeCtx.getMetricGroup().counter(COUNTER_TOTAL_FLUSH_BYTES);
         totalFlushRows = runtimeCtx.getMetricGroup().counter(COUNTER_TOTAL_FLUSH_ROWS);
@@ -162,6 +163,7 @@ public class StarRocksSinkManager implements Serializable {
         readDataTimeMs = runtimeCtx.getMetricGroup().histogram(HISTOGRAM_READ_DATA_TIME_MS, new DescriptiveStatisticsHistogram(sinkOptions.getSinkHistogramWindowSize()));
         writeDataTimeMs = runtimeCtx.getMetricGroup().histogram(HISTOGRAM_WRITE_DATA_TIME_MS, new DescriptiveStatisticsHistogram(sinkOptions.getSinkHistogramWindowSize()));
         loadTimeMs = runtimeCtx.getMetricGroup().histogram(HISTOGRAM_LOAD_TIME_MS, new DescriptiveStatisticsHistogram(sinkOptions.getSinkHistogramWindowSize()));
+        starrocksStreamLoadVisitor.open(jsonWrapper);
     }
 
     public void startAsyncFlushing() {

--- a/src/main/java/com/starrocks/connector/flink/row/sink/StarRocksCsvSerializer.java
+++ b/src/main/java/com/starrocks/connector/flink/row/sink/StarRocksCsvSerializer.java
@@ -14,7 +14,7 @@
 
 package com.starrocks.connector.flink.row.sink;
 
-import com.alibaba.fastjson.JSON;
+import com.starrocks.connector.flink.tools.JsonWrapper;
 
 import java.util.List;
 import java.util.Map;
@@ -25,8 +25,15 @@ public class StarRocksCsvSerializer implements StarRocksISerializer {
 
     private final String columnSeparator;
 
+    private transient JsonWrapper jsonWrapper;
+
     public StarRocksCsvSerializer(String sp) {
         this.columnSeparator = StarRocksDelimiterParser.parse(sp, "\t");
+    }
+
+    @Override
+    public void open(SerializerContext context) {
+        this.jsonWrapper = context.getFastJsonWrapper();
     }
 
     @Override
@@ -34,7 +41,7 @@ public class StarRocksCsvSerializer implements StarRocksISerializer {
         StringBuilder sb = new StringBuilder();
         int idx = 0;
         for (Object val : values) {
-            sb.append(null == val ? "\\N" : ((val instanceof Map || val instanceof List) ? JSON.toJSONString(val) : val));
+            sb.append(null == val ? "\\N" : ((val instanceof Map || val instanceof List) ? jsonWrapper.toJSONString(val) : val));
             if (idx++ < values.length - 1) {
                 sb.append(columnSeparator);
             }

--- a/src/main/java/com/starrocks/connector/flink/row/sink/StarRocksIRowTransformer.java
+++ b/src/main/java/com/starrocks/connector/flink/row/sink/StarRocksIRowTransformer.java
@@ -15,7 +15,7 @@
 package com.starrocks.connector.flink.row.sink;
 
 import com.starrocks.connector.flink.table.StarRocksDataType;
-
+import com.starrocks.connector.flink.tools.JsonWrapper;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.table.api.TableSchema;
 
@@ -29,6 +29,8 @@ public interface StarRocksIRowTransformer<T> extends Serializable {
     void setTableSchema(TableSchema tableSchema);
 
     void setRuntimeContext(RuntimeContext ctx);
+
+    default void setFastJsonWrapper(JsonWrapper jsonWrapper) {}
 
     Object[] transform(T record, boolean supportUpsertDelete);
     

--- a/src/main/java/com/starrocks/connector/flink/row/sink/StarRocksISerializer.java
+++ b/src/main/java/com/starrocks/connector/flink/row/sink/StarRocksISerializer.java
@@ -14,10 +14,25 @@
 
 package com.starrocks.connector.flink.row.sink;
 
+import com.starrocks.connector.flink.tools.JsonWrapper;
+
 import java.io.Serializable;
 
 public interface StarRocksISerializer extends Serializable {
 
+    default void open(SerializerContext context) {}
+
     String serialize(Object[] values);
-    
+
+    class SerializerContext {
+        private final JsonWrapper jsonWrapper;
+
+        public SerializerContext(JsonWrapper jsonWrapper) {
+            this.jsonWrapper = jsonWrapper;
+        }
+
+        public JsonWrapper getFastJsonWrapper() {
+            return jsonWrapper;
+        }
+    }
 }

--- a/src/main/java/com/starrocks/connector/flink/row/sink/StarRocksJsonSerializer.java
+++ b/src/main/java/com/starrocks/connector/flink/row/sink/StarRocksJsonSerializer.java
@@ -14,7 +14,7 @@
 
 package com.starrocks.connector.flink.row.sink;
 
-import com.alibaba.fastjson.JSON;
+import com.starrocks.connector.flink.tools.JsonWrapper;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -25,8 +25,15 @@ public class StarRocksJsonSerializer implements StarRocksISerializer {
     
     private final String[] fieldNames;
 
+    private transient JsonWrapper jsonWrapper;
+
     public StarRocksJsonSerializer(String[] fieldNames) {
         this.fieldNames = fieldNames;
+    }
+
+    @Override
+    public void open(SerializerContext context) {
+        this.jsonWrapper = context.getFastJsonWrapper();
     }
 
     @Override
@@ -38,7 +45,7 @@ public class StarRocksJsonSerializer implements StarRocksISerializer {
             idx++;
         }
 
-        return JSON.toJSONString(rowMap);
+        return jsonWrapper.toJSONString(rowMap);
     }
     
 }

--- a/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksDynamicSinkFunctionV2.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksDynamicSinkFunctionV2.java
@@ -29,6 +29,7 @@ import com.starrocks.connector.flink.row.sink.StarRocksISerializer;
 import com.starrocks.connector.flink.row.sink.StarRocksSerializerFactory;
 import com.starrocks.connector.flink.table.data.StarRocksRowData;
 import com.starrocks.connector.flink.tools.EnvUtils;
+import com.starrocks.connector.flink.tools.JsonWrapper;
 import com.starrocks.data.load.stream.StreamLoadSnapshot;
 import com.starrocks.data.load.stream.v2.StreamLoadManagerV2;
 import net.sf.jsqlparser.parser.CCJSqlParserUtil;
@@ -84,6 +85,8 @@ public class StarRocksDynamicSinkFunctionV2<T> extends StarRocksDynamicSinkFunct
     private transient List<StarRocksSinkBufferEntity> legacyData;
 
     private transient long totalReceivedRows;
+
+    private transient JsonWrapper jsonWrapper;
 
     public StarRocksDynamicSinkFunctionV2(StarRocksSinkOptions sinkOptions,
                                           TableSchema schema,
@@ -197,14 +200,24 @@ public class StarRocksDynamicSinkFunctionV2<T> extends StarRocksDynamicSinkFunct
     @Override
     public void open(Configuration parameters) throws Exception {
         totalReceivedRows = 0;
+        this.serializer.open(new StarRocksISerializer.SerializerContext(getOrCreateJsonWrapper()));
         sinkManager.init();
         this.streamLoadListener = new StarRocksStreamLoadListener(getRuntimeContext(), sinkOptions);
         sinkManager.setStreamLoadListener(streamLoadListener);
         if (rowTransformer != null) {
             rowTransformer.setRuntimeContext(getRuntimeContext());
+            rowTransformer.setFastJsonWrapper(getOrCreateJsonWrapper());
         }
         notifyCheckpointComplete(Long.MAX_VALUE);
         log.info("Open sink function v2. {}", EnvUtils.getGitInformation());
+    }
+
+    private JsonWrapper getOrCreateJsonWrapper() {
+        if (jsonWrapper == null) {
+            this.jsonWrapper = new JsonWrapper();
+        }
+
+        return jsonWrapper;
     }
 
     @Override
@@ -263,7 +276,7 @@ public class StarRocksDynamicSinkFunctionV2<T> extends StarRocksDynamicSinkFunct
                 );
 
         ListState<byte[]> listState = functionInitializationContext.getOperatorStateStore().getListState(descriptor);
-        snapshotStates = new SimpleVersionedListState<>(listState, new StarRocksVersionedSerializer());
+        snapshotStates = new SimpleVersionedListState<>(listState, new StarRocksVersionedSerializer(getOrCreateJsonWrapper()));
 
         // old version
         ListStateDescriptor<Map<String, StarRocksSinkBufferEntity>> legacyDescriptor =

--- a/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksVersionedSerializer.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksVersionedSerializer.java
@@ -20,7 +20,7 @@
 
 package com.starrocks.connector.flink.table.sink;
 
-import com.alibaba.fastjson.JSON;
+import com.starrocks.connector.flink.tools.JsonWrapper;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 
 import java.io.IOException;
@@ -40,6 +40,12 @@ public class StarRocksVersionedSerializer implements SimpleVersionedSerializer<S
         }
     }
 
+    private final JsonWrapper jsonWrapper;
+
+    public StarRocksVersionedSerializer(JsonWrapper jsonWrapper) {
+        this.jsonWrapper = jsonWrapper;
+    }
+
     @Override
     public int getVersion() {
         return SerializerVersion.V1.getVersion();
@@ -47,11 +53,11 @@ public class StarRocksVersionedSerializer implements SimpleVersionedSerializer<S
 
     @Override
     public byte[] serialize(StarrocksSnapshotState state) throws IOException {
-        return JSON.toJSONBytes(state);
+        return jsonWrapper.toJSONBytes(state);
     }
 
     @Override
     public StarrocksSnapshotState deserialize(int version, byte[] serialized) throws IOException {
-        return JSON.parseObject(serialized, StarrocksSnapshotState.class);
+        return jsonWrapper.parseObject(serialized, StarrocksSnapshotState.class);
     }
 }

--- a/src/main/java/com/starrocks/connector/flink/tools/JsonWrapper.java
+++ b/src/main/java/com/starrocks/connector/flink/tools/JsonWrapper.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2021-present StarRocks, Inc. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.starrocks.connector.flink.tools;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.parser.ParserConfig;
+import com.alibaba.fastjson.serializer.JSONSerializer;
+import com.alibaba.fastjson.serializer.ObjectSerializer;
+import com.alibaba.fastjson.serializer.SerializeConfig;
+import com.alibaba.fastjson.serializer.SerializeWriter;
+import com.alibaba.fastjson.util.IOUtils;
+import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.data.binary.BinaryStringData;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.lang.reflect.Type;
+
+import static com.alibaba.fastjson.JSON.DEFAULT_PARSER_FEATURE;
+
+public class JsonWrapper {
+
+    // These two configs are to replace the global/static instance of SerializeConfig#globalInstance
+    // and ParserConfig#global in fastjson so that the lifetimes of the configs are same as the instance
+    // of this sink, and will not be used by other instances. Otherwise, Flink may fail on checking
+    // classloader leak if the job failover repeatedly. See the flink document for details
+    // https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/config/#classloader-check-leaked-classloader
+    private SerializeConfig serializeConfig;
+    private ParserConfig parserConfig;
+
+    public JsonWrapper() {
+        this.serializeConfig = new SerializeConfig();
+        this.parserConfig = new ParserConfig();
+
+        serializeConfig.put(BinaryStringData.class, new BinaryStringDataSerializer());
+        serializeConfig.put(DecimalData.class, new DecimalDataSerializer());
+        serializeConfig.put(TimestampData.class, new TimestampDataSerializer());
+    }
+
+    public byte[] toJSONBytes(Object object) {
+        return JSON.toJSONBytes(object, serializeConfig);
+    }
+
+    public String toJSONString(Object object) {
+        return JSON.toJSONString(object, serializeConfig);
+    }
+
+    public Object parse(String text) {
+        return JSON.parse(text, parserConfig);
+    }
+
+    public <T> T parseObject(byte[] bytes, Type clazz) {
+        return JSON.parseObject(bytes, 0, bytes.length, IOUtils.UTF8, clazz, parserConfig, null, DEFAULT_PARSER_FEATURE);
+    }
+}
+
+final class BinaryStringDataSerializer implements ObjectSerializer, Serializable {
+    private static final long serialVersionUID = 1L;
+    @Override
+    public void write(JSONSerializer serializer, Object object, Object fieldName, Type fieldType, int features) throws
+            IOException {
+        SerializeWriter out = serializer.getWriter();
+        if (null == object) {
+            serializer.getWriter().writeNull();
+            return;
+        }
+        BinaryStringData strData = (BinaryStringData)object;
+        out.writeString(strData.toString());
+    }
+}
+
+final class DecimalDataSerializer implements ObjectSerializer, Serializable {
+    private static final long serialVersionUID = 1L;
+    @Override
+    public void write(JSONSerializer serializer, Object object, Object fieldName, Type fieldType, int features) throws IOException {
+        SerializeWriter out = serializer.getWriter();
+        if (null == object) {
+            serializer.getWriter().writeNull();
+            return;
+        }
+        out.writeString(((DecimalData)object).toBigDecimal().toPlainString());
+    }
+}
+
+final class TimestampDataSerializer implements ObjectSerializer, Serializable {
+    private static final long serialVersionUID = 1L;
+    @Override
+    public void write(JSONSerializer serializer, Object object, Object fieldName, Type fieldType, int features) throws IOException {
+        SerializeWriter out = serializer.getWriter();
+        if (null == object) {
+            serializer.getWriter().writeNull();
+            return;
+        }
+        out.writeString(((TimestampData)object).toLocalDateTime().toString());
+    }
+}
+

--- a/src/test/java/com/starrocks/connector/flink/it/sink/StarRocksSinkITTest.java
+++ b/src/test/java/com/starrocks/connector/flink/it/sink/StarRocksSinkITTest.java
@@ -33,6 +33,8 @@ import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.types.Row;
 import org.apache.flink.types.RowKind;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -45,8 +47,19 @@ import java.util.function.Function;
 
 import static com.starrocks.connector.flink.it.sink.StarRocksTableUtils.scanTable;
 import static com.starrocks.connector.flink.it.sink.StarRocksTableUtils.verifyResult;
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeTrue;
 
+@RunWith(Parameterized.class)
 public class StarRocksSinkITTest extends StarRocksSinkITTestBase {
+
+    @Parameterized.Parameters(name = "isSinkV1={0}")
+    public static List<Object> parameters() {
+        return Arrays.asList(false, true);
+    }
+
+    @Parameterized.Parameter
+    public boolean isSinkV1;
 
     @Test
     public void testDupKeyWriteFullColumnsInOrder() throws Exception {
@@ -82,6 +95,7 @@ public class StarRocksSinkITTest extends StarRocksSinkITTestBase {
 
     @Test
     public void testDupKeyWritePartialColumnsInOrder() throws Exception {
+        assumeFalse(isSinkV1);
         String ddl = "c0 INT, c2 STRING";
         List<Row> testData = new ArrayList<>();
         testData.add(Row.of(1, "abc"));
@@ -98,6 +112,7 @@ public class StarRocksSinkITTest extends StarRocksSinkITTestBase {
 
     @Test
     public void testDupKeyWritePartialColumnsOutOfOrder() throws Exception {
+        assumeFalse(isSinkV1);
         String ddl = "c2 STRING, c0 INT";
         List<Row> testData = new ArrayList<>();
         testData.add(Row.of("abc", 1));
@@ -133,6 +148,7 @@ public class StarRocksSinkITTest extends StarRocksSinkITTestBase {
                 "'connector' = 'starrocks'," +
                 "'jdbc-url'='" + sinkOptions.getJdbcUrl() + "'," +
                 "'load-url'='" + String.join(";", sinkOptions.getLoadUrlList()) + "'," +
+                "'sink.version' = '" + (isSinkV1 ? "V1" : "V2") + "'," +
                 "'database-name' = '" + DB_NAME + "'," +
                 "'table-name' = '" + sinkOptions.getTableName() + "'," +
                 "'username' = '" + sinkOptions.getUsername() + "'," +
@@ -200,6 +216,7 @@ public class StarRocksSinkITTest extends StarRocksSinkITTestBase {
 
     @Test
     public void testPkWritePartialColumnsInOrder() throws Exception {
+        assumeFalse(isSinkV1);
         String ddl = "c0 INT, c2 STRING";
         List<Row> testData = new ArrayList<>();
         testData.add(Row.of(1, "abc"));
@@ -216,6 +233,7 @@ public class StarRocksSinkITTest extends StarRocksSinkITTestBase {
 
     @Test
     public void testPkWritePartialColumnsOutOfOrder() throws Exception {
+        assumeFalse(isSinkV1);
         String ddl = "c2 STRING, c0 INT";
         List<Row> testData = new ArrayList<>();
         testData.add(Row.of("abc", 1));
@@ -252,6 +270,7 @@ public class StarRocksSinkITTest extends StarRocksSinkITTestBase {
                 "'connector' = 'starrocks'," +
                 "'jdbc-url'='" + sinkOptions.getJdbcUrl() + "'," +
                 "'load-url'='" + String.join(";", sinkOptions.getLoadUrlList()) + "'," +
+                "'sink.version' = '" + (isSinkV1 ? "V1" : "V2") + "'," +
                 "'database-name' = '" + DB_NAME + "'," +
                 "'table-name' = '" + sinkOptions.getTableName() + "'," +
                 "'username' = '" + sinkOptions.getUsername() + "'," +
@@ -301,6 +320,7 @@ public class StarRocksSinkITTest extends StarRocksSinkITTestBase {
                 "'connector' = 'starrocks'," +
                 "'jdbc-url'='" + sinkOptions.getJdbcUrl() + "'," +
                 "'load-url'='" + String.join(";", sinkOptions.getLoadUrlList()) + "'," +
+                "'sink.version' = '" + (isSinkV1 ? "V1" : "V2") + "'," +
                 "'database-name' = '" + DB_NAME + "'," +
                 "'table-name' = '" + sinkOptions.getTableName() + "'," +
                 "'username' = '" + sinkOptions.getUsername() + "'," +
@@ -319,6 +339,8 @@ public class StarRocksSinkITTest extends StarRocksSinkITTestBase {
 
     @Test
     public void testPKPartialUpdateDelete() throws Exception {
+        assumeFalse(isSinkV1);
+        assumeFalse(isSinkV1);
         String tableName = createPkTable("testPKPartialUpdateDelete");
         executeSrSQL(String.format("INSERT INTO `%s`.`%s` VALUES (1, 1.0, '1')", DB_NAME, tableName));
         verifyResult(Collections.singletonList(Arrays.asList(1, 1.0f, "1")), scanTable(DB_CONNECTION, DB_NAME, tableName));
@@ -350,6 +372,7 @@ public class StarRocksSinkITTest extends StarRocksSinkITTestBase {
                 "'connector' = 'starrocks'," +
                 "'jdbc-url'='" + sinkOptions.getJdbcUrl() + "'," +
                 "'load-url'='" + String.join(";", sinkOptions.getLoadUrlList()) + "'," +
+                "'sink.version' = '" + (isSinkV1 ? "V1" : "V2") + "'," +
                 "'database-name' = '" + DB_NAME + "'," +
                 "'table-name' = '" + sinkOptions.getTableName() + "'," +
                 "'username' = '" + sinkOptions.getUsername() + "'," +
@@ -396,6 +419,7 @@ public class StarRocksSinkITTest extends StarRocksSinkITTestBase {
 
     @Test
     public void testJsonFormat() throws Exception {
+        assumeFalse(isSinkV1);
         testConfigurationBase(
                 Collections.singletonMap("sink.properties.format", "json"), env -> null);
     }
@@ -423,6 +447,7 @@ public class StarRocksSinkITTest extends StarRocksSinkITTestBase {
                 "'connector' = 'starrocks'," +
                 "'jdbc-url'='" + getJdbcUrl() + "'," +
                 "'load-url'='" + String.join(";", getHttpUrls()) + "'," +
+                "'sink.version' = '" + (isSinkV1 ? "V1" : "V2") + "'," +
                 "'database-name' = '" + DB_NAME + "'," +
                 "'table-name' = '" + tableName + "'," +
                 "'username' = 'root'," +

--- a/src/test/java/com/starrocks/connector/flink/row/sink/StarRocksJsonSerializerTest.java
+++ b/src/test/java/com/starrocks/connector/flink/row/sink/StarRocksJsonSerializerTest.java
@@ -14,11 +14,10 @@
 
 package com.starrocks.connector.flink.row.sink;
 
+import com.alibaba.fastjson.JSON;
+import com.starrocks.connector.flink.StarRocksSinkBaseTest;
+import com.starrocks.connector.flink.tools.JsonWrapper;
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -27,10 +26,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import com.alibaba.fastjson.JSON;
-import com.starrocks.connector.flink.StarRocksSinkBaseTest;
-import com.starrocks.connector.flink.row.sink.StarRocksISerializer;
-import com.starrocks.connector.flink.row.sink.StarRocksSerializerFactory;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 
 public class StarRocksJsonSerializerTest extends StarRocksSinkBaseTest {
@@ -39,6 +37,7 @@ public class StarRocksJsonSerializerTest extends StarRocksSinkBaseTest {
     public void testCumstomizedSeparatorSerialize() throws IOException {
         OPTIONS.getSinkStreamLoadProperties().put("format", "json");
         StarRocksISerializer serializer = StarRocksSerializerFactory.createSerializer(OPTIONS, TABLE_SCHEMA.getFieldNames());
+        serializer.open(new StarRocksISerializer.SerializerContext(new JsonWrapper()));
         List<Object[]> originRows = Arrays.asList(
             new Object[]{1,"222",333.1,true,"1dsasd","ppp","2020-01-01"},
             new Object[]{2,"333",444.2,false,"1dsasd","ppp","2020-01-01"}


### PR DESCRIPTION
## What type of PR is this：
- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

### Problem
If a job fails many times, flink can warn there is a classloader leak when fastjson serializes/deserializes data
`Caused by: java.lang.IllegalStateException: Trying to access closed classloader. Please check if you store classloaders directly or indirectly in static fields. If the stacktrace suggests that the leak occurs in a third party library and cannot be fixed immediately, you can disable this check with the configuration 'classloader.check-leaked-classloader'.`
<img width="1583" alt="image" src="https://github.com/StarRocks/starrocks-connector-for-apache-flink/assets/11382970/a21259d5-967a-4c47-9164-c8451f39f28e">

### Reason
Fastjson uses two global/static configs by default to serialize and deserialize data (SerializeConfig#globalInstance and ParserConfig#global). Flink's classloader mechanism will treat them as classloader leak if a JVM instance run a job in multiple times, such as failover or in session mode. See flink [classloader.check-leaked-classloader]( https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/config/#classloader-check-leaked-classloader) for details.

### Solution
Don't use fastjson's global configs. Instead each sink instance creates and uses it's own configs, and do not shared with other instance

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

