### PR TITLE
[Enhancement] Try to cleanup lingering transactions when restoring in exactly-once mode

### DIFF
--- a/src/main/java/com/starrocks/connector/flink/table/sink/ExactlyOnceLabelGenerator.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/ExactlyOnceLabelGenerator.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2021-present StarRocks, Inc. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.starrocks.connector.flink.table.sink;
+
+import com.google.common.base.Objects;
+import com.starrocks.data.load.stream.LabelGenerator;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Label generator for a table under exactly-once mode. The generator should guarantee the
+ * uniqueness of the label across different flink jobs, different tables in one job, different
+ * subtasks for a table in one job, and different transactions in on subtask. The label is
+ * in the format {labelPrefix}-{table}-{subtaskIndex}-{id}, and it will be unique because
+ * 1. labelPrefix is unique across different flink jobs, so there is no conflict among flink
+ *    jobs. Note that the uniqueness of labelPrefix should be guaranteed by users.
+ * 2. the table name is unique in a database of StarRocks, and the label only need to be unique in
+ *    the scope of a database. so the label can be unique even if write to multiple tables in a job
+ * 3. use subtaskIndex to make it unique across subtasks if the sink writes parallel
+ * 4. use incremental id to make it unique across different transactions in a subtask
+ *
+ * <p>
+ * The reason why we design this generator for exactly-once is to clean up lingering transactions.
+ * Compared to at-least-once, exactly-once will not abort the PREPARED transactions when the job
+ * failovers or exits because it's 2PC mechanism. Some of those PREPARED transactions may be in a
+ * successful checkpoint, and will be committed when the job restores from the checkpoint, but some
+ * of them are just useless, and should be aborted, otherwise they will be lingering in StarRocks
+ * until timeout which maybe make StarRocks unstable, so we should try to abort these lingering
+ * transactions when the job restores. The key is to find those lingering transactions, and we achieve
+ * it by generating labels according to certain rules, storing the label generator information in
+ * checkpoint, and constructing labels of possible lingering transactions when restoring from the
+ * checkpoints. First, each label has an incremental id, and when checkpointing, the labels with ids
+ * less than nextId must be successful, and ids for lingering transactions must be no less than nextId.
+ * Secondly, make a snapshot {@link ExactlyOnceLabelGeneratorSnapshot} for the generator when checkpointing,
+ * and store it in the state. Thirdly, when restoring from the checkpoint, we can get the nextId, build
+ * labels with those ids no less than nextId, and , query label state in StarRocks, and abort them
+ * if they are PREPARED.
+ */
+public class ExactlyOnceLabelGenerator implements LabelGenerator {
+
+    private final String labelPrefix;
+    private final String db;
+    private final String table;
+    private final int numberOfSubtasks;
+    private final int subTaskIndex;
+    /**
+     * The id only increment when checkpoint triggers, so it will not
+     * be larger than the next checkpoint id. But it may be smaller
+     * than the next checkpoint id because some checkpoints will not
+     * trigger on this subtask, and the id will not increment.
+     */
+    private final AtomicLong nextId;
+
+    public ExactlyOnceLabelGenerator(String labelPrefix, String db, String table,
+                                     int numberOfSubtasks, int subTaskIndex, long initId) {
+        this.labelPrefix = labelPrefix;
+        this.db = db;
+        this.table = table;
+        this.numberOfSubtasks = numberOfSubtasks;
+        this.subTaskIndex = subTaskIndex;
+        this.nextId = new AtomicLong(initId);
+    }
+
+    @Override
+    public String next() {
+        return genLabel(labelPrefix, table, subTaskIndex, nextId.getAndIncrement());
+    }
+
+    public ExactlyOnceLabelGeneratorSnapshot snapshot(long checkpointId) {
+        return new ExactlyOnceLabelGeneratorSnapshot(
+                checkpointId, db, table, labelPrefix, numberOfSubtasks, subTaskIndex, nextId.get());
+    }
+
+    public static String genLabel(String labelPrefix, String table, int subTaskIndex, long id) {
+        return String.format("%s-%s-%s-%s", labelPrefix, table, subTaskIndex, id);
+    }
+
+    @Override
+    public String toString() {
+        return "ExactlyOnceLabelGenerator{" +
+                "labelPrefix='" + labelPrefix + '\'' +
+                ", db='" + db + '\'' +
+                ", table='" + table + '\'' +
+                ", numberOfSubtasks=" + numberOfSubtasks +
+                ", subTaskIndex=" + subTaskIndex +
+                ", nextId=" + nextId +
+                '}';
+    }
+
+    public static class LabelDbTableSubtask {
+
+        private final String labelPrefix;
+        private final String db;
+        private final String table;
+        private final int subTaskIndex;
+
+        public LabelDbTableSubtask(String labelPrefix, String db, String table, int subTaskIndex) {
+            this.labelPrefix = labelPrefix;
+            this.db = db;
+            this.table = table;
+            this.subTaskIndex = subTaskIndex;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            LabelDbTableSubtask that = (LabelDbTableSubtask) o;
+            return subTaskIndex == that.subTaskIndex &&
+                    Objects.equal(labelPrefix, that.labelPrefix) &&
+                    Objects.equal(db, that.db) &&
+                    Objects.equal(table, that.table);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(labelPrefix, db, table, subTaskIndex);
+        }
+    }
+}

--- a/src/main/java/com/starrocks/connector/flink/table/sink/ExactlyOnceLabelGenerator.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/ExactlyOnceLabelGenerator.java
@@ -89,6 +89,34 @@ public class ExactlyOnceLabelGenerator implements LabelGenerator {
                 checkpointId, db, table, labelPrefix, numberOfSubtasks, subTaskIndex, nextId.get());
     }
 
+    public String getLabelPrefix() {
+        return labelPrefix;
+    }
+
+    public String getDb() {
+        return db;
+    }
+
+    public String getTable() {
+        return table;
+    }
+
+    public int getNumberOfSubtasks() {
+        return numberOfSubtasks;
+    }
+
+    public int getSubTaskIndex() {
+        return subTaskIndex;
+    }
+
+    public long getNextId() {
+        return nextId.get();
+    }
+
+    public ExactlyOnceLabelGenerator.LabelDbTableSubtask createLabelDbTableSubtask() {
+        return new ExactlyOnceLabelGenerator.LabelDbTableSubtask(labelPrefix, db, table, subTaskIndex);
+    }
+
     public static String genLabel(String labelPrefix, String table, int subTaskIndex, long id) {
         return String.format("%s-%s-%s-%s", labelPrefix, table, subTaskIndex, id);
     }

--- a/src/main/java/com/starrocks/connector/flink/table/sink/ExactlyOnceLabelGeneratorFactory.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/ExactlyOnceLabelGeneratorFactory.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2021-present StarRocks, Inc. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.starrocks.connector.flink.table.sink;
+
+import com.starrocks.data.load.stream.LabelGenerator;
+import com.starrocks.data.load.stream.LabelGeneratorFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Label generator factory for exactly-once.
+ */
+public class ExactlyOnceLabelGeneratorFactory implements LabelGeneratorFactory {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ExactlyOnceLabelGeneratorFactory.class);
+
+    private final String labelPrefix;
+    private final int numberOfSubtasks;
+    private final int subtaskIndex;
+    private final long restoreCheckpointId;
+    // Label generators. The mapping is db -> table -> generator.
+    private final Map<String, Map<String, ExactlyOnceLabelGenerator>> labelGenerators;
+
+    public ExactlyOnceLabelGeneratorFactory(String labelPrefix, int numberOfSubtasks, int subtaskIndex, long restoreCheckpointId) {
+        this.labelPrefix = labelPrefix;
+        this.numberOfSubtasks = numberOfSubtasks;
+        this.subtaskIndex = subtaskIndex;
+        this.restoreCheckpointId = restoreCheckpointId;
+        this.labelGenerators = new ConcurrentHashMap<>();
+        LOG.info("Create label generator factory. labelPrefix: {}, numberOfSubtasks: {}, subtaskIndex: {}, " +
+                "restoreCheckpointId: {}", labelPrefix, numberOfSubtasks, subtaskIndex, restoreCheckpointId);
+    }
+
+    @Override
+    public synchronized LabelGenerator create(String db, String table) {
+            Map<String, ExactlyOnceLabelGenerator> tableMap = labelGenerators.computeIfAbsent(db, key -> new HashMap<>());
+            ExactlyOnceLabelGenerator generator = tableMap.get(table);
+            if (generator == null) {
+                // use restoreCheckpointId + 1 as the initial id rather than 0 to avoid
+                // conflicts because the same labelPrefix is switched repeatedly
+                generator = new ExactlyOnceLabelGenerator(labelPrefix, db, table,
+                        numberOfSubtasks, subtaskIndex, restoreCheckpointId + 1);
+                tableMap.put(table, generator);
+                LOG.info("Create label generator: {}", generator);
+            }
+            return generator;
+    }
+
+    public synchronized List<ExactlyOnceLabelGeneratorSnapshot> snapshot(long checkpointId) {
+        List<ExactlyOnceLabelGeneratorSnapshot> metas = new ArrayList<>();
+        for (Map.Entry<String, Map<String, ExactlyOnceLabelGenerator>> entry : labelGenerators.entrySet()) {
+            for (ExactlyOnceLabelGenerator generator : entry.getValue().values()) {
+                metas.add(generator.snapshot(checkpointId));
+            }
+        }
+        return metas;
+    }
+
+    public synchronized void restore(List<ExactlyOnceLabelGeneratorSnapshot> snapshots) {
+        Map<ExactlyOnceLabelGenerator.LabelDbTableSubtask, ExactlyOnceLabelGeneratorSnapshot> map = new HashMap<>();
+        for (ExactlyOnceLabelGeneratorSnapshot snapshot : snapshots) {
+            if (snapshot.getSubtaskIndex() != subtaskIndex && !snapshot.getLabelPrefix().equals(labelPrefix)) {
+                LOG.info("Skip snapshot: {}", snapshot);
+                continue;
+            }
+
+            ExactlyOnceLabelGenerator.LabelDbTableSubtask meta = snapshot.createLabelDbTableSubtask();
+            ExactlyOnceLabelGeneratorSnapshot oldSnapshot = map.get(meta);
+            // Sanity check that there should not have duplicated snapshot for a LabelDbTableSubtask
+            if (oldSnapshot != null) {
+                LOG.warn("Find duplicate snapshot, old snapshot: {}, new snapshot: {}", oldSnapshot, snapshot);
+            }
+            map.put(meta, snapshot);
+        }
+
+        for (ExactlyOnceLabelGeneratorSnapshot snapshot : map.values()) {
+            ExactlyOnceLabelGenerator generator = new ExactlyOnceLabelGenerator(
+                    labelPrefix, snapshot.getDb(), snapshot.getTable(), numberOfSubtasks, subtaskIndex, snapshot.getNextId());
+            labelGenerators.computeIfAbsent(snapshot.getDb(), key -> new HashMap<>())
+                    .put(snapshot.getTable(), generator);
+            LOG.info("Restore snapshot: {}, generator: {}", snapshot, generator);
+        }
+    }
+}

