### PR TITLE
[BugFix] Add commons-codec dependency used by Base64.encodeBase64

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,11 @@ limitations under the License.
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.15</version>
+        </dependency>
+        <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>fastjson</artifactId>
             <version>1.2.75</version>
@@ -452,6 +457,10 @@ limitations under the License.
                                     <pattern>com.fasterxml.jackson</pattern>
                                     <shadedPattern>com.starrocks.streamload.shade.com.fasterxml.jackson</shadedPattern>
                                 </relocation>
+                                <relocation>
+                                    <pattern>org.apache.commons</pattern>
+                                    <shadedPattern>com.starrocks.shade.org.apache.commons</shadedPattern>
+                                </relocation>
                             </relocations>
                             <artifactSet>
                                 <includes>
@@ -463,6 +472,7 @@ limitations under the License.
                                     <include>io.netty:*</include>
                                     <include>com.google.flatbuffers:flatbuffers-java</include>
                                     <include>com.google.guava:*</include>
+                                    <include>commons-codec:commons-codec</include>
                                 </includes>
                             </artifactSet>
                             <filters>


### PR DESCRIPTION
## What type of PR is this：
- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
commons-codec is removed in #305 , but it's actually needed by http auth (Base64.encodeBase64), so add it back

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

