### PR TITLE
[Enhancement] Support to map a subset of StarRocks columns to Flink source table

### DIFF
--- a/src/main/java/com/starrocks/connector/flink/table/source/StarRocksDynamicSourceFunction.java
+++ b/src/main/java/com/starrocks/connector/flink/table/source/StarRocksDynamicSourceFunction.java
@@ -115,7 +115,7 @@ public class StarRocksDynamicSourceFunction extends RichParallelSourceFunction<R
         case QueryAllColumns:
         case QuerySomeColumns:
             String columns = Arrays.stream(selectColumns)
-                    .map(SelectColumn::getColumnName)
+                    .map(col -> "`" + col.getColumnName() + "`")
                             .collect(Collectors.joining(","));
             sqlSb.append(columns);
             break;

--- a/src/main/java/com/starrocks/connector/flink/table/source/StarRocksDynamicTableSource.java
+++ b/src/main/java/com/starrocks/connector/flink/table/source/StarRocksDynamicTableSource.java
@@ -14,10 +14,6 @@
 
 package com.starrocks.connector.flink.table.source;
 
-import com.starrocks.connector.flink.table.source.struct.ColumnRichInfo;
-import com.starrocks.connector.flink.table.source.struct.PushDownHolder;
-import com.starrocks.connector.flink.table.source.struct.SelectColumn;
-
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.connector.ChangelogMode;
@@ -30,6 +26,10 @@ import org.apache.flink.table.connector.source.abilities.SupportsFilterPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsLimitPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown;
 import org.apache.flink.table.expressions.ResolvedExpression;
+
+import com.starrocks.connector.flink.table.source.struct.ColumnRichInfo;
+import com.starrocks.connector.flink.table.source.struct.PushDownHolder;
+import com.starrocks.connector.flink.table.source.struct.SelectColumn;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -62,7 +62,6 @@ public class StarRocksDynamicTableSource implements ScanTableSource, LookupTable
             this.pushDownHolder.getFilter(), 
             this.pushDownHolder.getLimit(), 
             this.pushDownHolder.getSelectColumns(), 
-            this.pushDownHolder.getColumns(), 
             this.pushDownHolder.getQueryType());
         return SourceFunctionProvider.of(sourceFunction, true);
     }
@@ -120,8 +119,6 @@ public class StarRocksDynamicTableSource implements ScanTableSource, LookupTable
             columnList.add(columnName);
             selectColumns.add(new SelectColumn(columnName, index));
         }
-        String columns = String.join(", ", columnList);
-        this.pushDownHolder.setColumns(columns);
         this.pushDownHolder.setSelectColumns(selectColumns.toArray(new SelectColumn[selectColumns.size()]));
     }
 

--- a/src/main/java/com/starrocks/connector/flink/table/source/struct/PushDownHolder.java
+++ b/src/main/java/com/starrocks/connector/flink/table/source/struct/PushDownHolder.java
@@ -25,7 +25,6 @@ public class PushDownHolder implements Serializable {
     private String filter = "";
     private long limit;
     private SelectColumn[] selectColumns; 
-    private String columns;
     private StarRocksSourceQueryType queryType;
 
     public String getFilter() {
@@ -45,12 +44,6 @@ public class PushDownHolder implements Serializable {
     }
     public void setSelectColumns(SelectColumn[] selectColumns) {
         this.selectColumns = selectColumns;
-    }
-    public String getColumns() {
-        return columns;
-    }
-    public void setColumns(String columns) {
-        this.columns = columns;
     }
     public StarRocksSourceQueryType getQueryType() {
         return queryType;

--- a/src/test/java/com/starrocks/connector/flink/manager/source/StarRocksQueryPlanVisitorTest.java
+++ b/src/test/java/com/starrocks/connector/flink/manager/source/StarRocksQueryPlanVisitorTest.java
@@ -43,7 +43,7 @@ public class StarRocksQueryPlanVisitorTest extends StarRocksSourceBaseTest {
     public void testGetQueryPlan() throws IOException {
         mockResonsefunc();
         StarRocksQueryPlanVisitor visitor = new StarRocksQueryPlanVisitor(OPTIONS);
-        QueryInfo queryInfo = visitor.getQueryInfo(querySQL);
+        QueryInfo queryInfo = visitor.getQueryInfo(getQuerySql());
         List<Long> tabletsList = new ArrayList<>();
         List<Integer> countList = new ArrayList<>();
         queryInfo.getBeXTablets().forEach(beXTablets -> {

--- a/src/test/java/com/starrocks/connector/flink/table/source/StarRocksDynamicTableSourceTest.java
+++ b/src/test/java/com/starrocks/connector/flink/table/source/StarRocksDynamicTableSourceTest.java
@@ -14,9 +14,6 @@
 
 package com.starrocks.connector.flink.table.source;
 
-import com.starrocks.connector.flink.it.source.StarRocksSourceBaseTest;
-import com.starrocks.connector.flink.table.source.struct.PushDownHolder;
-
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.TableEnvironment;
@@ -24,6 +21,9 @@ import org.apache.flink.table.expressions.CallExpression;
 import org.apache.flink.table.expressions.FieldReferenceExpression;
 import org.apache.flink.table.expressions.ResolvedExpression;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+
+import com.starrocks.connector.flink.it.source.StarRocksSourceBaseTest;
+import com.starrocks.connector.flink.table.source.struct.PushDownHolder;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -50,7 +50,6 @@ public class StarRocksDynamicTableSourceTest extends StarRocksSourceBaseTest {
     @Test
     public void testApplyProjection() {
         dynamicTableSource.applyProjection(PROJECTION_ARRAY);
-        assertEquals("char_1, int_1", pushDownHolder.getColumns());
 
         for (int i = 0; i < SELECT_COLUMNS.length; i ++) {
             assertEquals(SELECT_COLUMNS[i].getColumnIndexInFlinkTable(), pushDownHolder.getSelectColumns()[i].getColumnIndexInFlinkTable());


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
Currently columns between Flink schema and StarRocks schema must be same. It's not easy to use if the StarRocks table has thousands of columns, but the user only wants to read some columns of it. This PR supports to define the Flink source table only with some columns of StarRocks table that need to read. For example,
StarRocks schema
```
CREATE TABLE t (
    c0 INT,
    c1 FLOAT,
    c3 STRING
);
```
If you just want to read c0 and c3, you can define flink source table as follows. Before this PR, must include all columns
```
CREATE TABLE t (
    c0 INT,
    c3 STRING
) WITH (
  ......
)
```

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

