### PR TITLE
[BugFix] Do not abort completed txns when setting consumer mode to the latest offset

### DIFF
--- a/src/main/java/com/starrocks/connector/flink/table/sink/LingeringTransactionAborter.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/LingeringTransactionAborter.java
@@ -98,7 +98,7 @@ public class LingeringTransactionAborter {
         // there are lingering transactions with this label prefix because the job maybe
         // fail before the first checkpoint is completed, so there is no snapshot for
         // the current label prefix
-        if (currentLabelPrefix != null && !oldLabelPrefixes.contains(currentLabelPrefix)) {
+        if (currentLabelPrefix != null && !oldLabelPrefixes.isEmpty() && !oldLabelPrefixes.contains(currentLabelPrefix)) {
             abortCurrentLabelPrefix();
         }
     }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
When forcibly setting the consumer mode to the `latest-offset` and restart a Flink job with `stateless startup` mode, do not abort the former completed transactions.

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
We had some dirty data in our Kafka topic, so we tried to ignore the dirty data and forcibly set the latest offset to consume the newest data in `Alibaba Cloud VVP Flink` with `stateless startup` mode, and the `V2 exactly-once` label prefix was `flink-h6juywtleyaozjhnk12q1p19`:  
![image](https://github.com/user-attachments/assets/3c4a248d-674b-486d-a251-75193e9263b0)  
However, the Flink job failed to restart, and we met the error below:  
```
java.lang.Exception: Failed to abort transactions with label flink-h6juywtleyaozjhnk12q1p19-event_h6juywtleyaozjhnk12q1p19-0-1, db: data_lake_prod_dwd, table: event_h6juywtleyaozjhnk12q1p19
	at com.starrocks.connector.flink.table.sink.LingeringTransactionAborter.abortCurrentLabelPrefix(LingeringTransactionAborter.java:159) ~[?:?]
	at com.starrocks.connector.flink.table.sink.LingeringTransactionAborter.execute(LingeringTransactionAborter.java:102) ~[?:?]
	at com.starrocks.connector.flink.table.sink.StarRocksDynamicSinkFunctionV2.openForExactlyOnce(StarRocksDynamicSinkFunctionV2.java:228) ~[?:?]
	at com.starrocks.connector.flink.table.sink.StarRocksDynamicSinkFunctionV2.open(StarRocksDynamicSinkFunctionV2.java:212) ~[?:?]
	at org.apache.flink.api.common.functions.util.FunctionUtils.openFunction(FunctionUtils.java:34) ~[flink-dist-1.15-vvr-6.0.4-SNAPSHOT.jar:1.15-vvr-6.0.4-SNAPSHOT]
	at org.apache.flink.streaming.api.operators.AbstractUdfStreamOperator.open(AbstractUdfStreamOperator.java:100) ~[flink-dist-1.15-vvr-6.0.4-SNAPSHOT.jar:1.15-vvr-6.0.4-SNAPSHOT]
	at org.apache.flink.streaming.api.operators.StreamSink.open(StreamSink.java:46) ~[flink-dist-1.15-vvr-6.0.4-SNAPSHOT.jar:1.15-vvr-6.0.4-SNAPSHOT]
	at org.apache.flink.streaming.runtime.tasks.RegularOperatorChain.initializeStateAndOpenOperators(RegularOperatorChain.java:107) ~[flink-dist-1.15-vvr-6.0.4-SNAPSHOT.jar:1.15-vvr-6.0.4-SNAPSHOT]
	at org.apache.flink.streaming.runtime.tasks.StreamTask.restoreGates(StreamTask.java:851) ~[flink-dist-1.15-vvr-6.0.4-SNAPSHOT.jar:1.15-vvr-6.0.4-SNAPSHOT]
	at org.apache.flink.streaming.runtime.tasks.StreamTaskActionExecutor$1.call(StreamTaskActionExecutor.java:55) ~[flink-dist-1.15-vvr-6.0.4-SNAPSHOT.jar:1.15-vvr-6.0.4-SNAPSHOT]
	at org.apache.flink.streaming.runtime.tasks.StreamTask.restoreInternal(StreamTask.java:798) ~[flink-dist-1.15-vvr-6.0.4-SNAPSHOT.jar:1.15-vvr-6.0.4-SNAPSHOT]
	at org.apache.flink.streaming.runtime.tasks.StreamTask.restore(StreamTask.java:765) ~[flink-dist-1.15-vvr-6.0.4-SNAPSHOT.jar:1.15-vvr-6.0.4-SNAPSHOT]
	at org.apache.flink.runtime.taskmanager.Task.runWithSystemExitMonitoring(Task.java:954) ~[flink-dist-1.15-vvr-6.0.4-SNAPSHOT.jar:1.15-vvr-6.0.4-SNAPSHOT]
	at org.apache.flink.runtime.taskmanager.Task.restoreAndInvoke(Task.java:923) ~[flink-dist-1.15-vvr-6.0.4-SNAPSHOT.jar:1.15-vvr-6.0.4-SNAPSHOT]
	at org.apache.flink.runtime.taskmanager.Task.doRun(Task.java:746) ~[flink-dist-1.15-vvr-6.0.4-SNAPSHOT.jar:1.15-vvr-6.0.4-SNAPSHOT]
	at org.apache.flink.runtime.taskmanager.Task.run(Task.java:568) ~[flink-dist-1.15-vvr-6.0.4-SNAPSHOT.jar:1.15-vvr-6.0.4-SNAPSHOT]
	at java.lang.Thread.run(Thread.java:834) ~[?:1.8.0_102]
Caused by: java.lang.Exception: Try to abort a finished transactions, db: data_lake_prod_dwd, table: event_h6juywtleyaozjhnk12q1p19, label: flink-h6juywtleyaozjhnk12q1p19-event_h6juywtleyaozjhnk12q1p19-0-1, status: VISIBLE. The reason may be that you are restoring from an earlier checkpoint rather than the newest, and you can use a new sink.label-prefix, or report the issue
	at com.starrocks.connector.flink.table.sink.LingeringTransactionAborter.tryAbortTransaction(LingeringTransactionAborter.java:194) ~[?:?]
	at com.starrocks.connector.flink.table.sink.LingeringTransactionAborter.abortCurrentLabelPrefix(LingeringTransactionAborter.java:144) ~[?:?]
	... 16 more
```
![image](https://github.com/user-attachments/assets/c7fcb3e7-52b2-4e4e-a52c-9021562a51ae)  
![image](https://github.com/user-attachments/assets/fe3d348c-8b38-4578-acdc-0ec831e42ab1)  

After reading relevant source codes, we found that the `oldLabelPrefixes` set maybe empty if we restart the Flink job with `stateless startup` mode:   
![image](https://github.com/user-attachments/assets/c32dd970-523d-427a-a563-33ac5ca50444)  

Then the label id will be the same as the former completed transaction, which is a conflict.  


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

