### PR TITLE
[Feature] Support to trigger flush according to the number of rows

### DIFF
--- a/starrocks-stream-load-sdk/pom.xml
+++ b/starrocks-stream-load-sdk/pom.xml
@@ -59,6 +59,14 @@
         </dependency>
 
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.4.6</version>
+            <type>jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/properties/StreamLoadTableProperties.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/properties/StreamLoadTableProperties.java
@@ -37,6 +37,7 @@ public class StreamLoadTableProperties implements Serializable {
 
     private final boolean enableUpsertDelete;
     private final long chunkLimit;
+    private final int maxBufferRows;
 
     private StreamLoadTableProperties(Builder builder) {
         this.database = builder.database;
@@ -56,6 +57,7 @@ public class StreamLoadTableProperties implements Serializable {
         } else {
             chunkLimit = Math.min(10737418240L, builder.chunkLimit);
         }
+        this.maxBufferRows = builder.maxBufferRows;
         this.properties = builder.properties;
     }
 
@@ -83,6 +85,10 @@ public class StreamLoadTableProperties implements Serializable {
         return chunkLimit;
     }
 
+    public int getMaxBufferRows() {
+        return maxBufferRows;
+    }
+
     public Map<String, String> getProperties() {
         return properties;
     }
@@ -100,6 +106,7 @@ public class StreamLoadTableProperties implements Serializable {
         private boolean enableUpsertDelete;
         private StreamLoadDataFormat dataFormat;
         private long chunkLimit;
+        private int maxBufferRows = Integer.MAX_VALUE;
 
         private final Map<String, String> properties = new HashMap<>();
 
@@ -139,6 +146,11 @@ public class StreamLoadTableProperties implements Serializable {
 
         public Builder chunkLimit(long chunkLimit) {
             this.chunkLimit = chunkLimit;
+            return this;
+        }
+
+        public Builder maxBufferRows(int maxBufferRows) {
+            this.maxBufferRows = maxBufferRows;
             return this;
         }
 

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/FlushReason.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/FlushReason.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021-present StarRocks, Inc. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.starrocks.data.load.stream.v2;
+
+/**
+ * Reason to trigger flush for a table.
+ */
+public enum FlushReason {
+    // No need to flush
+    NONE,
+    // Should commit the data
+    COMMIT,
+    // Cache is full, and need flush on or more tables
+    CACHE_FULL,
+    // The number of buffered rows reaches the limit
+    BUFFER_ROWS_REACH_LIMIT
+}

--- a/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/FlushAndCommitStrategyTest.java
+++ b/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/FlushAndCommitStrategyTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2021-present StarRocks, Inc. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.starrocks.data.load.stream;
+
+import com.starrocks.data.load.stream.properties.StreamLoadProperties;
+import com.starrocks.data.load.stream.v2.FlushAndCommitStrategy;
+import com.starrocks.data.load.stream.v2.FlushReason;
+import com.starrocks.data.load.stream.v2.TransactionTableRegion;
+import org.junit.Test;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class FlushAndCommitStrategyTest {
+
+    @Test
+    public void testFlushWithoutCacheFull() {
+        StreamLoadProperties properties = StreamLoadProperties.builder()
+                .expectDelayTime(1000)
+                .scanningFrequency(50)
+                .cacheMaxBytes(1024 * 1024)
+                .build();
+        FlushAndCommitStrategy strategy = new FlushAndCommitStrategy(properties, true);
+        // should flush because age is enough
+        TransactionTableRegion region1 = mockRegion("u1", 21, 100, FlushReason.NONE);
+        // should flush because BUFFER_ROWS_REACH_LIMIT
+        TransactionTableRegion region2 = mockRegion("u2", 10, 50, FlushReason.BUFFER_ROWS_REACH_LIMIT);
+        // should not flush
+        TransactionTableRegion region3 = mockRegion("u3", 10, 120, FlushReason.NONE);
+
+        LinkedList<TransactionTableRegion> queue = new LinkedList<>();
+        queue.add(region1);
+        queue.add(region2);
+        queue.add(region3);
+        long cacheBytes = queue.stream().mapToLong(TransactionTableRegion::getCacheBytes).sum();
+        List<FlushAndCommitStrategy.SelectFlushResult> resultList = strategy.selectFlushRegions(queue, cacheBytes);
+        assertEquals(2, resultList.size());
+        assertSame(region1, resultList.get(0).getRegion());
+        assertSame(FlushReason.COMMIT, resultList.get(0).getReason());
+        assertSame(region2, resultList.get(1).getRegion());
+        assertSame(FlushReason.BUFFER_ROWS_REACH_LIMIT, resultList.get(1).getReason());
+    }
+
+    @Test
+    public void testFlushWithCacheFull() {
+        StreamLoadProperties properties = StreamLoadProperties.builder()
+                .expectDelayTime(1000)
+                .scanningFrequency(50)
+                .cacheMaxBytes(100)
+                .build();
+        FlushAndCommitStrategy strategy = new FlushAndCommitStrategy(properties, true);
+        // should not flush
+        TransactionTableRegion region1 = mockRegion("u1", 1, 100, FlushReason.NONE);
+        // should flush because the cache bytes is the maximum
+        TransactionTableRegion region2 = mockRegion("u2", 1, 200, FlushReason.NONE);
+        // should not flush
+        TransactionTableRegion region3 = mockRegion("u3", 1, 120, FlushReason.NONE);
+
+        LinkedList<TransactionTableRegion> queue = new LinkedList<>();
+        queue.add(region1);
+        queue.add(region2);
+        queue.add(region3);
+        long cacheBytes = queue.stream().mapToLong(TransactionTableRegion::getCacheBytes).sum();
+        List<FlushAndCommitStrategy.SelectFlushResult> resultList = strategy.selectFlushRegions(queue, cacheBytes);
+        assertEquals(1, resultList.size());
+        assertSame(region2, resultList.get(0).getRegion());
+        assertSame(FlushReason.CACHE_FULL, resultList.get(0).getReason());
+    }
+
+    private static TransactionTableRegion mockRegion(String uniqueKey, long age, long cacheBytes, FlushReason flushReason) {
+        TransactionTableRegion region = mock(TransactionTableRegion.class);
+        when(region.getUniqueKey()).thenReturn(uniqueKey);
+        when(region.getAge()).thenReturn(age);
+        when(region.getCacheBytes()).thenReturn(cacheBytes);
+        when(region.shouldFlush()).thenReturn(flushReason);
+        return region;
+    }
+}


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [X] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This PR adds a new flush strategy that trigger flush if the number of buffered rows in a table reaches the limitation. It's helpful for some users to verify the result in the loading process according to count(*) which should be the multiple times of the number of rows limitation.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