--- a/src/main/java/com/starrocks/connector/flink/table/sink/ExactlyOnceLabelGeneratorSnapshot.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/ExactlyOnceLabelGeneratorSnapshot.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2021-present StarRocks, Inc. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.starrocks.connector.flink.table.sink;
+
+/** Snapshot for the label generator. */
+public class ExactlyOnceLabelGeneratorSnapshot {
+
+    /** Which checkpoint creates this snapshot. */
+    private final long checkpointId;
+    /** The database which the generator belongs to. */
+    private final String db;
+    /** The table which the generator belongs to. */
+    private final String table;
+    /** The label prefix. */
+    private final String labelPrefix;
+    /** The number of subtasks (the parallelism of the sink) when this snapshot is created. */
+    private final int numberOfSubtasks;
+    /** The index of the subtask that creates this snapshot. */
+    private final int subtaskIndex;
+    /** Next id used to create label. */
+    private final long nextId;
+
+    public ExactlyOnceLabelGeneratorSnapshot(long checkpointId, String db, String table,
+                                             String labelPrefix, int numberOfSubtasks, int subtaskIndex, long nextId) {
+        this.checkpointId = checkpointId;
+        this.db = db;
+        this.table = table;
+        this.labelPrefix = labelPrefix;
+        this.numberOfSubtasks = numberOfSubtasks;
+        this.subtaskIndex = subtaskIndex;
+        this.nextId = nextId;
+    }
+
+    public long getCheckpointId() {
+        return checkpointId;
+    }
+
+    public String getDb() {
+        return db;
+    }
+
+    public String getTable() {
+        return table;
+    }
+
+    public String getLabelPrefix() {
+        return labelPrefix;
+    }
+
+    public int getNumberOfSubtasks() {
+        return numberOfSubtasks;
+    }
+
+    public int getSubtaskIndex() {
+        return subtaskIndex;
+    }
+
+    public long getNextId() {
+        return nextId;
+    }
+
+    public ExactlyOnceLabelGenerator.LabelDbTableSubtask createLabelDbTableSubtask() {
+        return new ExactlyOnceLabelGenerator.LabelDbTableSubtask(labelPrefix, db, table, subtaskIndex);
+    }
+
+    @Override
+    public String toString() {
+        return "ExactlyOnceLabelGeneratorSnapshot{" +
+                "checkpointId=" + checkpointId +
+                ", db='" + db + '\'' +
+                ", table='" + table + '\'' +
+                ", labelPrefix='" + labelPrefix + '\'' +
+                ", numberOfSubtasks=" + numberOfSubtasks +
+                ", subtaskIndex=" + subtaskIndex +
+                ", nextId=" + nextId +
+                '}';
+    }
+}

--- a/src/main/java/com/starrocks/connector/flink/table/sink/ExactlyOnceLabelGeneratorSnapshot.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/ExactlyOnceLabelGeneratorSnapshot.java
@@ -20,6 +20,8 @@
 
 package com.starrocks.connector.flink.table.sink;
 
