### PR TITLE
[BugFix] Fix SDK write failure for non-default tables

### DIFF
--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/DefaultStreamLoadManager.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/DefaultStreamLoadManager.java
@@ -414,7 +414,7 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
             synchronized (regions) {
                 region = regions.get(uniqueKey);
                 if (region == null) {
-                    StreamLoadTableProperties tableProperties = properties.getTableProperties(uniqueKey);
+                    StreamLoadTableProperties tableProperties = properties.getTableProperties(uniqueKey, database, table);
                     LabelGenerator labelGenerator = labelGeneratorFactory.create(database, table);
                     region = new BatchTableRegion(uniqueKey, database, table, this, tableProperties,
                             streamLoader, labelGenerator);

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/properties/StreamLoadProperties.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/properties/StreamLoadProperties.java
@@ -22,7 +22,6 @@ package com.starrocks.data.load.stream.properties;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.starrocks.data.load.stream.StarRocksVersion;
-import com.starrocks.data.load.stream.StreamLoadUtils;
 
 import java.io.Serializable;
 import java.util.Arrays;
@@ -166,16 +165,8 @@ public class StreamLoadProperties implements Serializable {
         return defaultTableProperties;
     }
 
-    public StreamLoadTableProperties getTableProperties(String database, String table) {
-        return getTableProperties(StreamLoadUtils.getTableUniqueKey(database, table));
-    }
-
-    public StreamLoadTableProperties getTableProperties(String uniqueKey) {
-        return tablePropertiesMap.getOrDefault(uniqueKey, defaultTableProperties);
-    }
-
     public StreamLoadTableProperties getTableProperties(String uniqueKey, String database, String table) {
-        StreamLoadTableProperties tableProperties = getTableProperties(uniqueKey);
+        StreamLoadTableProperties tableProperties = tablePropertiesMap.getOrDefault(uniqueKey, defaultTableProperties);
         if (!tableProperties.getDatabase().equals(database) || !tableProperties.getDatabase().equals(table)) {
             StreamLoadTableProperties.Builder tablePropertiesBuilder = StreamLoadTableProperties.builder();
             tablePropertiesBuilder = tablePropertiesBuilder.copyFrom(tableProperties).database(database).table(table);

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/properties/StreamLoadProperties.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/properties/StreamLoadProperties.java
@@ -174,6 +174,17 @@ public class StreamLoadProperties implements Serializable {
         return tablePropertiesMap.getOrDefault(uniqueKey, defaultTableProperties);
     }
 
+    public StreamLoadTableProperties getTableProperties(String uniqueKey, String database, String table) {
+        StreamLoadTableProperties tableProperties = getTableProperties(uniqueKey);
+        if (!tableProperties.getDatabase().equals(database) || !tableProperties.getDatabase().equals(table)) {
+            StreamLoadTableProperties.Builder tablePropertiesBuilder = StreamLoadTableProperties.builder();
+            tablePropertiesBuilder = tablePropertiesBuilder.copyFrom(tableProperties).database(database).table(table);
+            return tablePropertiesBuilder.build();
+        } else {
+            return tableProperties;
+        }
+    }
+
     public Map<String, StreamLoadTableProperties> getTablePropertiesMap() {
         return tablePropertiesMap;
     }

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/properties/StreamLoadTableProperties.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/properties/StreamLoadTableProperties.java
@@ -34,8 +34,6 @@ public class StreamLoadTableProperties implements Serializable {
     private final String table;
     private final StreamLoadDataFormat dataFormat;
     private final Map<String, String> properties;
-
-    private final boolean enableUpsertDelete;
     private final long chunkLimit;
     private final int maxBufferRows;
     private final String columns;
@@ -48,7 +46,6 @@ public class StreamLoadTableProperties implements Serializable {
                 ? StreamLoadUtils.getTableUniqueKey(database, table)
                 : builder.uniqueKey;
 
-        this.enableUpsertDelete = builder.enableUpsertDelete;
         this.dataFormat = builder.dataFormat == null
                 ? StreamLoadDataFormat.JSON
                 : builder.dataFormat;
@@ -77,10 +74,6 @@ public class StreamLoadTableProperties implements Serializable {
         return table;
     }
 
-    public boolean isEnableUpsertDelete() {
-        return enableUpsertDelete;
-    }
-
     public StreamLoadDataFormat getDataFormat() {
         return dataFormat;
     }
@@ -106,8 +99,6 @@ public class StreamLoadTableProperties implements Serializable {
         private String database;
         private String table;
         private String columns;
-
-        private boolean enableUpsertDelete;
         private StreamLoadDataFormat dataFormat;
         private long chunkLimit;
         private int maxBufferRows = Integer.MAX_VALUE;
@@ -119,13 +110,16 @@ public class StreamLoadTableProperties implements Serializable {
         }
 
         // This function does not copy the uniqueKey and properties attributes because the uniqueKey 
-        // is generated in the StreamLoadTableProperties constructor, and the properties are automatically 
+        // is generated in the StreamLoadTableProperties constructor.
+        // The properties only contains three elements(database,table,columns), which are automatically
         // populated during the build process.
+        // TODO: StreamLoadProperties.headers hold properties common to multiple tables, while
+        // StreamLoadTableProperties.properties hold the specific properties of an individual table.
+        // This should be taken into consideration during the refactoring.
         public Builder copyFrom(StreamLoadTableProperties streamLoadTableProperties) {
             database(streamLoadTableProperties.getDatabase());
             table(streamLoadTableProperties.getTable());
             columns(streamLoadTableProperties.getColumns());
-            enableUpsertDelete(streamLoadTableProperties.isEnableUpsertDelete());
             streamLoadDataFormat(streamLoadTableProperties.getDataFormat());
             chunkLimit(streamLoadTableProperties.getChunkLimit());
             maxBufferRows(streamLoadTableProperties.getMaxBufferRows());
@@ -149,11 +143,6 @@ public class StreamLoadTableProperties implements Serializable {
 
         public Builder columns(String columns) {
             this.columns = columns;
-            return this;
-        }
-
-        public Builder enableUpsertDelete(boolean enableUpsertDelete) {
-            this.enableUpsertDelete = enableUpsertDelete;
             return this;
         }
 

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/properties/StreamLoadTableProperties.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/properties/StreamLoadTableProperties.java
@@ -117,6 +117,8 @@ public class StreamLoadTableProperties implements Serializable {
         // StreamLoadTableProperties.properties hold the specific properties of an individual table.
         // This should be taken into consideration during the refactoring.
         public Builder copyFrom(StreamLoadTableProperties streamLoadTableProperties) {
+            // TODO: datbase, table, columns are private propertis for an individual table.
+            // We may not copy thers private propertis.
             database(streamLoadTableProperties.getDatabase());
             table(streamLoadTableProperties.getTable());
             columns(streamLoadTableProperties.getColumns());

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/properties/StreamLoadTableProperties.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/properties/StreamLoadTableProperties.java
@@ -38,6 +38,7 @@ public class StreamLoadTableProperties implements Serializable {
     private final boolean enableUpsertDelete;
     private final long chunkLimit;
     private final int maxBufferRows;
+    private final String columns;
 
     private StreamLoadTableProperties(Builder builder) {
         this.database = builder.database;
@@ -59,7 +60,10 @@ public class StreamLoadTableProperties implements Serializable {
         }
         this.maxBufferRows = builder.maxBufferRows;
         this.properties = builder.properties;
+        this.columns = builder.columns;
     }
+
+    public String getColumns() {return columns; }
 
     public String getUniqueKey() {
         return uniqueKey;
@@ -112,6 +116,20 @@ public class StreamLoadTableProperties implements Serializable {
 
         private Builder() {
 
+        }
+
+        // This function does not copy the uniqueKey and properties attributes because the uniqueKey 
+        // is generated in the StreamLoadTableProperties constructor, and the properties are automatically 
+        // populated during the build process.
+        public Builder copyFrom(StreamLoadTableProperties streamLoadTableProperties) {
+            database(streamLoadTableProperties.getDatabase());
+            table(streamLoadTableProperties.getTable());
+            columns(streamLoadTableProperties.getColumns());
+            enableUpsertDelete(streamLoadTableProperties.isEnableUpsertDelete());
+            streamLoadDataFormat(streamLoadTableProperties.getDataFormat());
+            chunkLimit(streamLoadTableProperties.getChunkLimit());
+            maxBufferRows(streamLoadTableProperties.getMaxBufferRows());
+            return this;
         }
 
         public Builder uniqueKey(String uniqueKey) {

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/StreamLoadManagerV2.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/StreamLoadManagerV2.java
@@ -440,7 +440,7 @@ public class StreamLoadManagerV2 implements StreamLoadManager, Serializable {
             synchronized (regions) {
                 region = regions.get(uniqueKey);
                 if (region == null) {
-                    StreamLoadTableProperties tableProperties = properties.getTableProperties(uniqueKey);
+                    StreamLoadTableProperties tableProperties = properties.getTableProperties(uniqueKey, database, table);
                     LabelGenerator labelGenerator = labelGeneratorFactory.create(database, table);
                     region = new TransactionTableRegion(uniqueKey, database, table, this,
                             tableProperties, streamLoader, labelGenerator, maxRetries, retryIntervalInMs);


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
For the Stream Load SDK, if the table to be written to is a non-default table, the DefaultStreamLoader.send method still requests SR to write data to the default table, causing the stream load job to fail. This PR fixes this issue.
![image](https://github.com/StarRocks/starrocks-connector-for-apache-flink/assets/45813655/1736893c-cb5c-40fd-a335-65a86799dfad)

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

