### PR TITLE
[Feature] Sink supports LZ4 compression with json format

### DIFF
--- a/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksSinkOptions.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksSinkOptions.java
@@ -511,7 +511,8 @@ public class StarRocksSinkOptions implements Serializable {
                 .table(getTableName())
                 .streamLoadDataFormat(dataFormat)
                 .chunkLimit(getChunkLimit())
-                .enableUpsertDelete(supportUpsertDelete());
+                .enableUpsertDelete(supportUpsertDelete())
+                .addCommonProperties(getSinkStreamLoadProperties());
 
         if (hasColumnMappingProperty()) {
             defaultTablePropertiesBuilder.columns(streamLoadProps.get("columns"));

--- a/src/test/java/com/starrocks/connector/flink/it/sink/StarRocksSinkITTest.java
+++ b/src/test/java/com/starrocks/connector/flink/it/sink/StarRocksSinkITTest.java
@@ -724,4 +724,17 @@ public class StarRocksSinkITTest extends StarRocksITTestBase {
         executeSrSQL(createStarRocksTable);
         return tableName;
     }
+
+    @Test
+    public void testJsonLz4Compression() throws Exception {
+        assumeTrue(isSinkV2);
+        Map<String, String> map = new HashMap<>();
+        map.put("sink.properties.format", "json");
+        map.put("sink.properties.strip_outer_array", "true");
+        map.put("sink.properties.compression", "lz4_frame");
+        testConfigurationBase(map, env -> null);
+
+        map.put("sink.at-least-once.use-transaction-stream-load", "false");
+        testConfigurationBase(map, env -> null);
+    }
 }

--- a/starrocks-stream-load-sdk/pom.xml
+++ b/starrocks-stream-load-sdk/pom.xml
@@ -18,6 +18,7 @@
         <httpcore.version>4.4.15</httpcore.version>
         <fastjson.version>1.2.83</fastjson.version>
         <fasterxml.version>2.12.4</fasterxml.version>
+        <lz4.version>1.8.0</lz4.version>
     </properties>
 
     <dependencies>
@@ -56,6 +57,12 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
             <version>${fasterxml.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.lz4</groupId>
+            <artifactId>lz4-java</artifactId>
+            <version>${lz4.version}</version>
         </dependency>
 
         <dependency>

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/StreamLoadDataFormat.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/StreamLoadDataFormat.java
@@ -29,6 +29,10 @@ public interface StreamLoadDataFormat {
     StreamLoadDataFormat JSON = new JSONFormat();
     StreamLoadDataFormat CSV = new CSVFormat();
 
+    default String name() {
+        return "";
+    }
+
     byte[] first();
     byte[] delimiter();
     byte[] end();
@@ -49,6 +53,11 @@ public interface StreamLoadDataFormat {
             }
 
             this.delimiter = rowDelimiter.getBytes(StandardCharsets.UTF_8);
+        }
+
+        @Override
+        public String name() {
+            return "csv";
         }
 
         @Override
@@ -88,6 +97,11 @@ public interface StreamLoadDataFormat {
         private static final byte[] first = "[".getBytes(StandardCharsets.UTF_8);
         private static final byte[] delimiter = ",".getBytes(StandardCharsets.UTF_8);
         private static final byte[] end = "]".getBytes(StandardCharsets.UTF_8);
+
+        @Override
+        public String name() {
+            return "json";
+        }
 
         @Override
         public byte[] first() {

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/annotation/Evolving.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/annotation/Evolving.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021-present StarRocks, Inc. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.starrocks.data.load.stream.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+/**
+ * APIs that are not stable yet.
+ */
+@Documented
+@Target({ElementType.TYPE, ElementType.FIELD, ElementType.METHOD})
+public @interface Evolving {}

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/compress/CompressionCodec.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/compress/CompressionCodec.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021-present StarRocks, Inc. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.starrocks.data.load.stream.compress;
+
+import com.starrocks.data.load.stream.StreamLoadDataFormat;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Map;
+import java.util.Optional;
+
+/** Compress data with the specified compression algorithm. */
+public interface CompressionCodec {
+
+    /**
+     * Create an output stream to compress the raw output stream.
+     *
+     * @param rawOutputStream the output stream to compress
+     * @param contentSize the content size of the raw stream. -1 if the size is unknown
+     * @return an output stream with compressed data
+     */
+    OutputStream createCompressionStream(final OutputStream rawOutputStream, long contentSize) throws IOException;
+
+    static Optional<CompressionCodec> createCompressionCodec(StreamLoadDataFormat dataFormat,
+                                                             Optional<String> compressionType,
+                                                             Map<String, Object> properties) {
+        if (!compressionType.isPresent()) {
+            return Optional.empty();
+        }
+
+        if (LZ4FrameCompressionCodec.NAME.equalsIgnoreCase(compressionType.get())) {
+            if (dataFormat instanceof StreamLoadDataFormat.JSONFormat) {
+                return Optional.of(LZ4FrameCompressionCodec.create(properties));
+            }
+        }
+
+        throw new UnsupportedOperationException(
+                String.format("Not support to compress format %s with compression type %s",
+                        dataFormat.name(), compressionType.get()));
+    }
+}

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/compress/CompressionHttpEntity.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/compress/CompressionHttpEntity.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2021-present StarRocks, Inc. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.starrocks.data.load.stream.compress;
+
+import com.starrocks.data.load.stream.v2.ChunkHttpEntity;
+import org.apache.http.entity.HttpEntityWrapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/** Wrapping entity that compresses content when writing. */
+public class CompressionHttpEntity extends HttpEntityWrapper {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CompressionHttpEntity.class);
+
+    private final CompressionCodec compressionCodec;
+
+    public CompressionHttpEntity(ChunkHttpEntity entity, CompressionCodec compressionCodec) {
+        super(entity);
+        this.compressionCodec = compressionCodec;
+        entity.setLogAfterWrite(false);
+    }
+
+    @Override
+    public long getContentLength() {
+        return -1;
+    }
+
+    @Override
+    public boolean isChunked() {
+        // force content chunking
+        return true;
+    }
+
+    @Override
+    public InputStream getContent() throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void writeTo(final OutputStream outStream) throws IOException {
+        ChunkHttpEntity entity = (ChunkHttpEntity) wrappedEntity;
+        final CountingOutputStream countingOutputStream = new CountingOutputStream(outStream);
+        final OutputStream compressOutputStream =
+                compressionCodec.createCompressionStream(countingOutputStream, entity.getContentLength());
+        entity.writeTo(compressOutputStream);
+        compressOutputStream.close();
+        long rawSize = entity.getContentLength();
+        long compressSize = countingOutputStream.getCount();
+        float compressRatio = compressSize == 0 ? 1 : (float) rawSize / compressSize;
+        LOG.info("Finish to write entity for table {}, raw size : {}, compressed size: {}, compress ratio: {}",
+                entity.getTableUniqueKey(), rawSize, compressSize, compressRatio) ;
+    }
+
+    @Override
+    public boolean isStreaming() {
+        return false;
+    }
+}

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/compress/CompressionHttpEntity.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/compress/CompressionHttpEntity.java
@@ -60,6 +60,7 @@ public class CompressionHttpEntity extends HttpEntityWrapper {
 
     @Override
     public void writeTo(final OutputStream outStream) throws IOException {
+        long startTime = System.nanoTime();
         ChunkHttpEntity entity = (ChunkHttpEntity) wrappedEntity;
         final CountingOutputStream countingOutputStream = new CountingOutputStream(outStream);
         final OutputStream compressOutputStream =
@@ -69,8 +70,8 @@ public class CompressionHttpEntity extends HttpEntityWrapper {
         long rawSize = entity.getContentLength();
         long compressSize = countingOutputStream.getCount();
         float compressRatio = compressSize == 0 ? 1 : (float) rawSize / compressSize;
-        LOG.info("Finish to write entity for table {}, raw size : {}, compressed size: {}, compress ratio: {}",
-                entity.getTableUniqueKey(), rawSize, compressSize, compressRatio) ;
+        LOG.info("Write entity for table {}, raw/compressed size:{}/{}, compress ratio:{}, time:{}us",
+                entity.getTableUniqueKey(), rawSize, compressSize, compressRatio, (System.nanoTime() - startTime) / 1000) ;
     }
 
     @Override

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/compress/CompressionOptions.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/compress/CompressionOptions.java
@@ -25,8 +25,5 @@ import net.jpountz.lz4.LZ4FrameOutputStream;
 public class CompressionOptions {
 
     public static final String LZ4_BLOCK_SIZE = "compression.lz4.block.size";
-    public static final LZ4FrameOutputStream.BLOCKSIZE DEFAULT_LZ4_BLOCK_SIZE = LZ4FrameOutputStream.BLOCKSIZE.SIZE_1MB;
-
-    public static final String LZ4_BLOCK_INDEPENDENCE = "compression.lz4.block.independence";
-    public static final boolean DEFAULT_LZ4_BLOCK_INDEPENDENCE = false;
+    public static final LZ4FrameOutputStream.BLOCKSIZE DEFAULT_LZ4_BLOCK_SIZE = LZ4FrameOutputStream.BLOCKSIZE.SIZE_4MB;
 }

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/compress/CompressionOptions.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/compress/CompressionOptions.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021-present StarRocks, Inc. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.starrocks.data.load.stream.compress;
+
+import net.jpountz.lz4.LZ4FrameOutputStream;
+
+public class CompressionOptions {
+
+    public static final String LZ4_BLOCK_SIZE = "compression.lz4.block.size";
+    public static final LZ4FrameOutputStream.BLOCKSIZE DEFAULT_LZ4_BLOCK_SIZE = LZ4FrameOutputStream.BLOCKSIZE.SIZE_1MB;
+
+    public static final String LZ4_BLOCK_INDEPENDENCE = "compression.lz4.block.independence";
+    public static final boolean DEFAULT_LZ4_BLOCK_INDEPENDENCE = false;
+}

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/compress/CountingOutputStream.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/compress/CountingOutputStream.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021-present StarRocks, Inc. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.starrocks.data.load.stream.compress;
+
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+/** Count how many bytes written. */
+public class CountingOutputStream extends FilterOutputStream {
+
+    private long count;
+
+    public CountingOutputStream(OutputStream out) {
+        super(out);
+    }
+
+    public long getCount() {
+        return this.count;
+    }
+
+    public void write(byte[] b, int off, int len) throws IOException {
+        this.out.write(b, off, len);
+        this.count += len;
+    }
+
+    public void write(int b) throws IOException {
+        this.out.write(b);
+        ++this.count;
+    }
+
+}

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/compress/LZ4FrameCompressionCodec.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/compress/LZ4FrameCompressionCodec.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2021-present StarRocks, Inc. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.starrocks.data.load.stream.compress;
+
+import net.jpountz.lz4.LZ4Compressor;
+import net.jpountz.lz4.LZ4Factory;
+import net.jpountz.lz4.LZ4FrameOutputStream;
+import net.jpountz.xxhash.XXHash32;
+import net.jpountz.xxhash.XXHashFactory;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Map;
+
+/** Compress data using LZ4_FRAME. */
+public class LZ4FrameCompressionCodec implements CompressionCodec {
+
+    public static final String NAME = "LZ4_FRAME";
+
+    private final LZ4FrameOutputStream.BLOCKSIZE blockSize;
+    private final boolean blockIndependence;
+    private final LZ4Compressor compressor;
+    private final XXHash32 hash;
+
+    public LZ4FrameCompressionCodec(LZ4FrameOutputStream.BLOCKSIZE blockSize, boolean blockIndependence) {
+        this.blockSize = blockSize;
+        this.blockIndependence = blockIndependence;
+        this.compressor = LZ4Factory.fastestInstance().fastCompressor();
+        this.hash = XXHashFactory.fastestInstance().hash32();
+    }
+
+    @Override
+    public OutputStream createCompressionStream(OutputStream rawOutputStream, long contentSize) throws IOException {
+        if (contentSize < 0) {
+            return blockIndependence ?
+                    new LZ4FrameOutputStream(rawOutputStream, blockSize, -1, compressor, hash,
+                            LZ4FrameOutputStream.FLG.Bits.BLOCK_INDEPENDENCE) :
+                    new LZ4FrameOutputStream(rawOutputStream, blockSize, -1, compressor, hash);
+        } else {
+            return blockIndependence ?
+                    new LZ4FrameOutputStream(rawOutputStream, blockSize, contentSize, compressor, hash,
+                            LZ4FrameOutputStream.FLG.Bits.CONTENT_SIZE,
+                            LZ4FrameOutputStream.FLG.Bits.BLOCK_INDEPENDENCE) :
+                    new LZ4FrameOutputStream(rawOutputStream, blockSize, contentSize, compressor, hash,
+                            LZ4FrameOutputStream.FLG.Bits.CONTENT_SIZE);
+        }
+    }
+
+    public static LZ4FrameCompressionCodec create(Map<String, Object> properties) {
+        LZ4FrameOutputStream.BLOCKSIZE blockSize = (LZ4FrameOutputStream.BLOCKSIZE) properties.getOrDefault(
+                CompressionOptions.LZ4_BLOCK_SIZE, CompressionOptions.DEFAULT_LZ4_BLOCK_SIZE);
+        boolean blockIndependence = (boolean) properties.getOrDefault(
+                CompressionOptions.LZ4_BLOCK_INDEPENDENCE, CompressionOptions.DEFAULT_LZ4_BLOCK_INDEPENDENCE);
+        return new LZ4FrameCompressionCodec(blockSize, blockIndependence);
+    }
+}

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/properties/StreamLoadTableProperties.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/properties/StreamLoadTableProperties.java
@@ -205,11 +205,6 @@ public class StreamLoadTableProperties implements Serializable {
             return this;
         }
 
-        public Builder enableLZ4BlockIndependence() {
-            tableProperties.put(CompressionOptions.LZ4_BLOCK_INDEPENDENCE, true);
-            return this;
-        }
-
         public StreamLoadTableProperties build() {
             if (database == null || table == null) {
                 throw new IllegalArgumentException(String.format("database `%s` or table `%s` can't be null", database, table));

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/properties/StreamLoadTableProperties.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/properties/StreamLoadTableProperties.java
@@ -29,6 +29,7 @@ import net.jpountz.lz4.LZ4FrameOutputStream;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 public class StreamLoadTableProperties implements Serializable {
 
@@ -37,12 +38,13 @@ public class StreamLoadTableProperties implements Serializable {
     private final String table;
     private final StreamLoadDataFormat dataFormat;
     private final Map<String, Object> tableProperties;
-    // stream load properties
+    // individual stream load properties
     private final Map<String, String> properties;
     private final boolean enableUpsertDelete;
     private final long chunkLimit;
     private final int maxBufferRows;
     private final String columns;
+    private final Map<String, String> commonProperties;
 
     private StreamLoadTableProperties(Builder builder) {
         this.database = builder.database;
@@ -66,6 +68,7 @@ public class StreamLoadTableProperties implements Serializable {
         this.tableProperties = new HashMap<>(builder.tableProperties);
         this.properties = new HashMap<>(builder.properties);
         this.columns = builder.columns;
+        this.commonProperties = new HashMap<>(builder.commonProperties);
     }
 
     public String getColumns() {return columns; }
@@ -107,6 +110,19 @@ public class StreamLoadTableProperties implements Serializable {
         return properties;
     }
 
+    public Map<String, String> getCommonProperties() {
+        return commonProperties;
+    }
+
+    public Optional<String> getProperty(String name) {
+        String value = properties.get(name);
+        if (value != null) {
+            return Optional.of(value);
+        }
+
+        return Optional.ofNullable(commonProperties.get(name));
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -125,6 +141,8 @@ public class StreamLoadTableProperties implements Serializable {
 
         // Stream load properties
         private final Map<String, String> properties = new HashMap<>();
+
+        private final Map<String, String> commonProperties = new HashMap<>();
 
         private Builder() {
 
@@ -147,6 +165,7 @@ public class StreamLoadTableProperties implements Serializable {
             chunkLimit(streamLoadTableProperties.getChunkLimit());
             maxBufferRows(streamLoadTableProperties.getMaxBufferRows());
             tableProperties.putAll(streamLoadTableProperties.getTableProperties());
+            commonProperties.putAll(streamLoadTableProperties.getCommonProperties());
             return this;
         }
 
@@ -202,6 +221,11 @@ public class StreamLoadTableProperties implements Serializable {
 
         public Builder setLZ4BlockSize(LZ4FrameOutputStream.BLOCKSIZE blockSize) {
             tableProperties.put(CompressionOptions.LZ4_BLOCK_SIZE, blockSize);
+            return this;
+        }
+
+        public Builder addCommonProperties(Map<String, String> properties) {
+            this.commonProperties.putAll(properties);
             return this;
         }
 

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/properties/StreamLoadTableProperties.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/properties/StreamLoadTableProperties.java
@@ -22,6 +22,9 @@ package com.starrocks.data.load.stream.properties;
 
 import com.starrocks.data.load.stream.StreamLoadDataFormat;
 import com.starrocks.data.load.stream.StreamLoadUtils;
+import com.starrocks.data.load.stream.annotation.Evolving;
+import com.starrocks.data.load.stream.compress.CompressionOptions;
+import net.jpountz.lz4.LZ4FrameOutputStream;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -33,6 +36,8 @@ public class StreamLoadTableProperties implements Serializable {
     private final String database;
     private final String table;
     private final StreamLoadDataFormat dataFormat;
+    private final Map<String, Object> tableProperties;
+    // stream load properties
     private final Map<String, String> properties;
     private final boolean enableUpsertDelete;
     private final long chunkLimit;
@@ -58,7 +63,8 @@ public class StreamLoadTableProperties implements Serializable {
             chunkLimit = Math.min(10737418240L, builder.chunkLimit);
         }
         this.maxBufferRows = builder.maxBufferRows;
-        this.properties = builder.properties;
+        this.tableProperties = new HashMap<>(builder.tableProperties);
+        this.properties = new HashMap<>(builder.properties);
         this.columns = builder.columns;
     }
 
@@ -92,6 +98,11 @@ public class StreamLoadTableProperties implements Serializable {
         return maxBufferRows;
     }
 
+    @Evolving
+    public Map<String, Object> getTableProperties() {
+        return tableProperties;
+    }
+
     public Map<String, String> getProperties() {
         return properties;
     }
@@ -110,6 +121,9 @@ public class StreamLoadTableProperties implements Serializable {
         private long chunkLimit;
         private int maxBufferRows = Integer.MAX_VALUE;
 
+        private final Map<String, Object> tableProperties = new HashMap<>();
+
+        // Stream load properties
         private final Map<String, String> properties = new HashMap<>();
 
         private Builder() {
@@ -132,6 +146,7 @@ public class StreamLoadTableProperties implements Serializable {
             streamLoadDataFormat(streamLoadTableProperties.getDataFormat());
             chunkLimit(streamLoadTableProperties.getChunkLimit());
             maxBufferRows(streamLoadTableProperties.getMaxBufferRows());
+            tableProperties.putAll(streamLoadTableProperties.getTableProperties());
             return this;
         }
 
@@ -182,6 +197,16 @@ public class StreamLoadTableProperties implements Serializable {
 
         public Builder addProperty(String key, String value) {
             this.properties.put(key, value);
+            return this;
+        }
+
+        public Builder setLZ4BlockSize(LZ4FrameOutputStream.BLOCKSIZE blockSize) {
+            tableProperties.put(CompressionOptions.LZ4_BLOCK_SIZE, blockSize);
+            return this;
+        }
+
+        public Builder enableLZ4BlockIndependence() {
+            tableProperties.put(CompressionOptions.LZ4_BLOCK_INDEPENDENCE, true);
             return this;
         }
 

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/ChunkHttpEntity.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/ChunkHttpEntity.java
@@ -92,6 +92,7 @@ public class ChunkHttpEntity extends AbstractHttpEntity {
 
     @Override
     public void writeTo(OutputStream outputStream) throws IOException {
+        long startTime = System.nanoTime();
         try (InputStream inputStream = new ChunkInputStream(chunk)) {
             final byte[] buffer = new byte[OUTPUT_BUFFER_SIZE];
             int len;
@@ -100,8 +101,8 @@ public class ChunkHttpEntity extends AbstractHttpEntity {
             }
         }
         if (logAfterWrite || LOG.isDebugEnabled()) {
-            LOG.info("Finish to write entity for table {}, contentLength : {}",
-                    tableUniqueKey, contentLength);
+            LOG.info("Write entity for table {}, size:{}, time:{}us",
+                    tableUniqueKey, contentLength, (System.nanoTime() - startTime) / 1000);
         }
     }
 

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/ChunkHttpEntity.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/ChunkHttpEntity.java
@@ -41,18 +41,18 @@ public class ChunkHttpEntity extends AbstractHttpEntity {
     private static final Header CONTENT_TYPE =
             new BasicHeader(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_OCTET_STREAM.toString());
     private final String tableUniqueKey;
-    private final InputStream content;
+    private final Chunk chunk;
     private final long contentLength;
 
     public ChunkHttpEntity(String tableUniqueKey, Chunk chunk) {
         this.tableUniqueKey = tableUniqueKey;
-        this.content = new ChunkInputStream(chunk);
+        this.chunk = chunk;
         this.contentLength = chunk.chunkBytes();
     }
 
     @Override
     public boolean isRepeatable() {
-        return false;
+        return true;
     }
 
     @Override
@@ -77,13 +77,13 @@ public class ChunkHttpEntity extends AbstractHttpEntity {
 
     @Override
     public InputStream getContent() {
-        return content;
+        return new ChunkInputStream(chunk);
     }
 
     @Override
     public void writeTo(OutputStream outputStream) throws IOException {
         long total = 0;
-        try (InputStream inputStream = this.content) {
+        try (InputStream inputStream = new ChunkInputStream(chunk)) {
             final byte[] buffer = new byte[OUTPUT_BUFFER_SIZE];
             int l;
             while ((l = inputStream.read(buffer)) != -1) {

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/TransactionTableRegion.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/TransactionTableRegion.java
@@ -97,7 +97,7 @@ public class TransactionTableRegion implements TableRegion {
         this.labelGenerator = labelGenerator;
         this.compressionCodec = CompressionCodec.createCompressionCodec(
                 properties.getDataFormat(),
-                Optional.ofNullable(properties.getProperties().get("compression")),
+                properties.getProperty("compression"),
                 properties.getTableProperties());
         this.state = new AtomicReference<>(State.ACTIVE);
         this.lastCommitTimeMills = System.currentTimeMillis();

--- a/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/ChunkHttpEntityTest.java
+++ b/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/ChunkHttpEntityTest.java
@@ -27,6 +27,7 @@ import java.io.ByteArrayOutputStream;
 
 import static com.starrocks.data.load.stream.ChunkInputStreamTest.genChunk;
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
 
 public class ChunkHttpEntityTest {
 
@@ -34,6 +35,7 @@ public class ChunkHttpEntityTest {
     public void testWrite() throws Exception {
         ChunkInputStreamTest.ChunkMeta chunkMeta = genChunk();
         ChunkHttpEntity entity = new ChunkHttpEntity("test", chunkMeta.chunk);
+        assertTrue(entity.isRepeatable());
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         entity.writeTo(outputStream);
         assertArrayEquals(chunkMeta.expectedData, outputStream.toByteArray());

--- a/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/ChunkInputStreamTest.java
+++ b/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/ChunkInputStreamTest.java
@@ -107,8 +107,8 @@ public class ChunkInputStreamTest {
     }
 
     public static class ChunkMeta {
-        Chunk chunk;
-        byte[] expectedData;
+        public Chunk chunk;
+        public byte[] expectedData;
 
         public ChunkMeta(Chunk chunk, byte[] expectedData) {
             this.chunk = chunk;

--- a/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/compress/CompressionCodecTestBase.java
+++ b/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/compress/CompressionCodecTestBase.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021-present StarRocks, Inc. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.starrocks.data.load.stream.compress;
+
+import com.starrocks.data.load.stream.ChunkInputStreamTest;
+import com.starrocks.data.load.stream.v2.ChunkHttpEntity;
+
+import java.io.ByteArrayOutputStream;
+
+import static com.starrocks.data.load.stream.ChunkInputStreamTest.genChunk;
+import static org.junit.Assert.assertArrayEquals;
+
+/** Test base for {@link CompressionCodec}. */
+public abstract class CompressionCodecTestBase {
+
+    protected abstract byte[] decompress(byte[] compressedData, int rawSize) throws Exception;
+
+    public void testCompressBase(CompressionCodec compressionCodec) throws Exception {
+        ChunkInputStreamTest.ChunkMeta chunkMeta = genChunk();
+        ChunkHttpEntity entity = new ChunkHttpEntity("test", chunkMeta.chunk);
+        CompressionHttpEntity compressionEntity = new CompressionHttpEntity(entity, compressionCodec);
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        compressionEntity.writeTo(outputStream);
+        byte[] result = outputStream.toByteArray();
+        byte[] descompressData = decompress(result, (int) entity.getContentLength());
+        assertArrayEquals(chunkMeta.expectedData, descompressData);
+    }
+}

--- a/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/compress/CompressionHttpEntityTest.java
+++ b/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/compress/CompressionHttpEntityTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021-present StarRocks, Inc. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.starrocks.data.load.stream.compress;
+
+import com.starrocks.data.load.stream.ChunkInputStreamTest;
+import com.starrocks.data.load.stream.v2.ChunkHttpEntity;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.starrocks.data.load.stream.ChunkInputStreamTest.genChunk;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+/** Tests for {@link CompressionHttpEntity}. */
+public class CompressionHttpEntityTest {
+
+    @Test
+    public void testBasic() throws Exception {
+        ChunkInputStreamTest.ChunkMeta chunkMeta = genChunk();
+        ChunkHttpEntity entity = new ChunkHttpEntity("test", chunkMeta.chunk);
+        MockCompressionCodec compressionCodec = new MockCompressionCodec();
+        CompressionHttpEntity compressionEntity = new CompressionHttpEntity(entity, compressionCodec);
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        compressionEntity.writeTo(outputStream);
+        assertArrayEquals(chunkMeta.expectedData, outputStream.toByteArray());
+        assertEquals(1, compressionCodec.getStreams().size());
+        assertEquals(entity.getContentLength(), compressionCodec.getStreams().get(0).getCount());
+    }
+
+    private static class MockCompressionCodec implements CompressionCodec {
+
+        private final List<CountingOutputStream> streams;
+
+        public MockCompressionCodec() {
+            this.streams = new ArrayList<>();
+        }
+
+        public List<CountingOutputStream> getStreams() {
+            return streams;
+        }
+
+        @Override
+        public OutputStream createCompressionStream(OutputStream rawOutputStream, long contentSize) throws IOException {
+            this.streams.add(new CountingOutputStream(rawOutputStream));
+            return streams.get(streams.size() - 1);
+        }
+    }
+}

--- a/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/compress/CountingOutputStreamTest.java
+++ b/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/compress/CountingOutputStreamTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021-present StarRocks, Inc. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.starrocks.data.load.stream.compress;
+
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.junit.Assert.assertEquals;
+
+/** Tests for {@link CountingOutputStream}. */
+public class CountingOutputStreamTest {
+
+    @Test
+    public void testCount() throws Exception {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        CountingOutputStream countingOutputStream = new CountingOutputStream(outputStream);
+
+        byte[] data = new byte[100];
+        ThreadLocalRandom.current().nextBytes(data);
+        countingOutputStream.write(data[0]);
+        assertEquals(1, countingOutputStream.getCount());
+        countingOutputStream.write(data, 1, data.length - 2);
+        assertEquals(data.length - 1, countingOutputStream.getCount());
+        countingOutputStream.write(data[data.length - 1]);
+        assertEquals(data.length, countingOutputStream.getCount());
+        countingOutputStream.write(data);
+        assertEquals(data.length * 2, countingOutputStream.getCount());
+        countingOutputStream.close();
+
+        byte[] result = outputStream.toByteArray();
+        assertEquals(data.length * 2, result.length);
+        for (int i = 0; i < result.length;) {
+            for (int j = 0; j < data.length; j++, i++) {
+                assertEquals(data[j], result[i]);
+            }
+        }
+        assertEquals(data.length * 2, countingOutputStream.getCount());
+    }
+}

--- a/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/compress/LZ4FrameCompressionCodecTest.java
+++ b/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/compress/LZ4FrameCompressionCodecTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021-present StarRocks, Inc. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.starrocks.data.load.stream.compress;
+
+import net.jpountz.lz4.LZ4FrameInputStream;
+import net.jpountz.lz4.LZ4FrameOutputStream;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class LZ4FrameCompressionCodecTest extends CompressionCodecTestBase {
+
+    @Override
+    protected byte[] decompress(byte[] compressedData, int rawSize) throws Exception {
+        byte[] result = new byte[rawSize];
+        LZ4FrameInputStream inputStream = new LZ4FrameInputStream(new ByteArrayInputStream(compressedData));
+        inputStream.read(result);
+        inputStream.close();
+        return result;
+    }
+
+    @Test
+    public void testCreate() {
+        Map<String, Object> properties = new HashMap<>();
+        LZ4FrameCompressionCodec codec1 = LZ4FrameCompressionCodec.create(properties);
+        assertEquals(LZ4FrameOutputStream.BLOCKSIZE.SIZE_4MB, codec1.getBlockSize());
+
+        properties.put("compression.lz4.block.size", LZ4FrameOutputStream.BLOCKSIZE.SIZE_1MB);
+        LZ4FrameCompressionCodec codec2 = LZ4FrameCompressionCodec.create(properties);
+        assertEquals(LZ4FrameOutputStream.BLOCKSIZE.SIZE_1MB, codec2.getBlockSize());
+    }
+
+    @Test
+    public void testCompress() throws Exception {
+        LZ4FrameCompressionCodec codec = LZ4FrameCompressionCodec.create(new HashMap<>());
+        testCompressBase(codec);
+    }
+}


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [X] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
After StarRocks supports lz4 compression for stream load json format in https://github.com/StarRocks/starrocks/pull/43732, the connector can compress the json data before sending to StarRocks which will reduce the network traffic significantly.  In the test to load clickbench data to starrocks, the compression ratio can be ~8, and the load performance has a 3.64% degradation which is acceptable.
You can enable it with the following configuration
```
'sink.properties.format' = 'json'
'sink.properties.compression' = 'lz4_frame'
```

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

