### PR TITLE
Add sink-side parameter to ignore deletion.

### DIFF
--- a/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksDynamicSinkFunction.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksDynamicSinkFunction.java
@@ -124,6 +124,10 @@ public class StarRocksDynamicSinkFunction<T> extends StarRocksDynamicSinkFunctio
                     (!sinkOptions.supportUpsertDelete() || sinkOptions.getIgnoreUpdateBefore())) {
                 return;
             }
+            if (RowKind.DELETE.equals(((RowData)value).getRowKind()) &&
+                    (!sinkOptions.supportUpsertDelete() || sinkOptions.getIgnoreDelete())) {
+                return;
+            }
             if (!sinkOptions.supportUpsertDelete() && RowKind.DELETE.equals(((RowData)value).getRowKind())) {
                 // let go the UPDATE_AFTER and INSERT rows for tables who have a group of `unique` or `duplicate` keys.
                 return;

--- a/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksDynamicSinkFunctionV2.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksDynamicSinkFunctionV2.java
@@ -155,6 +155,10 @@ public class StarRocksDynamicSinkFunctionV2<T> extends StarRocksDynamicSinkFunct
                     (!sinkOptions.supportUpsertDelete() || sinkOptions.getIgnoreUpdateBefore())) {
                 return;
             }
+            if (RowKind.DELETE.equals(((RowData)value).getRowKind()) &&
+                    (!sinkOptions.supportUpsertDelete() || sinkOptions.getIgnoreDelete())) {
+                return;
+            }
             if (!sinkOptions.supportUpsertDelete() && RowKind.DELETE.equals(((RowData)value).getRowKind())) {
                 // let go the UPDATE_AFTER and INSERT rows for tables who have a group of `unique` or `duplicate` keys.
                 return;

--- a/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksDynamicTableSinkFactory.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksDynamicTableSinkFactory.java
@@ -87,6 +87,7 @@ public class StarRocksDynamicTableSinkFactory implements DynamicTableSinkFactory
         optionalOptions.add(StarRocksSinkOptions.SINK_ABORT_LINGERING_TXNS);
         optionalOptions.add(StarRocksSinkOptions.SINK_ABORT_CHECK_NUM_TXNS);
         optionalOptions.add(StarRocksSinkOptions.SINK_USE_NEW_SINK_API);
+        optionalOptions.add(StarRocksSinkOptions.SINK_IGNORE_DELETE);
         return optionalOptions;
     }
 }

--- a/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksSinkOptions.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksSinkOptions.java
@@ -136,6 +136,11 @@ public class StarRocksSinkOptions implements Serializable {
                     "insert the update_after row in StarRocks, and this options should be set false for this case. Note that how " +
                     "to set this options depends on the user case.");
 
+    public static final ConfigOption<Boolean> SINK_IGNORE_DELETE = ConfigOptions.key("sink.ignore.delete")
+            .booleanType().defaultValue(false).withDescription("Whether to ignore delete records, which helps retain full data " +
+                    "during Flink CDC synchronization without needing to modify the source-side Flink CDC message sending parameters. " +
+                    "This option is set to false by default.");
+
     public static final ConfigOption<Boolean> SINK_ENABLE_EXACTLY_ONCE_LABEL_GEN = ConfigOptions.key("sink.exactly-once.enable-label-gen")
             .booleanType().defaultValue(true).withDescription("Only available when using exactly-once and sink.label-prefix is set. " +
                     "When it's true, the connector will generate label in the format '{labelPrefix}-{tableName}-{subtaskIndex}-{id}'. " +
@@ -314,6 +319,10 @@ public class StarRocksSinkOptions implements Serializable {
 
     public boolean getIgnoreUpdateBefore() {
         return tableOptions.get(SINK_IGNORE_UPDATE_BEFORE);
+    }
+
+    public boolean getIgnoreDelete() {
+        return tableOptions.get(SINK_IGNORE_DELETE);
     }
 
     public static Builder builder() {


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
This PR introduces a new parameter to control whether to ignore delete records. By default, this parameter is set to `false`, meaning delete records will be processed normally. However, when users choose to set it to `true`, the system will ignore the delete records. This feature is particularly useful in scenarios where users want to retain full data when syncing with Flink CDC, without altering the source Flink CDC message sending configuration.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [x] I have added documentation for my new feature or new function
