### PR TITLE
[BugFix] Fix SDK write failure for non-default tables

### DIFF
--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/DefaultStreamLoader.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/DefaultStreamLoader.java
@@ -292,7 +292,11 @@ public class DefaultStreamLoader implements StreamLoader, Serializable {
 
             for (Map.Entry<String, String> entry : tableProperties.getProperties().entrySet()) {
                 httpPut.removeHeaders(entry.getKey());
-                httpPut.addHeader(entry.getKey(), entry.getValue());
+                if (entry.getKey().equals("table")) {
+                    httpPut.addHeader(entry.getKey(), region.getTable());
+                } else {
+                    httpPut.addHeader(entry.getKey(), entry.getValue());
+                }
             }
 
             httpPut.addHeader("label", label);


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
For the Stream Load SDK, if the table to be written to is a non-default table, the DefaultStreamLoader.send method still requests SR to write data to the default table, causing the stream load job to fail. This PR fixes this issue.
![image](https://github.com/StarRocks/starrocks-connector-for-apache-flink/assets/45813655/8298636d-c380-469d-b58a-c30afcd69804)

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

