### PR TITLE
[Enhancement] Add an option to disable wrapping json to json array.

### DIFF
--- a/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksDynamicTableSinkFactory.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksDynamicTableSinkFactory.java
@@ -87,6 +87,7 @@ public class StarRocksDynamicTableSinkFactory implements DynamicTableSinkFactory
         optionalOptions.add(StarRocksSinkOptions.SINK_ABORT_LINGERING_TXNS);
         optionalOptions.add(StarRocksSinkOptions.SINK_ABORT_CHECK_NUM_TXNS);
         optionalOptions.add(StarRocksSinkOptions.SINK_USE_NEW_SINK_API);
+        optionalOptions.add(StarRocksSinkOptions.SINK_WRAP_JSON_AS_ARRAY);
         return optionalOptions;
     }
 }

--- a/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksSinkOptions.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksSinkOptions.java
@@ -161,7 +161,7 @@ public class StarRocksSinkOptions implements Serializable {
 
     public static final ConfigOption<Boolean> SINK_WRAP_JSON_AS_ARRAY = ConfigOptions.key("sink.wrap-json-as-array")
             .booleanType()
-            .defaultValue(true)
+            .defaultValue(false)
             .withDescription("Whether wrap data as array or not.");
 
     // Sink semantic
@@ -557,9 +557,12 @@ public class StarRocksSinkOptions implements Serializable {
         // By default, using json format should enable strip_outer_array and ignore_json_size,
         // which will simplify the configurations
         if (dataFormat instanceof StreamLoadDataFormat.JSONFormat) {
-            if (!streamLoadProperties.containsKey("strip_outer_array")) {
+            if (!streamLoadProperties.containsKey("strip_outer_array") || isWrapJsonAsArray()) {
+                // When sink.wrap_json_as_array is enabled, strip_outer_array should be set to true as well.
+                // Because users know the source data contains json array, and they need strip_outer_array.
                 streamLoadProperties.put("strip_outer_array", "true");
             }
+
             if (!streamLoadProperties.containsKey("ignore_json_size")) {
                 streamLoadProperties.put("ignore_json_size", "true");
             }

--- a/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksSinkOptions.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksSinkOptions.java
@@ -159,6 +159,11 @@ public class StarRocksSinkOptions implements Serializable {
 
     public static final ConfigOption<Integer> SINK_PARALLELISM = FactoryUtil.SINK_PARALLELISM;
 
+    public static final ConfigOption<Boolean> SINK_WRAP_JSON_AS_ARRAY = ConfigOptions.key("sink.wrap-json-as-array")
+            .booleanType()
+            .defaultValue(true)
+            .withDescription("Whether wrap data as array or not.");
+
     // Sink semantic
     private static final Set<String> SINK_SEMANTIC_ENUMS = Arrays.stream(StarRocksSinkSemantic.values()).map(s -> s.getName()).collect(Collectors.toSet());
     // wild stream load properties' prefix
@@ -375,6 +380,10 @@ public class StarRocksSinkOptions implements Serializable {
 
     public boolean isUseUnifiedSinkApi() {
         return tableOptions.get(SINK_USE_NEW_SINK_API);
+    }
+
+    public boolean isWrapJsonAsArray() {
+        return tableOptions.get(SINK_WRAP_JSON_AS_ARRAY);
     }
 
     private void validateStreamLoadUrl() {


### PR DESCRIPTION
When inserting data like the below:

```java
String[] records = new String[]{
        "[{\"id\":400, \"name\":\"400\"}]",
        "[{\"id\":500, \"name\":\"500\"}]"
};
DataStream<String> source = env.fromElements(records);
```

It fails since connector wrapped the json array into json array's array.

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