+import com.google.common.base.Objects;
+
 /** Snapshot for the label generator. */
 public class ExactlyOnceLabelGeneratorSnapshot {
 
@@ -34,18 +36,18 @@ public class ExactlyOnceLabelGeneratorSnapshot {
     /** The number of subtasks (the parallelism of the sink) when this snapshot is created. */
     private final int numberOfSubtasks;
     /** The index of the subtask that creates this snapshot. */
-    private final int subtaskIndex;
+    private final int subTaskIndex;
     /** Next id used to create label. */
     private final long nextId;
 
     public ExactlyOnceLabelGeneratorSnapshot(long checkpointId, String db, String table,
-                                             String labelPrefix, int numberOfSubtasks, int subtaskIndex, long nextId) {
+                                             String labelPrefix, int numberOfSubtasks, int subTaskIndex, long nextId) {
         this.checkpointId = checkpointId;
         this.db = db;
         this.table = table;
         this.labelPrefix = labelPrefix;
         this.numberOfSubtasks = numberOfSubtasks;
-        this.subtaskIndex = subtaskIndex;
+        this.subTaskIndex = subTaskIndex;
         this.nextId = nextId;
     }
 
@@ -69,8 +71,8 @@ public class ExactlyOnceLabelGeneratorSnapshot {
         return numberOfSubtasks;
     }
 
-    public int getSubtaskIndex() {
-        return subtaskIndex;
+    public int getSubTaskIndex() {
+        return subTaskIndex;
     }
 
     public long getNextId() {
@@ -78,7 +80,37 @@ public class ExactlyOnceLabelGeneratorSnapshot {
     }
 
     public ExactlyOnceLabelGenerator.LabelDbTableSubtask createLabelDbTableSubtask() {
-        return new ExactlyOnceLabelGenerator.LabelDbTableSubtask(labelPrefix, db, table, subtaskIndex);
+        return new ExactlyOnceLabelGenerator.LabelDbTableSubtask(labelPrefix, db, table, subTaskIndex);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ExactlyOnceLabelGeneratorSnapshot snapshot = (ExactlyOnceLabelGeneratorSnapshot) o;
+        return checkpointId == snapshot.checkpointId
+                && numberOfSubtasks == snapshot.numberOfSubtasks
+                && subTaskIndex == snapshot.subTaskIndex
+                && nextId == snapshot.nextId
+                && Objects.equal(db, snapshot.db)
+                && Objects.equal(table, snapshot.table)
+                && Objects.equal(labelPrefix, snapshot.labelPrefix);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(
+                checkpointId,
+                db,
+                table,
+                labelPrefix,
+                numberOfSubtasks,
+                subTaskIndex,
+                nextId);
     }
 
     @Override
@@ -89,7 +121,7 @@ public class ExactlyOnceLabelGeneratorSnapshot {
                 ", table='" + table + '\'' +
                 ", labelPrefix='" + labelPrefix + '\'' +
                 ", numberOfSubtasks=" + numberOfSubtasks +
-                ", subtaskIndex=" + subtaskIndex +
+                ", subtaskIndex=" + subTaskIndex +
                 ", nextId=" + nextId +
                 '}';
     }

--- a/src/main/java/com/starrocks/connector/flink/table/sink/LingeringTransactionAborter.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/LingeringTransactionAborter.java
@@ -112,11 +112,16 @@ public class LingeringTransactionAborter {
                         snapshot.getLabelPrefix(), snapshot.getTable(), snapshot.getSubTaskIndex(), id);
                 try {
                     boolean result = tryAbortTransaction(snapshot.getDb(), snapshot.getTable(), label);
+                    if (result) {
+                        LOG.info("Successful to abort transaction, label: {}, snapshot: {}", label, snapshot);
+                    } else {
+                        LOG.info("Transaction does not need abort, label: {}, snapshot: {}, ", label, snapshot);
+                    }
+
                     // if checkNumTxns < 0, end up after finding the first transaction that does not need abort
-                    if (!result && checkNumTxns < 0) {
+                    if (checkNumTxns < 0 && !result) {
                         break;
                     }
-                    LOG.info("Successful to abort transaction with label {}, the snapshot is {}", label, snapshot);
                 } catch (Exception e) {
                     String errMsg = String.format("Failed to abort transactions with label %s, the snapshot is %s",
                             label, snapshot);
@@ -137,11 +142,16 @@ public class LingeringTransactionAborter {
                 String label = ExactlyOnceLabelGenerator.genLabel(currentLabelPrefix, dbTable.f1, subtaskIndex, id);
                 try {
                     boolean result = tryAbortTransaction(dbTable.f0, dbTable.f1, label);
+                    if (result) {
+                        LOG.info("Successful to abort transaction, label: {}, db: {}, table: {}", label, dbTable.f0, dbTable.f1);
+                    } else {
+                        LOG.info("Transaction does not need abort, label: {}, db: {}, table: {}", label, dbTable.f0, dbTable.f1);
+                    }
+
                     // if checkNumTxns < 0, end up after finding the first transaction that does not need abort
-                    if (!result && checkNumTxns < 0) {
+                    if (checkNumTxns < 0 && !result) {
                         break;
                     }
-                    LOG.info("Successful to abort transaction with label {}, db: {}, table: {}", label, dbTable.f0, dbTable.f1);
                 } catch (Exception e) {
                     String errMsg = String.format("Failed to abort transactions with label %s, db: %s, table: %s",
                             label, dbTable.f0, dbTable.f1);

--- a/src/main/java/com/starrocks/connector/flink/table/sink/LingeringTransactionAborter.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/LingeringTransactionAborter.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2021-present StarRocks, Inc. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.starrocks.connector.flink.table.sink;
+
+import com.starrocks.data.load.stream.StreamLoadSnapshot;
+import com.starrocks.data.load.stream.StreamLoader;
+import com.starrocks.data.load.stream.TransactionStatus;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/** Abort lingering transactions according. */
+public class LingeringTransactionAborter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LingeringTransactionAborter.class);
+
+    private final String currentLabelPrefix;
+    private final long restoredCheckpointId;
+    private final int subtaskIndex;
+    private final int checkNumTxns;
+    private final List<Tuple2<String, String>> dbTables;
+    private final List<ExactlyOnceLabelGeneratorSnapshot> snapshots;
+    private final StreamLoader streamLoader;
+
+    public LingeringTransactionAborter(
+            String currentLabelPrefix,
+            long restoredCheckpointId,
+            int subtaskIndex,
+            int checkNumTxns,
+            List<Tuple2<String, String>> dbTables,
+            List<ExactlyOnceLabelGeneratorSnapshot> snapshots,
+            StreamLoader streamLoader) {
+        this.currentLabelPrefix = currentLabelPrefix;
+        this.restoredCheckpointId = restoredCheckpointId;
+        this.subtaskIndex = subtaskIndex;
+        this.checkNumTxns = checkNumTxns;
+        this.dbTables = dbTables;
+        this.snapshots = snapshots;
+        this.streamLoader = streamLoader;
+        LOG.info("Create lingering transaction aborter, currentLabelPrefix: {}, restoredCheckpointId: {}, " +
+                "subtaskIndex: {}, checkNumTxns: {}, dbTables: {}, snapshots: {}",
+                currentLabelPrefix, restoredCheckpointId, subtaskIndex, checkNumTxns, dbTables, snapshots);
+    }
+
+    public void execute() throws Exception {
+        Map<ExactlyOnceLabelGenerator.LabelDbTableSubtask, ExactlyOnceLabelGeneratorSnapshot> map = new HashMap<>();
+        Set<String> oldLabelPrefixes = new HashSet<>();
+        for (ExactlyOnceLabelGeneratorSnapshot snapshot : snapshots) {
+            // sanity check that the checkpoint id of the snapshot should be the same with the restoredCheckpointId
+            if (snapshot.getCheckpointId() != restoredCheckpointId) {
+                LOG.warn("The checkpoint id for snapshot is not equal to the restored id, restoredCheckpointId: {}," +
+                        " snapshot: {}", restoredCheckpointId, snapshot);
+                continue;
+            }
+
+            ExactlyOnceLabelGenerator.LabelDbTableSubtask meta = snapshot.createLabelDbTableSubtask();
+            ExactlyOnceLabelGeneratorSnapshot oldSnapshot = map.get(meta);
+            // Sanity check that there should not have duplicated snapshot for a LabelDbTableSubtask
+            if (oldSnapshot != null) {
+                LOG.warn("Find duplicate snapshot, old snapshot: {}, new snapshot: {}", oldSnapshot, snapshot);
+            }
+            map.put(meta, snapshot);
+            oldLabelPrefixes.add(snapshot.getLabelPrefix());
+        }
+
+        // Sanity check that the label prefix should be same for all snapshots
+        if (oldLabelPrefixes.size() > 1) {
+            LOG.warn("There are multiple label prefix, {}", oldLabelPrefixes);
+        }
+        abortSnapshotLabelPrefix(new ArrayList<>(map.values()));
+
+        // If the current label prefix is not same as the previous, it's also possible
+        // there are lingering transactions with this label prefix because the job maybe
+        // fail before the first checkpoint is completed, so there is no snapshot for
+        // the current label prefix
+        if (currentLabelPrefix != null && !oldLabelPrefixes.contains(currentLabelPrefix)) {
+            abortCurrentLabelPrefix();
+        }
+    }
+
+    private void abortSnapshotLabelPrefix(List<ExactlyOnceLabelGeneratorSnapshot> snapshots) throws Exception {
+        for (ExactlyOnceLabelGeneratorSnapshot snapshot : snapshots) {
+            // if checkNumTxns is negative, execute until finding the first txn that does not need abort
+            long endId = checkNumTxns < 0 ? Long.MAX_VALUE : snapshot.getNextId() + checkNumTxns;
+            for (long id = snapshot.getNextId(); id < endId; id++) {
+                String label = ExactlyOnceLabelGenerator.genLabel(
+                        snapshot.getLabelPrefix(), snapshot.getTable(), snapshot.getSubtaskIndex(), id);
+                try {
+                    boolean result = tryAbortTransaction(snapshot.getDb(), snapshot.getTable(), label);
+                    // if checkNumTxns < 0, end up after finding the first transaction that does not need abort
+                    if (!result && checkNumTxns < 0) {
+                        break;
+                    }
+                    LOG.info("Successful to abort transaction with label {}, the snapshot is {}", label, snapshot);
+                } catch (Exception e) {
+                    String errMsg = String.format("Failed to abort transactions with label %s, the snapshot is %s",
+                            label, snapshot);
+                    LOG.error("{}", errMsg, e);
+                    throw new Exception(errMsg, e);
+                }
+            }
+        }
+    }
+
+    private void abortCurrentLabelPrefix() throws Exception {
+        for (Tuple2<String, String> dbTable : dbTables) {
+            //TODO considering rescale
+            // if checkNumTxns is negative, execute until find the first txn that does not need abort
+            // The start checkpoint
+            long endId = checkNumTxns < 0 ? Long.MAX_VALUE : restoredCheckpointId + checkNumTxns;
+            for (long id = restoredCheckpointId + 1; id < endId; id++) {
+                String label = ExactlyOnceLabelGenerator.genLabel(dbTable.f0, dbTable.f1, subtaskIndex, id);
+                try {
+                    boolean result = tryAbortTransaction(dbTable.f0, dbTable.f1, label);
+                    // if checkNumTxns < 0, end up after finding the first transaction that does not need abort
+                    if (!result && checkNumTxns < 0) {
+                        break;
+                    }
+                    LOG.info("Successful to abort transaction with label {}, db: {}, table: {}", label, dbTable.f0, dbTable.f1);
+                } catch (Exception e) {
+                    String errMsg = String.format("Failed to abort transactions with label %s, db: %s, table: %s",
+                            label, dbTable.f0, dbTable.f1);
+                    LOG.error("{}", errMsg, e);
+                    throw new Exception(errMsg, e);
+                }
+            }
+        }
+    }
+
+    // Try to abort the transaction with the label. Return false if the transaction does
+    // not need abort, such as the transaction does not exist, or it's already been aborted,
+    // and return true if the label abort successfully. An exception will be thrown if the
+    // transaction need abort but fail.
+    private boolean tryAbortTransaction(String db, String table, String label) throws Exception {
+        TransactionStatus status;
+        try {
+            status = streamLoader.getLoadStatus(db, table, label);
+            LOG.info("Transaction status for db: {}, table: {}, label: {}, status: {}",
+                    db, table, label, status);
+        } catch (Exception e) {
+            String errMsg = String.format("Fail to get status of the label when trying to abort " +
+                    "lingering transactions, db: %s, table: %s, label: %s", db, table, label);
+            LOG.error(errMsg, e);
+            throw new Exception(errMsg, e);
+        }
+
+        if (status == TransactionStatus.UNKNOWN || status == TransactionStatus.ABORTED) {
+            return false;
+        }
+
+        if (status == TransactionStatus.COMMITTED || status == TransactionStatus.VISIBLE) {
+            // One possible reason is that the job is restoring from
+            // an earlier checkpoint rather than the newest
+            String errMsg = String.format("Try to abort a finished transactions, db: %s, table: %s, " +
+                    "label: %s, status: %s. The reason may be that you are restoring from an earlier " +
+                    "checkpoint rather than the newest, and you can use a new sink.label-prefix, or " +
+                    "report the issue", db, table, label, status);
+            LOG.error(errMsg);
+            throw new Exception(errMsg);
+        }
+
+        if (status != TransactionStatus.PREPARE && status != TransactionStatus.PREPARED) {
+            String errMsg = String.format("The status of the transaction is not supported when trying " +
+                    "to abort lingering transactions, db: %s, table: %s, label: %s, status: %s",
+                    db, table, label, status);
+            LOG.error(errMsg);
+            throw new Exception(errMsg);
+        }
+
+        try {
+            StreamLoadSnapshot.Transaction transaction = new StreamLoadSnapshot.Transaction(db, table, label);
+            boolean result = streamLoader.rollback(transaction);
+            if (!result) {
+                // TODO rollback does not return fail reason currently
+                throw new Exception(String.format("Failed to abort transaction, and please find " +
+                        "the reason in the taskmanager log, db: %s, table: %s, label: %s", db, table, label));
+            }
+            LOG.info("Successful to abort the lingering transaction, db: {}, table: {}, label: {}",
+                    db, table, label);
+            return true;
+        } catch (Exception e) {
+            // get the label status again to make sure whether the label has been aborted
+            TransactionStatus newStatus = null;
+            try {
+                newStatus = streamLoader.getLoadStatus(db, table, label);
+                LOG.info("Transaction status after trying to abort for db: {}, table: {}, label: {}, " +
+                                "status: {}", db, table, label, newStatus);
+            } catch (Exception ie) {
+                LOG.error("Fail to get new transaction status after failing to abort the transaction, " +
+                        "db: {}, table: {}, label: {}", db, table, label, ie);
+            }
+
+            if (newStatus == null || newStatus == TransactionStatus.PREPARE || newStatus == TransactionStatus.PREPARED) {
+                String errMsg = String.format("Fail to abort lingering transaction, db: %s, table: %s, " +
+                        "label: %s, status: %s", db, table, label, newStatus);
+                LOG.error(errMsg, e);
+                throw new Exception(errMsg, e);
+            }
+
+            LOG.info("Successful to abort the lingering transaction, db: {}, table: {}, label: {}, " +
+                    "new status: {}, but there is an exception when abort it", db, table, label, newStatus, e);
+            return true;
+        }
+    }
+}

--- a/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksDynamicSinkFunctionV2.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksDynamicSinkFunctionV2.java
@@ -252,6 +252,7 @@ public class StarRocksDynamicSinkFunctionV2<T> extends StarRocksDynamicSinkFunct
                     getRuntimeContext().getIndexOfThisSubtask(),
                     restoredCheckpointId);
             labelGeneratorFactory.restore(restoredGeneratorSnapshots);
+            sinkManager.setLabelGeneratorFactory(labelGeneratorFactory);
         }
 
         notifyCheckpointComplete(Long.MAX_VALUE);

--- a/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksDynamicSinkFunctionV2.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksDynamicSinkFunctionV2.java
@@ -41,6 +41,7 @@ import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.typeinfo.TypeHint;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.checkpoint.CheckpointIDCounter;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.streaming.api.operators.util.SimpleVersionedListState;
@@ -61,6 +62,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 
 public class StarRocksDynamicSinkFunctionV2<T> extends StarRocksDynamicSinkFunctionBase<T> {
 
@@ -75,9 +77,18 @@ public class StarRocksDynamicSinkFunctionV2<T> extends StarRocksDynamicSinkFunct
     private final StarRocksIRowTransformer<T> rowTransformer;
 
     private transient volatile ListState<StarrocksSnapshotState> snapshotStates;
-    private final Map<Long, List<StreamLoadSnapshot>> snapshotMap = new ConcurrentHashMap<>();
+
+    private transient long restoredCheckpointId;
+
+    private transient List<ExactlyOnceLabelGeneratorSnapshot> restoredGeneratorSnapshots;
+
+    private transient Map<Long, List<StreamLoadSnapshot>> snapshotMap;
 
     private transient StarRocksStreamLoadListener streamLoadListener;
+
+    // Only valid when using exactly-once and label prefix is set
+    @Nullable
+    private transient ExactlyOnceLabelGeneratorFactory labelGeneratorFactory;
 
     @Deprecated
     private transient ListState<Map<String, StarRocksSinkBufferEntity>> legacyState;
@@ -203,15 +214,47 @@ public class StarRocksDynamicSinkFunctionV2<T> extends StarRocksDynamicSinkFunct
         if (serializer != null) {
             this.serializer.open(new StarRocksISerializer.SerializerContext(getOrCreateJsonWrapper()));
         }
-        sinkManager.init();
         this.streamLoadListener = new StarRocksStreamLoadListener(getRuntimeContext(), sinkOptions);
         sinkManager.setStreamLoadListener(streamLoadListener);
+        if (labelGeneratorFactory != null) {
+            sinkManager.setLabelGeneratorFactory(labelGeneratorFactory);
+        }
+        sinkManager.init();
         if (rowTransformer != null) {
             rowTransformer.setRuntimeContext(getRuntimeContext());
             rowTransformer.setFastJsonWrapper(getOrCreateJsonWrapper());
         }
-        notifyCheckpointComplete(Long.MAX_VALUE);
+
+        if (sinkOptions.getSemantic() == StarRocksSinkSemantic.EXACTLY_ONCE) {
+            openForExactlyOnce();
+        }
+
         log.info("Open sink function v2. {}", EnvUtils.getGitInformation());
+    }
+
+    private void openForExactlyOnce() throws Exception {
+        if (sinkOptions.isAbortLingeringTxns()) {
+            LingeringTransactionAborter aborter = new LingeringTransactionAborter(
+                    sinkOptions.getLabelPrefix(),
+                    restoredCheckpointId,
+                    getRuntimeContext().getIndexOfThisSubtask(),
+                    sinkOptions.getAbortCheckNumTxns(),
+                    sinkOptions.getDbTables(),
+                    restoredGeneratorSnapshots,
+                    sinkManager.getStreamLoader());
+            aborter.execute();
+        }
+
+        if (sinkOptions.getLabelPrefix() != null) {
+            this.labelGeneratorFactory = new ExactlyOnceLabelGeneratorFactory(
+                    sinkOptions.getLabelPrefix(),
+                    getRuntimeContext().getNumberOfParallelSubtasks(),
+                    getRuntimeContext().getIndexOfThisSubtask(),
+                    restoredCheckpointId);
+            labelGeneratorFactory.restore(restoredGeneratorSnapshots);
+        }
+
+        notifyCheckpointComplete(Long.MAX_VALUE);
     }
 
     private JsonWrapper getOrCreateJsonWrapper() {
@@ -229,6 +272,7 @@ public class StarRocksDynamicSinkFunctionV2<T> extends StarRocksDynamicSinkFunct
 
     @Override
     public void close() {
+        log.info("Close sink function");
         try {
             sinkManager.flush();
         } catch (Exception e) {
@@ -254,7 +298,9 @@ public class StarRocksDynamicSinkFunctionV2<T> extends StarRocksDynamicSinkFunct
             snapshotMap.put(functionSnapshotContext.getCheckpointId(), Collections.singletonList(snapshot));
 
             snapshotStates.clear();
-            snapshotStates.add(StarrocksSnapshotState.of(snapshotMap));
+            List<ExactlyOnceLabelGeneratorSnapshot> labelSnapshots = labelGeneratorFactory == null ? null
+                    : labelGeneratorFactory.snapshot(functionSnapshotContext.getCheckpointId());
+            snapshotStates.add(StarrocksSnapshotState.of(snapshotMap, labelSnapshots));
         } else {
             sinkManager.abort(snapshot);
             throw new RuntimeException("Snapshot state failed by prepare");
@@ -267,6 +313,7 @@ public class StarRocksDynamicSinkFunctionV2<T> extends StarRocksDynamicSinkFunct
 
     @Override
     public void initializeState(FunctionInitializationContext functionInitializationContext) throws Exception {
+        log.info("Initialize state");
         if (sinkOptions.getSemantic() != StarRocksSinkSemantic.EXACTLY_ONCE) {
             return;
         }
@@ -287,7 +334,10 @@ public class StarRocksDynamicSinkFunctionV2<T> extends StarRocksDynamicSinkFunct
                         TypeInformation.of(new TypeHint<Map<String, StarRocksSinkBufferEntity>>(){})
                 );
         legacyState = functionInitializationContext.getOperatorStateStore().getListState(legacyDescriptor);
-
+        this.restoredCheckpointId = functionInitializationContext.getRestoredCheckpointId()
+                .orElse(CheckpointIDCounter.INITIAL_CHECKPOINT_ID - 1);
+        this.restoredGeneratorSnapshots = new ArrayList<>();
+        this.snapshotMap = new ConcurrentHashMap<>();
         if (functionInitializationContext.isRestored()) {
             for (StarrocksSnapshotState state : snapshotStates.get()) {
                 for (Map.Entry<Long, List<StreamLoadSnapshot>> entry : state.getData().entrySet()) {
@@ -298,6 +348,10 @@ public class StarRocksDynamicSinkFunctionV2<T> extends StarRocksDynamicSinkFunct
                         v.addAll(entry.getValue());
                         return v;
                     });
+                }
+
+                if (state.getLabelSnapshots() != null) {
+                    restoredGeneratorSnapshots.addAll(state.getLabelSnapshots());
                 }
             }
 
@@ -311,9 +365,11 @@ public class StarRocksDynamicSinkFunctionV2<T> extends StarRocksDynamicSinkFunct
 
     @Override
     public void notifyCheckpointComplete(long checkpointId) throws Exception {
+        if (sinkOptions.getSemantic() != StarRocksSinkSemantic.EXACTLY_ONCE) {
+            return;
+        }
 
         boolean succeed = true;
-
         List<Long> commitCheckpointIds = snapshotMap.keySet().stream()
                 .filter(cpId -> cpId <= checkpointId)
                 .sorted(Long::compare)

--- a/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksDynamicTableSinkFactory.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksDynamicTableSinkFactory.java
@@ -76,6 +76,7 @@ public class StarRocksDynamicTableSinkFactory implements DynamicTableSinkFactory
         optionalOptions.add(StarRocksSinkOptions.SINK_CHUNK_LIMIT);
         optionalOptions.add(StarRocksSinkOptions.SINK_SCAN_FREQUENCY);
         optionalOptions.add(StarRocksSinkOptions.SINK_IGNORE_UPDATE_BEFORE);
+        optionalOptions.add(StarRocksSinkOptions.SINK_ABORT_LINGERING_TXNS);
         return optionalOptions;
     }
 }

--- a/src/main/java/com/starrocks/connector/flink/table/sink/StarrocksSnapshotState.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/StarrocksSnapshotState.java
@@ -26,15 +26,20 @@ import com.starrocks.data.load.stream.StreamLoadSnapshot;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 public class StarrocksSnapshotState implements Serializable {
     private String version;
     private Map<Long, List<StreamLoadSnapshot>> data;
+    @Nullable
+    private List<ExactlyOnceLabelGeneratorSnapshot> labelSnapshots;
 
-    public static StarrocksSnapshotState of(Map<Long, List<StreamLoadSnapshot>> data) {
+    public static StarrocksSnapshotState of(
+            Map<Long, List<StreamLoadSnapshot>> data, List<ExactlyOnceLabelGeneratorSnapshot> labelSnapshots) {
         StarrocksSnapshotState starrocksSnapshotState = new StarrocksSnapshotState();
         starrocksSnapshotState.version = EnvUtils.getSRFCVersion();
         starrocksSnapshotState.data = data;
+        starrocksSnapshotState.labelSnapshots = labelSnapshots;
         return starrocksSnapshotState;
     }
 
@@ -52,5 +57,14 @@ public class StarrocksSnapshotState implements Serializable {
 
     public void setData(Map<Long, List<StreamLoadSnapshot>> data) {
         this.data = data;
+    }
+
+    @Nullable
+    public List<ExactlyOnceLabelGeneratorSnapshot> getLabelSnapshots() {
+        return labelSnapshots;
+    }
+
+    public void setLabelSnapshots(@Nullable List<ExactlyOnceLabelGeneratorSnapshot> labelSnapshots) {
+        this.labelSnapshots = labelSnapshots;
     }
 }

--- a/src/test/java/com/starrocks/connector/flink/table/sink/ExactlyOnceLabelTest.java
+++ b/src/test/java/com/starrocks/connector/flink/table/sink/ExactlyOnceLabelTest.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2021-present StarRocks, Inc. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.starrocks.connector.flink.table.sink;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+
+/** Tests for {@link ExactlyOnceLabelGenerator} and {@link ExactlyOnceLabelGeneratorFactory}. */
+public class ExactlyOnceLabelTest {
+
+    @Test
+    public void testGenerator() {
+        ExactlyOnceLabelGenerator generator = new ExactlyOnceLabelGenerator(
+                "test_label",
+                "test_db",
+                "test_table",
+                5,
+                2,
+                10);
+        for (int i = 10; i < 20; i++) {
+            assertEquals("test_label-test_table-2-" + i, generator.next());
+        }
+    }
+
+    @Test
+    public void testGeneratorFactory() {
+        ExactlyOnceLabelGeneratorFactory factory = new ExactlyOnceLabelGeneratorFactory(
+                "test_label", 7, 3, 34);
+
+        ExactlyOnceLabelGenerator generator1 = factory.create("db1", "tbl1");
+        ExactlyOnceLabelGenerator generator2 = factory.create("db1", "tbl2");
+        ExactlyOnceLabelGenerator generator3 = factory.create("db2", "tbl1");
+
+        assertNotSame(generator1, generator2);
+        assertNotSame(generator1, generator3);
+        assertSame(generator1, factory.create("db1", "tbl1"));
+
+        for (int i = 35; i < 50; i++) {
+            for (ExactlyOnceLabelGenerator generator : Arrays.asList(generator1, generator2, generator3)) {
+                String label = String.format("test_label-%s-3-%s", generator.getTable(), i);
+                assertEquals(label, generator.next());
+            }
+        }
+    }
+
+    @Test
+    public void testSnapshot() {
+        ExactlyOnceLabelGeneratorFactory factory = new ExactlyOnceLabelGeneratorFactory(
+                "test_label", 7, 3, 34);
+
+        List<ExactlyOnceLabelGenerator> generators = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            String db = "db" + i;
+            for (int j = 0; j < 5; j++) {
+                generators.add(factory.create(db, "tbl" + j));
+            }
+        }
+
+        Random random = new Random(System.currentTimeMillis());
+        for (int i = 0; i < 1000; i++) {
+            int index = random.nextInt(generators.size());
+            generators.get(index).next();
+        }
+
+        List<ExactlyOnceLabelGeneratorSnapshot> snapshots5 = factory.snapshot(5);
+        assertEquals(generators.size(), snapshots5.size());
+        Map<ExactlyOnceLabelGenerator.LabelDbTableSubtask, ExactlyOnceLabelGenerator> map = new HashMap<>();
+        generators.forEach(gen -> map.put(gen.createLabelDbTableSubtask(), gen));
+        for (ExactlyOnceLabelGeneratorSnapshot snapshot : snapshots5) {
+            ExactlyOnceLabelGenerator generator = map.remove(snapshot.createLabelDbTableSubtask());
+            assertNotNull(generator);
+            verifySnapshot(5, generator, snapshot);
+        }
+
+        for (int i = 10; i < 15; i++) {
+            String db = "db" + i;
+            for (int j = 0; j < 5; j++) {
+                generators.add(factory.create(db, "tbl" + j));
+            }
+        }
+        for (int i = 0; i < 1000; i++) {
+            int index = random.nextInt(generators.size());
+            generators.get(index).next();
+        }
+
+        List<ExactlyOnceLabelGeneratorSnapshot> snapshots9 = factory.snapshot(9);
+        assertEquals(generators.size(), snapshots9.size());
+        Map<ExactlyOnceLabelGenerator.LabelDbTableSubtask, ExactlyOnceLabelGenerator> map1 = new HashMap<>();
+        generators.forEach(gen -> map1.put(gen.createLabelDbTableSubtask(), gen));
+        for (ExactlyOnceLabelGeneratorSnapshot snapshot : snapshots9) {
+            ExactlyOnceLabelGenerator generator = map1.remove(snapshot.createLabelDbTableSubtask());
+            assertNotNull(generator);
+            verifySnapshot(9, generator, snapshot);
+        }
+    }
+
+    @Test
+    public void testRestoreWithoutRescaleAndLabelPrefixChange() {
+        ExactlyOnceLabelGeneratorFactory factory = new ExactlyOnceLabelGeneratorFactory(
+                "test_label", 7, 3, 34);
+
+        ExactlyOnceLabelGeneratorSnapshot snapshot1 = new ExactlyOnceLabelGeneratorSnapshot(
+                34, "db1", "tbl1", "test_label", 7, 3, 10);
+        ExactlyOnceLabelGeneratorSnapshot snapshot2 = new ExactlyOnceLabelGeneratorSnapshot(
+                34, "db1", "tbl2", "test_label", 7, 3, 5);
+        ExactlyOnceLabelGeneratorSnapshot snapshot3 = new ExactlyOnceLabelGeneratorSnapshot(
+                34, "db2", "tbl1", "test_label", 7, 3, 30);
+        ExactlyOnceLabelGeneratorSnapshot snapshot4 = new ExactlyOnceLabelGeneratorSnapshot(
+                34, "db2", "tbl2", "test_label", 7, 3, 23);
+
+        List<ExactlyOnceLabelGeneratorSnapshot> snapshots = Arrays.asList(snapshot1, snapshot2, snapshot3, snapshot4);
+        factory.restore(snapshots);
+        assertEquals(snapshots.size(), factory.numGenerators());
+        for (ExactlyOnceLabelGeneratorSnapshot snapshot : snapshots) {
+            ExactlyOnceLabelGenerator generator = factory.create(snapshot.getDb(), snapshot.getTable());
+            verifySnapshot(snapshot.getCheckpointId(), generator, snapshot);
+        }
+    }
+
+    @Test
+    public void testRestoreWithNewLabelPrefix() {
+        ExactlyOnceLabelGeneratorFactory factory = new ExactlyOnceLabelGeneratorFactory(
+                "test_label", 7, 3, 34);
+
+        ExactlyOnceLabelGeneratorSnapshot snapshot1 = new ExactlyOnceLabelGeneratorSnapshot(
+                34, "db1", "tbl1", "test_label_old", 7, 3, 10);
+        ExactlyOnceLabelGeneratorSnapshot snapshot2 = new ExactlyOnceLabelGeneratorSnapshot(
+                34, "db2", "tbl1", "test_label_old", 7, 3, 30);
+
+        List<ExactlyOnceLabelGeneratorSnapshot> snapshots = Arrays.asList(snapshot1, snapshot2);
+        factory.restore(snapshots);
+        assertEquals(0, factory.numGenerators());
+    }
+
+    @Test
+    public void testRestoreWithRescale() {
+        // Only need to test scale down where a new subtask maybe receive snapshots from multiple old subtasks.
+        // In scale up, each new subtask only receive snapshots from at most one of old subtasks, which is a
+        // special case of no rescale
+        ExactlyOnceLabelGeneratorFactory factory = new ExactlyOnceLabelGeneratorFactory(
+                "test_label", 5, 2, 34);
+
+        // from old subtask 1, and should not restore
+        ExactlyOnceLabelGeneratorSnapshot snapshot11 = new ExactlyOnceLabelGeneratorSnapshot(
+                34, "db1", "tbl1", "test_label", 7, 1, 10);
+        ExactlyOnceLabelGeneratorSnapshot snapshot12 = new ExactlyOnceLabelGeneratorSnapshot(
+                34, "db2", "tbl1", "test_label", 7, 1, 11);
+
+        // from old subtask 2, and should not restore
+        ExactlyOnceLabelGeneratorSnapshot snapshot21 = new ExactlyOnceLabelGeneratorSnapshot(
+                34, "db1", "tbl1", "test_label", 7, 2, 5);
+        ExactlyOnceLabelGeneratorSnapshot snapshot22 = new ExactlyOnceLabelGeneratorSnapshot(
+                34, "db2", "tbl1", "test_label", 7, 2, 30);
+
+        // from old subtask 3, and should not restore
+        ExactlyOnceLabelGeneratorSnapshot snapshot31 = new ExactlyOnceLabelGeneratorSnapshot(
+                34, "db1", "tbl1", "test_label", 7, 3, 23);
+        ExactlyOnceLabelGeneratorSnapshot snapshot32 = new ExactlyOnceLabelGeneratorSnapshot(
+                34, "db2", "tbl1", "test_label", 7, 3, 25);
+
+        List<ExactlyOnceLabelGeneratorSnapshot> snapshots =
+                Arrays.asList(snapshot11, snapshot12, snapshot21, snapshot22, snapshot31, snapshot32);
+        factory.restore(snapshots);
+        assertEquals(2, factory.numGenerators());
+
+        ExactlyOnceLabelGeneratorSnapshot snapshot21_restore = new ExactlyOnceLabelGeneratorSnapshot(
+                34, "db1", "tbl1", "test_label", 5, 2, 5);
+        ExactlyOnceLabelGeneratorSnapshot snapshot22_restore = new ExactlyOnceLabelGeneratorSnapshot(
+                34, "db2", "tbl1", "test_label", 5, 2, 30);
+        for (ExactlyOnceLabelGeneratorSnapshot snapshot : Arrays.asList(snapshot21_restore, snapshot22_restore)) {
+            ExactlyOnceLabelGenerator generator = factory.create(snapshot.getDb(), snapshot.getTable());
+            verifySnapshot(snapshot.getCheckpointId(), generator, snapshot);
+        }
+    }
+
+    private void verifySnapshot(long checkpointId, ExactlyOnceLabelGenerator generator, ExactlyOnceLabelGeneratorSnapshot snapshot) {
+        assertEquals(checkpointId, snapshot.getCheckpointId());
+        assertEquals(generator.getLabelPrefix(), snapshot.getLabelPrefix());
+        assertEquals(generator.getDb(), snapshot.getDb());
+        assertEquals(generator.getTable(), snapshot.getTable());
+        assertEquals(generator.getNumberOfSubtasks(), snapshot.getNumberOfSubtasks());
+        assertEquals(generator.getSubTaskIndex(), snapshot.getSubTaskIndex());
+        assertEquals(generator.getNextId(), snapshot.getNextId());
+    }
+}

--- a/src/test/java/com/starrocks/connector/flink/table/sink/LingeringTransactionAborterTest.java
+++ b/src/test/java/com/starrocks/connector/flink/table/sink/LingeringTransactionAborterTest.java
@@ -1,0 +1,492 @@
+/*
+ * Copyright 2021-present StarRocks, Inc. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.starrocks.connector.flink.table.sink;
+
+import com.starrocks.data.load.stream.StreamLoadManager;
+import com.starrocks.data.load.stream.StreamLoadResponse;
+import com.starrocks.data.load.stream.StreamLoadSnapshot;
+import com.starrocks.data.load.stream.StreamLoader;
+import com.starrocks.data.load.stream.TableRegion;
+import com.starrocks.data.load.stream.TransactionStatus;
+import com.starrocks.data.load.stream.properties.StreamLoadProperties;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.Future;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class LingeringTransactionAborterTest {
+
+    @Test
+    public void testRestoreWithSnapshot() throws Exception {
+        String labelPrefix = "test_label";
+        int numberOfSubtasks = 10;
+        int subtaskIndex = 1;
+        long restoreCheckpointId = 10;
+        Random random = new Random(System.currentTimeMillis());
+
+        List<Tuple2<String, String>> dbTables = new ArrayList<>();
+        List<ExactlyOnceLabelGeneratorSnapshot> snapshots = new ArrayList<>();
+        MockStreamLoader streamLoader = new MockStreamLoader();
+
+        for (int dbId = 0; dbId < 3; dbId++) {
+            for (int tblId = 0; tblId < 5; tblId++) {
+                String dbName = "db" + dbId;
+                String tblName = "tbl" + tblId;
+                dbTables.add(Tuple2.of(dbName, tblName));
+                long nextId = random.nextInt(100) + 1;
+                ExactlyOnceLabelGeneratorSnapshot snapshot = new ExactlyOnceLabelGeneratorSnapshot(
+                        restoreCheckpointId, dbName, tblName, labelPrefix, numberOfSubtasks, subtaskIndex, nextId);
+                snapshots.add(snapshot);
+                boolean hasLingeringTxn = random.nextInt(3) < 2;
+                if (hasLingeringTxn) {
+                    int numTxns = random.nextInt(5) + 1;
+                    for (int i = 0; i < numTxns; i++) {
+                        streamLoader.addLabelStatus(dbName, tblName, ExactlyOnceLabelGenerator.genLabel(
+                                labelPrefix, tblName, subtaskIndex, i + nextId), TransactionStatus.PREPARED);
+                    }
+                }
+            }
+        }
+
+        LingeringTransactionAborter aborter = new LingeringTransactionAborter(labelPrefix,
+                restoreCheckpointId, subtaskIndex, -1, dbTables, snapshots, streamLoader);
+        aborter.execute();
+
+        for (TransactionStatus status : streamLoader.getAllStatus().values()) {
+            assertEquals(TransactionStatus.ABORTED, status);
+        }
+        assertEquals(0, streamLoader.getNumUnknownTxnToAbort());
+    }
+
+    @Test
+    public void testRestoreWithoutSnapshot() throws Exception {
+        String labelPrefix = "test_label";
+        int subtaskIndex = 1;
+        long restoreCheckpointId = 10;
+        Random random = new Random(System.currentTimeMillis());
+
+        List<Tuple2<String, String>> dbTables = new ArrayList<>();
+        List<ExactlyOnceLabelGeneratorSnapshot> snapshots = new ArrayList<>();
+        MockStreamLoader streamLoader = new MockStreamLoader();
+
+        for (int dbId = 0; dbId < 3; dbId++) {
+            for (int tblId = 0; tblId < 5; tblId++) {
+                String dbName = "db" + dbId;
+                String tblName = "tbl" + tblId;
+                dbTables.add(Tuple2.of(dbName, tblName));
+                // nextId should be restoreCheckpointId + 1
+                long nextId = restoreCheckpointId + 1;
+                boolean hasLingeringTxn = random.nextInt(3) < 2;
+                if (hasLingeringTxn) {
+                    int numTxns = random.nextInt(5) + 1;
+                    for (int i = 0; i < numTxns; i++) {
+                        streamLoader.addLabelStatus(dbName, tblName, ExactlyOnceLabelGenerator.genLabel(
+                                labelPrefix, tblName, subtaskIndex, i + nextId), TransactionStatus.PREPARED);
+                    }
+                }
+            }
+        }
+
+        LingeringTransactionAborter aborter = new LingeringTransactionAborter(labelPrefix,
+                restoreCheckpointId, subtaskIndex, -1, dbTables, snapshots, streamLoader);
+        aborter.execute();
+
+        for (TransactionStatus status : streamLoader.getAllStatus().values()) {
+            assertEquals(TransactionStatus.ABORTED, status);
+        }
+        assertEquals(0, streamLoader.getNumUnknownTxnToAbort());
+    }
+
+    @Test
+    public void testRestoreAfterRescaleAndLabelChanged() throws Exception {
+        String oldLabelPrefix = "test_label_old";
+        String labelPrefix = "test_label";
+        int oldNumberOfSubtasks = 10;
+        int subtaskIndex = 1;
+        long restoreCheckpointId = 10;
+        Random random = new Random(System.currentTimeMillis());
+
+        List<Tuple2<String, String>> dbTables = new ArrayList<>();
+        List<ExactlyOnceLabelGeneratorSnapshot> snapshots = new ArrayList<>();
+        MockStreamLoader streamLoader = new MockStreamLoader();
+
+        for (int dbId = 0; dbId < 3; dbId++) {
+            for (int tblId = 0; tblId < 5; tblId++) {
+                String dbName = "db" + dbId;
+                String tblName = "tbl" + tblId;
+                dbTables.add(Tuple2.of(dbName, tblName));
+                // construct snapshots for multiple subtasks
+                for (int oldSubtaskIndex = subtaskIndex; oldSubtaskIndex < 5; oldSubtaskIndex++) {
+                    long nextId = random.nextInt(100) + 1;
+                    ExactlyOnceLabelGeneratorSnapshot snapshot = new ExactlyOnceLabelGeneratorSnapshot(
+                            restoreCheckpointId, dbName, tblName, oldLabelPrefix, oldNumberOfSubtasks, oldSubtaskIndex,
+                            nextId);
+                    snapshots.add(snapshot);
+                    boolean hasLingeringTxn = random.nextInt(3) < 2;
+                    if (hasLingeringTxn) {
+                        int numTxns = random.nextInt(5) + 1;
+                        for (int i = 0; i < numTxns; i++) {
+                            streamLoader.addLabelStatus(dbName, tblName, ExactlyOnceLabelGenerator.genLabel(
+                                    oldLabelPrefix, tblName, oldSubtaskIndex, i + nextId), TransactionStatus.PREPARED);
+                        }
+                    }
+                }
+
+                // lingering transactions for new label prefix
+                long nextId = restoreCheckpointId + 1;
+                boolean hasLingeringTxn = random.nextInt(3) < 2;
+                if (hasLingeringTxn) {
+                    int numTxns = random.nextInt(5) + 1;
+                    for (int i = 0; i < numTxns; i++) {
+                        streamLoader.addLabelStatus(dbName, tblName, ExactlyOnceLabelGenerator.genLabel(
+                                labelPrefix, tblName, subtaskIndex, i + nextId), TransactionStatus.PREPARED);
+                    }
+                }
+            }
+        }
+
+        LingeringTransactionAborter aborter = new LingeringTransactionAborter(labelPrefix,
+                restoreCheckpointId, subtaskIndex, -1, dbTables, snapshots, streamLoader);
+        aborter.execute();
+
+        for (TransactionStatus status : streamLoader.getAllStatus().values()) {
+            assertEquals(TransactionStatus.ABORTED, status);
+        }
+        assertEquals(0, streamLoader.getNumUnknownTxnToAbort());
+    }
+
+    @Test
+    public void testAbortSnapshotFailed() throws Exception {
+        String labelPrefix = "test_label";
+        int numberOfSubtasks = 10;
+        int subtaskIndex = 1;
+        long restoreCheckpointId = 10;
+
+        List<Tuple2<String, String>> dbTables = new ArrayList<>();
+        List<ExactlyOnceLabelGeneratorSnapshot> snapshots = new ArrayList<>();
+        MockStreamLoader streamLoader = new MockStreamLoader();
+
+        dbTables.add(Tuple2.of("db1", "tbl1"));
+        snapshots.add(new ExactlyOnceLabelGeneratorSnapshot(
+                restoreCheckpointId, "db1", "tbl1", labelPrefix, numberOfSubtasks, subtaskIndex, 2));
+        String label1 = ExactlyOnceLabelGenerator.genLabel(labelPrefix, "tbl1", subtaskIndex, 2);
+        streamLoader.addLabelStatus("db1", "tbl1", label1, TransactionStatus.PREPARED, false);
+
+        dbTables.add(Tuple2.of("db1", "tbl2"));
+        snapshots.add(new ExactlyOnceLabelGeneratorSnapshot(
+                restoreCheckpointId, "db1", "tbl2", labelPrefix, numberOfSubtasks, subtaskIndex, 2));
+        String label2 = ExactlyOnceLabelGenerator.genLabel(labelPrefix, "tbl2", subtaskIndex, 2);
+        streamLoader.addLabelStatus("db1", "tbl2", label2, TransactionStatus.PREPARED, true);
+
+        dbTables.add(Tuple2.of("db1", "tbl3"));
+        snapshots.add(new ExactlyOnceLabelGeneratorSnapshot(
+                restoreCheckpointId, "db1", "tbl3", labelPrefix, numberOfSubtasks, subtaskIndex, 2));
+        String label3 = ExactlyOnceLabelGenerator.genLabel(labelPrefix, "tbl3", subtaskIndex, 2);
+        streamLoader.addLabelStatus("db1", "tbl3", label3, TransactionStatus.PREPARED, false);
+
+        LingeringTransactionAborter aborter = new LingeringTransactionAborter(labelPrefix,
+                restoreCheckpointId, subtaskIndex, -1, dbTables, snapshots, streamLoader);
+        try {
+            aborter.execute();
+            fail();
+        } catch (Exception e) {
+            assertEquals("artificial exception", e.getCause().getCause().getMessage());
+        }
+
+        assertEquals(TransactionStatus.ABORTED, streamLoader.getLoadStatus("db1", "tbl1", label1));
+        assertEquals(TransactionStatus.PREPARED, streamLoader.getLoadStatus("db1", "tbl2", label2));
+        assertEquals(TransactionStatus.PREPARED, streamLoader.getLoadStatus("db1", "tbl3", label3));
+    }
+
+    @Test
+    public void testAbortNewLabelPrefixFailed() throws Exception {
+        String labelPrefix = "test_label";
+        int subtaskIndex = 1;
+        long restoreCheckpointId = 10;
+
+        List<Tuple2<String, String>> dbTables = new ArrayList<>();
+        List<ExactlyOnceLabelGeneratorSnapshot> snapshots = new ArrayList<>();
+        MockStreamLoader streamLoader = new MockStreamLoader();
+
+        dbTables.add(Tuple2.of("db1", "tbl1"));
+        String label1 = ExactlyOnceLabelGenerator.genLabel(labelPrefix, "tbl1", subtaskIndex,
+                restoreCheckpointId + 1);
+        streamLoader.addLabelStatus("db1", "tbl1", label1, TransactionStatus.PREPARED, false);
+
+        dbTables.add(Tuple2.of("db1", "tbl2"));
+        String label2 = ExactlyOnceLabelGenerator.genLabel(labelPrefix, "tbl2", subtaskIndex,
+                restoreCheckpointId + 1);
+        streamLoader.addLabelStatus("db1", "tbl2", label2, TransactionStatus.PREPARED, true);
+
+        dbTables.add(Tuple2.of("db1", "tbl3"));
+        String label3 = ExactlyOnceLabelGenerator.genLabel(labelPrefix, "tbl3", subtaskIndex,
+                restoreCheckpointId + 1);
+        streamLoader.addLabelStatus("db1", "tbl3", label3, TransactionStatus.PREPARED, false);
+
+        LingeringTransactionAborter aborter = new LingeringTransactionAborter(labelPrefix,
+                restoreCheckpointId, subtaskIndex, -1, dbTables, snapshots, streamLoader);
+        try {
+            aborter.execute();
+            fail();
+        } catch (Exception e) {
+            assertEquals("artificial exception", e.getCause().getCause().getMessage());
+        }
+
+        assertEquals(TransactionStatus.ABORTED, streamLoader.getLoadStatus("db1", "tbl1", label1));
+        assertEquals(TransactionStatus.PREPARED, streamLoader.getLoadStatus("db1", "tbl2", label2));
+        assertEquals(TransactionStatus.PREPARED, streamLoader.getLoadStatus("db1", "tbl3", label3));
+    }
+
+    @Test
+    public void testConcurrentAbort() throws Exception {
+        String labelPrefix = "test_label";
+        int subtaskIndex = 1;
+        long restoreCheckpointId = 10;
+
+        List<Tuple2<String, String>> dbTables = new ArrayList<>();
+        List<ExactlyOnceLabelGeneratorSnapshot> snapshots = new ArrayList<>();
+        MockStreamLoader streamLoader = new MockStreamLoader();
+
+        dbTables.add(Tuple2.of("db1", "tbl1"));
+        String label1 = ExactlyOnceLabelGenerator.genLabel(labelPrefix, "tbl1", subtaskIndex,
+                restoreCheckpointId + 1);
+        // simulate concurrent operation which maybe happen if two jobs are aborting concurrently,
+        // because the old job is not canceled completely
+        streamLoader.addLabelStatus("db1", "tbl1", label1, TransactionStatus.PREPARED,
+                Collections.singletonList(TransactionStatus.ABORTED));
+
+        LingeringTransactionAborter aborter = new LingeringTransactionAborter(labelPrefix,
+                restoreCheckpointId, subtaskIndex, -1, dbTables, snapshots, streamLoader);
+        aborter.execute();
+        for (TransactionStatus status : streamLoader.getAllStatus().values()) {
+            assertEquals(TransactionStatus.ABORTED, status);
+        }
+        assertEquals(0, streamLoader.getNumUnknownTxnToAbort());
+    }
+
+    @Test
+    public void testCheckNumber() throws Exception {
+        String oldLabelPrefix = "test_label_old";
+        String labelPrefix = "test_label";
+        int numberOfSubtasks = 10;
+        int subtaskIndex = 1;
+        long restoreCheckpointId = 10;
+
+        List<Tuple2<String, String>> dbTables = new ArrayList<>();
+        List<ExactlyOnceLabelGeneratorSnapshot> snapshots = new ArrayList<>();
+        MockStreamLoader streamLoader = new MockStreamLoader();
+
+        dbTables.add(Tuple2.of("db1", "tbl1"));
+        ExactlyOnceLabelGeneratorSnapshot snapshot = new ExactlyOnceLabelGeneratorSnapshot(
+                restoreCheckpointId, "db1", "tbl1", oldLabelPrefix, numberOfSubtasks, 1, 2);
+        snapshots.add(snapshot);
+        // discontinuous labels for snapshot
+        streamLoader.addLabelStatus("db1", "tbl1", ExactlyOnceLabelGenerator.genLabel(
+                oldLabelPrefix, "tbl1", subtaskIndex, 2), TransactionStatus.PREPARED);
+        streamLoader.addLabelStatus("db1", "tbl1", ExactlyOnceLabelGenerator.genLabel(
+                oldLabelPrefix, "tbl1", subtaskIndex, 4), TransactionStatus.PREPARED);
+
+        // discontinuous labels for new label prefix
+        streamLoader.addLabelStatus("db1", "tbl1", ExactlyOnceLabelGenerator.genLabel(
+                labelPrefix, "tbl1", subtaskIndex, restoreCheckpointId + 1), TransactionStatus.PREPARED);
+        streamLoader.addLabelStatus("db1", "tbl1", ExactlyOnceLabelGenerator.genLabel(
+                labelPrefix, "tbl1", subtaskIndex, restoreCheckpointId + 3), TransactionStatus.PREPARED);
+
+        LingeringTransactionAborter aborter = new LingeringTransactionAborter(labelPrefix,
+                restoreCheckpointId, subtaskIndex, 4, dbTables, snapshots, streamLoader);
+        aborter.execute();
+
+        for (TransactionStatus status : streamLoader.getAllStatus().values()) {
+            assertEquals(TransactionStatus.ABORTED, status);
+        }
+        assertEquals(0, streamLoader.getNumUnknownTxnToAbort());
+    }
+
+    @Test
+    public void testAbortFinishTransaction() throws Exception {
+        String labelPrefix = "test_label";
+        int subtaskIndex = 1;
+        long restoreCheckpointId = 10;
+
+        List<Tuple2<String, String>> dbTables = new ArrayList<>();
+        List<ExactlyOnceLabelGeneratorSnapshot> snapshots = new ArrayList<>();
+        MockStreamLoader streamLoader = new MockStreamLoader();
+
+        dbTables.add(Tuple2.of("db1", "tbl1"));
+        String label1 = ExactlyOnceLabelGenerator.genLabel(labelPrefix, "tbl1", subtaskIndex,
+                restoreCheckpointId + 1);
+        // simulate restore from an earlier checkpoint, and the transaction already finished
+        streamLoader.addLabelStatus("db1", "tbl1", label1, TransactionStatus.VISIBLE);
+
+        LingeringTransactionAborter aborter = new LingeringTransactionAborter(labelPrefix,
+                restoreCheckpointId, subtaskIndex, -1, dbTables, snapshots, streamLoader);
+        try {
+            aborter.execute();
+            fail();
+        } catch (Exception e) {
+            // ignore
+        }
+    }
+
+    private static class MockStreamLoader implements StreamLoader {
+
+        // mapping from tuple<db, table, label> to transaction status
+        private final Map<Tuple3<String, String, String>, TransactionStatus> labelStatus;
+
+        // status to transit after getLoadStatus is called
+        private final Map<Tuple3<String, String, String>, List<TransactionStatus>> transitStatusMap;
+
+        // The behaviour to abort the transaction. Whether throw exception.
+        private final Map<Tuple3<String, String, String>, Boolean> labelAbortBehaviours;
+
+        private int numUnknownTxnToAbort = 0;
+
+        public MockStreamLoader() {
+            this.labelStatus = new HashMap<>();
+            this.transitStatusMap = new HashMap<>();
+            this.labelAbortBehaviours = new HashMap<>();
+        }
+
+        public Map<Tuple3<String, String, String>, TransactionStatus> getAllStatus() {
+            return labelStatus;
+        }
+
+        public void addLabelStatus(String db, String table, String label, TransactionStatus initStatus) {
+            addLabelStatus(db, table, label, initStatus, Collections.emptyList());
+        }
+
+        public void addLabelStatus(String db, String table, String label,
+                               TransactionStatus initStatus, List<TransactionStatus> transitStatus) {
+            Tuple3<String, String, String> tuple = Tuple3.of(db, table, label);
+            labelStatus.put(tuple, initStatus);
+            transitStatusMap.put(tuple, (transitStatus == null ? Collections.emptyList() : new ArrayList<>(transitStatus)));
+        }
+
+        public void addLabelStatus(String db, String table, String label, TransactionStatus initStatus, boolean aborFail) {
+            addLabelStatus(db, table, label, initStatus, Collections.emptyList());
+            labelAbortBehaviours.put(Tuple3.of(db, table, label), aborFail);
+        }
+
+        @Override
+        public TransactionStatus getLoadStatus(String db, String table, String label) throws Exception {
+            Tuple3<String, String, String> tuple = Tuple3.of(db, table, label);
+            TransactionStatus status = labelStatus.get(tuple);
+            List<TransactionStatus> list = transitStatusMap.get(tuple);
+            if (list != null && !list.isEmpty()) {
+                labelStatus.put(tuple, list.get(0));
+                list.remove(0);
+            }
+            return status == null ? TransactionStatus.UNKNOWN : status;
+        }
+
+        @Override
+        public boolean rollback(StreamLoadSnapshot.Transaction transaction) {
+            Tuple3<String, String, String> tuple = Tuple3.of(
+                    transaction.getDatabase(), transaction.getTable(), transaction.getLabel());
+            Boolean fail = labelAbortBehaviours.get(tuple);
+            if (fail != null && fail) {
+                throw new RuntimeException("artificial exception");
+            }
+
+            TransactionStatus status = labelStatus.get(tuple);
+            // same behaviour as StarRocks DatabaseTransactionMgr#abortTransaction
+            if (status == null) {
+                numUnknownTxnToAbort += 1;
+                throw new RuntimeException("Transaction not found");
+            }
+
+            if (status == TransactionStatus.COMMITTED || status == TransactionStatus.VISIBLE) {
+                throw new RuntimeException("Transaction already committed");
+            }
+
+            if (status == TransactionStatus.PREPARE || status == TransactionStatus.PREPARED) {
+                labelStatus.put(tuple, TransactionStatus.ABORTED);
+                return true;
+            }
+
+            throw new RuntimeException("Unknown transaction state");
+        }
+
+        public int getNumUnknownTxnToAbort() {
+            return numUnknownTxnToAbort;
+        }
+
+        @Override
+        public void start(StreamLoadProperties properties, StreamLoadManager manager) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void close() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean begin(TableRegion region) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Future<StreamLoadResponse> send(TableRegion region) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Future<StreamLoadResponse> send(TableRegion region, int delayMs) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean prepare(StreamLoadSnapshot.Transaction transaction) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean commit(StreamLoadSnapshot.Transaction transaction) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean prepare(StreamLoadSnapshot snapshot) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean commit(StreamLoadSnapshot snapshot) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean rollback(StreamLoadSnapshot snapshot) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/src/test/java/com/starrocks/connector/flink/table/sink/StarrocksSnapshotStateTest.java
+++ b/src/test/java/com/starrocks/connector/flink/table/sink/StarrocksSnapshotStateTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2021-present StarRocks, Inc. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.starrocks.connector.flink.table.sink;
+
+import com.starrocks.connector.flink.tools.JsonWrapper;
+import com.starrocks.data.load.stream.StreamLoadSnapshot;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class StarrocksSnapshotStateTest {
+
+    @Test
+    public void testSerDataAndLabelSnapshots() throws Exception {
+        testSerDerBase(buildDataSnapshot(), buildLabelGeneratorSnapshots());
+    }
+
+    @Test
+    public void testSerNullLabelSnapshots() throws Exception {
+        testSerDerBase(buildDataSnapshot(), null);
+    }
+
+    private void testSerDerBase(Map<Long, List<StreamLoadSnapshot>> data, List<ExactlyOnceLabelGeneratorSnapshot> labelSnapshots) throws Exception {
+        StarRocksVersionedSerializer serializer = new StarRocksVersionedSerializer(new JsonWrapper());
+        StarrocksSnapshotState state = StarrocksSnapshotState.of(data, labelSnapshots);
+        byte[] serData = serializer.serialize(state);
+        StarrocksSnapshotState restoreState = serializer.deserialize(serializer.getVersion(), serData);
+        verifyState(state, restoreState);
+    }
+
+    private void verifyState(StarrocksSnapshotState expectState, StarrocksSnapshotState actualState) {
+        assertEquals(expectState.getVersion(), actualState.getVersion());
+        verifyData(expectState.getData(), actualState.getData());
+        verifyLabelSnapshots(expectState.getLabelSnapshots(), actualState.getLabelSnapshots());
+    }
+
+    private void verifyData(Map<Long, List<StreamLoadSnapshot>> expect, Map<Long, List<StreamLoadSnapshot>> actual) {
+        if (expect == null || actual == null) {
+            assertNull(expect);
+            assertNull(actual);
+            return;
+        }
+
+        assertEquals(expect.size(), actual.size());
+        for (Map.Entry<Long, List<StreamLoadSnapshot>> entry : expect.entrySet()) {
+            List<StreamLoadSnapshot> actualList = actual.get(entry.getKey());
+            assertNotNull(actualList);
+            assertEquals(entry.getValue().size(), actualList.size());
+            for (int i = 0; i < actualList.size(); i++) {
+                verifyStreamLoadSnapshot(entry.getValue().get(i), actualList.get(i));
+            }
+        }
+    }
+
+    private void verifyStreamLoadSnapshot(StreamLoadSnapshot expect, StreamLoadSnapshot actual) {
+        assertEquals(expect.getId(), actual.getId());
+        assertEquals(expect.getTimestamp(), actual.getTimestamp());
+        assertEquals(expect.getTransactions().size(), actual.getTransactions().size());
+        for (int i = 0; i < expect.getTransactions().size(); i++) {
+            StreamLoadSnapshot.Transaction expectTxn = expect.getTransactions().get(i);
+            StreamLoadSnapshot.Transaction actualTxn = actual.getTransactions().get(i);
+            assertEquals(expectTxn.getDatabase(), actualTxn.getDatabase());
+            assertEquals(expectTxn.getTable(), actualTxn.getTable());
+            assertEquals(expectTxn.getLabel(), actualTxn.getLabel());
+            assertEquals(expectTxn.isFinish(), actualTxn.isFinish());
+        }
+    }
+
+    private void verifyLabelSnapshots(List<ExactlyOnceLabelGeneratorSnapshot> expect, List<ExactlyOnceLabelGeneratorSnapshot> actual) {
+        if (expect == null || actual == null) {
+            assertNull(expect);
+            assertNull(actual);
+            return;
+        }
+
+        assertEquals(expect.size(), actual.size());
+        for (int i = 0; i < expect.size(); i++) {
+            assertEquals(expect.get(i), actual.get(i));
+        }
+    }
+
+    public Map<Long, List<StreamLoadSnapshot>> buildDataSnapshot() {
+        Random random = new Random(System.currentTimeMillis());
+        Map<Long, List<StreamLoadSnapshot>> data = new HashMap<>();
+        for (long i = 0; i < 10; i++) {
+            int num = random.nextInt(2);
+            List<StreamLoadSnapshot> snapshots = new ArrayList<>();
+            for (int j = 0; j < num; j++) {
+                snapshots.add(buildStreamLoadSnapshot(random));
+            }
+            data.put(i, snapshots);
+        }
+        return data;
+    }
+
+    private StreamLoadSnapshot buildStreamLoadSnapshot(Random random) {
+        StreamLoadSnapshot snapshot = new StreamLoadSnapshot();
+        snapshot.setId(UUID.randomUUID().toString());
+        List<StreamLoadSnapshot.Transaction> txns = new ArrayList<>();
+        for (int i = 0; i < random.nextInt(5) + 1; i++) {
+            txns.add(buildTransaction(random));
+        }
+        snapshot.setTransactions(txns);
+        snapshot.setTimestamp(System.currentTimeMillis());
+        return snapshot;
+    }
+
+    private StreamLoadSnapshot.Transaction buildTransaction(Random random) {
+        return new StreamLoadSnapshot.Transaction(
+                Integer.toString(random.nextInt()),
+                Integer.toString(random.nextInt()),
+                Integer.toString(random.nextInt()));
+    }
+
+    private List<ExactlyOnceLabelGeneratorSnapshot> buildLabelGeneratorSnapshots() {
+        Random random = new Random(System.currentTimeMillis());
+        List<ExactlyOnceLabelGeneratorSnapshot> list = new ArrayList<>();
+        int num = random.nextInt(10);
+        for (int i = 0; i < 10; i++) {
+            list.add(buildLabelSnapshot(random));
+        }
+        return list;
+    }
+
+    private ExactlyOnceLabelGeneratorSnapshot buildLabelSnapshot(Random random) {
+        return new ExactlyOnceLabelGeneratorSnapshot(
+                random.nextInt(1000),
+                Integer.toString(random.nextInt()),
+                Integer.toString(random.nextInt()),
+                Integer.toString(random.nextInt()),
+                random.nextInt(100),
+                random.nextInt(100),
+                random.nextInt(10000));
+    }
+}

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/BatchTableRegion.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/BatchTableRegion.java
@@ -22,7 +22,6 @@ package com.starrocks.data.load.stream;
 
 import com.starrocks.data.load.stream.http.StreamLoadEntityMeta;
 import com.starrocks.data.load.stream.properties.StreamLoadTableProperties;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,7 +43,7 @@ public class BatchTableRegion implements TableRegion {
 
     private final StreamLoadManager manager;
     private final StreamLoader streamLoader;
-
+    private final LabelGenerator labelGenerator;
     private final String uniqueKey;
     private final String database;
     private final String table;
@@ -74,7 +73,8 @@ public class BatchTableRegion implements TableRegion {
                             String table,
                             StreamLoadManager manager,
                             StreamLoadTableProperties properties,
-                            StreamLoader streamLoader) {
+                            StreamLoader streamLoader,
+                            LabelGenerator labelGenerator) {
         this.uniqueKey = uniqueKey;
         this.database = database;
         this.table = table;
@@ -82,6 +82,7 @@ public class BatchTableRegion implements TableRegion {
         this.properties = properties;
         this.dataFormat = properties.getDataFormat();
         this.streamLoader = streamLoader;
+        this.labelGenerator = labelGenerator;
         this.state = new AtomicReference<>(State.ACTIVE);
     }
 
@@ -103,6 +104,11 @@ public class BatchTableRegion implements TableRegion {
     @Override
     public String getTable() {
         return table;
+    }
+
+    @Override
+    public LabelGenerator getLabelGenerator() {
+        return labelGenerator;
     }
 
     @Override

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/DefaultStreamLoader.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/DefaultStreamLoader.java
@@ -46,6 +46,7 @@ import org.slf4j.LoggerFactory;
 import java.io.Serializable;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -416,6 +417,13 @@ public class DefaultStreamLoader implements StreamLoader, Serializable {
             log.error("{}", errorMsg, e);
             throw new StreamLoadFailException(errorMsg, e);
         }
+    }
+
+    @Override
+    public TransactionStatus getLoadStatus(String db, String table, String label) throws Exception {
+        String host = getAvailableHost();
+        String state = getLabelState(host, db, table, label, Collections.emptySet());
+        return TransactionStatus.valueOf(state.toUpperCase());
     }
 
     protected String getLabelState(String host, String database, String table, String label, Set<String> retryStates) throws Exception {

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/DefaultStreamLoader.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/DefaultStreamLoader.java
@@ -140,7 +140,7 @@ public class DefaultStreamLoader implements StreamLoader, Serializable {
 
     @Override
     public boolean begin(TableRegion region) {
-        region.setLabel(genLabel(region));
+        region.setLabel(region.getLabelGenerator().next());
         return true;
     }
 
@@ -501,12 +501,5 @@ public class DefaultStreamLoader implements StreamLoader, Serializable {
             throw new IllegalArgumentException("None of the hosts in `load_url` could be connected.");
         }
         return host + "/api/" + database + "/" + table + "/_stream_load";
-    }
-
-    protected String genLabel(TableRegion region) {
-        if (properties.getLabelPrefix() != null) {
-            return properties.getLabelPrefix() + UUID.randomUUID();
-        }
-        return UUID.randomUUID().toString();
     }
 }

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/LabelGenerator.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/LabelGenerator.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021-present StarRocks, Inc. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.starrocks.data.load.stream;
+
+import java.util.UUID;
+
+/** Generate labels. */
+public interface LabelGenerator {
+
+    String next();
+
+    class DefaultLabelGenerator implements LabelGenerator {
+
+        private final String labelPrefix;
+
+        public DefaultLabelGenerator(String labelPrefix) {
+            this.labelPrefix = labelPrefix;
+        }
+
+        @Override
+        public String next() {
+            return labelPrefix + "-" + UUID.randomUUID();
+        }
+    }
+}

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/LabelGeneratorFactory.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/LabelGeneratorFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021-present StarRocks, Inc. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.starrocks.data.load.stream;
+
+/** Factory for {@link LabelGenerator}. */
+public interface LabelGeneratorFactory {
+
+    // Create a label generator for the specified db and table.
+    LabelGenerator create(String db, String table);
+
+    class DefaultLabelGeneratorFactory implements LabelGeneratorFactory {
+
+        private final String labelPrefix;
+
+        public DefaultLabelGeneratorFactory(String labelPrefix) {
+            this.labelPrefix = labelPrefix == null ? "flink_" : labelPrefix;
+        }
+
+        @Override
+        public LabelGenerator create(String db, String table) {
+            return new LabelGenerator.DefaultLabelGenerator(labelPrefix);
+        }
+    }
+}

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/StreamLoadConstants.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/StreamLoadConstants.java
@@ -42,13 +42,6 @@ public interface StreamLoadConstants {
 
     String EXISTING_JOB_STATUS_FINISHED = "FINISHED";
 
-    String LABEL_STATE_VISIBLE = "VISIBLE";
-    String LABEL_STATE_COMMITTED = "COMMITTED";
-    String LABEL_STATE_PREPARED = "PREPARED";
-    String LABEL_STATE_PREPARE = "PREPARE";
-    String LABEL_STATE_ABORTED = "ABORTED";
-    String LABEL_STATE_UNKNOWN = "UNKNOWN";
-
     public static String getBeginUrl(String host) {
         if (host == null) {
             throw new IllegalArgumentException("None of the hosts in `load_url` could be connected.");

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/StreamTableRegion.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/StreamTableRegion.java
@@ -22,7 +22,6 @@ package com.starrocks.data.load.stream;
 
 import com.starrocks.data.load.stream.http.StreamLoadEntityMeta;
 import com.starrocks.data.load.stream.properties.StreamLoadTableProperties;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,7 +45,7 @@ public class StreamTableRegion implements TableRegion, Serializable {
     private static final byte[] END_STREAM = new byte[0];
 
     private final StreamLoader streamLoader;
-
+    private final LabelGenerator labelGenerator;
     private final String uniqueKey;
     private final String database;
     private final String table;
@@ -74,7 +73,8 @@ public class StreamTableRegion implements TableRegion, Serializable {
                              String table,
                              StreamLoadManager manager,
                              StreamLoadTableProperties properties,
-                             StreamLoader streamLoader) {
+                             StreamLoader streamLoader,
+                             LabelGenerator labelGenerator) {
         this.uniqueKey = uniqueKey;
         this.database = database;
         this.table = table;
@@ -83,6 +83,7 @@ public class StreamTableRegion implements TableRegion, Serializable {
         this.dataFormat = properties.getDataFormat();
         this.chunkLimit = properties.getChunkLimit();
         this.streamLoader = streamLoader;
+        this.labelGenerator = labelGenerator;
         this.state = new AtomicReference<>(State.ACTIVE);
     }
 
@@ -104,6 +105,11 @@ public class StreamTableRegion implements TableRegion, Serializable {
     @Override
     public String getTable() {
         return table;
+    }
+
+    @Override
+    public LabelGenerator getLabelGenerator() {
+        return labelGenerator;
     }
 
     @Override

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/TableRegion.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/TableRegion.java
@@ -33,7 +33,7 @@ public interface TableRegion {
     String getUniqueKey();
     String getDatabase();
     String getTable();
-
+    LabelGenerator getLabelGenerator();
     void setLabel(String label);
     String getLabel();
 

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/TransactionStatus.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/TransactionStatus.java
@@ -20,27 +20,15 @@
 
 package com.starrocks.data.load.stream;
 
-import com.starrocks.data.load.stream.properties.StreamLoadProperties;
+public enum TransactionStatus {
+    UNKNOWN,
+    PREPARE,
+    COMMITTED,
+    VISIBLE,
+    ABORTED,
+    PREPARED;
 
-import java.util.concurrent.Future;
-
-public interface StreamLoader {
-
-    void start(StreamLoadProperties properties, StreamLoadManager manager);
-    void close();
-
-    boolean begin(TableRegion region);
-    Future<StreamLoadResponse> send(TableRegion region);
-
-    Future<StreamLoadResponse> send(TableRegion region, int delayMs);
-
-    TransactionStatus getLoadStatus(String db, String table, String label) throws Exception;
-
-    boolean prepare(StreamLoadSnapshot.Transaction transaction);
-    boolean commit(StreamLoadSnapshot.Transaction transaction);
-    boolean rollback(StreamLoadSnapshot.Transaction transaction);
-
-    boolean prepare(StreamLoadSnapshot snapshot);
-    boolean commit(StreamLoadSnapshot snapshot);
-    boolean rollback(StreamLoadSnapshot snapshot);
+    public boolean isSame(String status) {
+        return name().equalsIgnoreCase(status);
+    }
 }

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/TransactionStreamLoader.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/TransactionStreamLoader.java
@@ -96,7 +96,7 @@ public class TransactionStreamLoader extends DefaultStreamLoader {
     public boolean begin(TableRegion region) {
         if (region.getLabel() == null) {
             for (int i = 0; i < 5; i++) {
-                region.setLabel(genLabel(region));
+                region.setLabel(region.getLabelGenerator().next());
                 if (doBegin(region)) {
                     return true;
                 } else {

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/StreamLoadManagerV2.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/StreamLoadManagerV2.java
@@ -386,6 +386,10 @@ public class StreamLoadManagerV2 implements StreamLoadManager, Serializable {
         return snapshot;
     }
 
+    public StreamLoader getStreamLoader() {
+        return streamLoader;
+    }
+
     @Override
     public boolean prepare(StreamLoadSnapshot snapshot) {
         return streamLoader.prepare(snapshot);

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/StreamLoadManagerV2.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/StreamLoadManagerV2.java
@@ -20,6 +20,8 @@ package com.starrocks.data.load.stream.v2;
 
 import com.starrocks.data.load.stream.DefaultStreamLoader;
 import com.starrocks.data.load.stream.EnvUtils;
+import com.starrocks.data.load.stream.LabelGenerator;
+import com.starrocks.data.load.stream.LabelGeneratorFactory;
 import com.starrocks.data.load.stream.LoadMetrics;
 import com.starrocks.data.load.stream.StreamLoadManager;
 import com.starrocks.data.load.stream.StreamLoadResponse;
@@ -116,6 +118,8 @@ public class StreamLoadManagerV2 implements StreamLoadManager, Serializable {
     private transient AtomicBoolean writeTriggerFlush;
     private transient LoadMetrics loadMetrics;
     private transient StreamLoadListener streamLoadListener;
+    private transient LabelGeneratorFactory labelGeneratorFactory;
+
     public StreamLoadManagerV2(StreamLoadProperties properties, boolean enableAutoCommit) {
         this.properties = properties;
         if (!enableAutoCommit && !properties.isEnableTransaction()) {
@@ -141,6 +145,10 @@ public class StreamLoadManagerV2 implements StreamLoadManager, Serializable {
 
     @Override
     public void init() {
+        if (labelGeneratorFactory == null) {
+            this.labelGeneratorFactory =
+                    new LabelGeneratorFactory.DefaultLabelGeneratorFactory(properties.getLabelPrefix());
+        }
         this.writeTriggerFlush = new AtomicBoolean(false);
         this.loadMetrics = new LoadMetrics();
         if (state.compareAndSet(State.INACTIVE, State.ACTIVE)) {
@@ -231,6 +239,10 @@ public class StreamLoadManagerV2 implements StreamLoadManager, Serializable {
 
     public void setStreamLoadListener(StreamLoadListener streamLoadListener) {
         this.streamLoadListener = streamLoadListener;
+    }
+
+    public void setLabelGeneratorFactory(LabelGeneratorFactory labelGeneratorFactory) {
+        this.labelGeneratorFactory = labelGeneratorFactory;
     }
 
     @Override
@@ -425,8 +437,9 @@ public class StreamLoadManagerV2 implements StreamLoadManager, Serializable {
                 region = regions.get(uniqueKey);
                 if (region == null) {
                     StreamLoadTableProperties tableProperties = properties.getTableProperties(uniqueKey);
+                    LabelGenerator labelGenerator = labelGeneratorFactory.create(database, table);
                     region = new TransactionTableRegion(uniqueKey, database, table, this,
-                            tableProperties, streamLoader, maxRetries, retryIntervalInMs);
+                            tableProperties, streamLoader, labelGenerator, maxRetries, retryIntervalInMs);
                     regions.put(uniqueKey, region);
                     flushQ.offer((TransactionTableRegion) region);
                 }

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/TransactionTableRegion.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/TransactionTableRegion.java
@@ -19,6 +19,7 @@
 package com.starrocks.data.load.stream.v2;
 
 import com.starrocks.data.load.stream.Chunk;
+import com.starrocks.data.load.stream.LabelGenerator;
 import com.starrocks.data.load.stream.StreamLoadManager;
 import com.starrocks.data.load.stream.StreamLoader;
 import com.starrocks.data.load.stream.StreamLoadResponse;
@@ -49,6 +50,7 @@ public class TransactionTableRegion implements TableRegion {
 
     private final StreamLoadManager manager;
     private final StreamLoader streamLoader;
+    private final LabelGenerator labelGenerator;
     private final String uniqueKey;
     private final String database;
     private final String table;
@@ -74,6 +76,7 @@ public class TransactionTableRegion implements TableRegion {
                             StreamLoadManager manager,
                             StreamLoadTableProperties properties,
                             StreamLoader streamLoader,
+                            LabelGenerator labelGenerator,
                             int maxRetries,
                             int retryIntervalInMs) {
         this.uniqueKey = uniqueKey;
@@ -82,6 +85,7 @@ public class TransactionTableRegion implements TableRegion {
         this.manager = manager;
         this.properties = properties;
         this.streamLoader = streamLoader;
+        this.labelGenerator = labelGenerator;
         this.state = new AtomicReference<>(State.ACTIVE);
         this.lastCommitTimeMills = System.currentTimeMillis();
         this.activeChunk = new Chunk(properties.getDataFormat());
@@ -107,6 +111,11 @@ public class TransactionTableRegion implements TableRegion {
     @Override
     public String getTable() {
         return table;
+    }
+
+    @Override
+    public LabelGenerator getLabelGenerator() {
+        return labelGenerator;
     }
 
     @Override


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

### What's the problem
When using exactly-once,  the connector will not abort the `PREPARED` transactions when the flink job failovers or exits because it's 2PC mechanism. Some of those PREPARED transactions may be in a successful checkpoint, and will be committed when the job restores from the checkpoint, but some of them are just useless, and should be aborted, otherwise they will be lingering in StarRocks until timeout which maybe make StarRocks unstable. We should try to abort those lingering transactions when restoring

### How to solve it
When flink job restores, the connector will try to find those lingering transactions, and abort them. The key is how to find those transactions because the labels of them are not stored in the checkpoint. Here we design a label generator (ExactlyOnceLabelGenerator) to solve it
1. the user must set option `sink.label-prefix` which is used as the prefix of the labels, and it must be unique across all the ingestions, including flink connector, broker load and routine load, running on the same StarRocks cluster 
2. the connector will generate label in the format `{labelPrefix}-{tableName}-{subtaskIndex}-{id}`. 
    * the `subtaskIndex` will make the label unique across subtasks if the sink writes parallel
    * `id` is incremental, and  it will make the label unique across different transactions in a subtask
3.  when checkpointing, current id will be stored as the state in the checkpoint, and the labels whose ids are less than the current id must be successful, and only those labels whose ids are equal or larger than the current id can be lingering
4. when restoring, read the current id from the checkpoint, construct the label with the id, and get label status from StarRocks. The transaction is lingering if it's in `PREPARED` state, and should abort it

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

