### PR TITLE
[BugFix]Fixed an issue where[BugFix]Fixed an issue where table names were printed incorrectly after creating a table in StarRocksCatalog. table names were printed incorrectly aft…

### DIFF
--- a/src/main/java/com/starrocks/connector/flink/catalog/StarRocksCatalog.java
+++ b/src/main/java/com/starrocks/connector/flink/catalog/StarRocksCatalog.java
@@ -284,14 +284,14 @@ public class StarRocksCatalog implements Serializable {
         try {
             executeUpdateStatement(createTableSql);
             LOG.info("Success to create table {}.{}, sql: {}",
-                    table.getDatabaseName(), table.getDatabaseName(), createTableSql);
+                    table.getDatabaseName(), table.getTableName(), createTableSql);
         } catch (Exception e) {
             LOG.error("Failed to create table {}.{}, sql: {}",
-                    table.getDatabaseName(), table.getDatabaseName(), createTableSql, e);
+                    table.getDatabaseName(), table.getTableName(), createTableSql, e);
             throw new StarRocksCatalogException(
                     String.format(
                             "Failed to create table %s.%s",
-                            table.getDatabaseName(), table.getDatabaseName()),
+                            table.getDatabaseName(), table.getTableName()),
                     e);
         }
     }


### PR DESCRIPTION
[BugFix]Fixed an issue where table names were printed incorrectly after creating a table in StarRocksCatalog.

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
Caused by: org.apache.flink.cdc.common.exceptions.SchemaEvolveException: com.starrocks.connector.flink.catalog.StarRocksCatalogException: Failed to create table origin_ennovation_ods_wzd_laiu8_sr.origin_ennovation_ods_wzd_laiu8_sr
	at org.apache.flink.cdc.connectors.starrocks.sink.StarRocksMetadataApplier.applyCreateTable(StarRocksMetadataApplier.java:130) ~[?:?]
	at org.apache.flink.cdc.connectors.starrocks.sink.StarRocksMetadataApplier.applySchemaChange(StarRocksMetadataApplier.java:101) ~[?:?]
	at org.apache.flink.cdc.runtime.operators.schema.coordinator.SchemaRegistryRequestHandler.applySchemaChange(SchemaRegistryRequestHandler.java:238) ~[?:?]
	at org.apache.flink.cdc.runtime.operators.schema.coordinator.SchemaRegistryRequestHandler.lambda$flushSuccess$0(SchemaRegistryRequestHandler.java:306) ~[?:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source) ~[?:?]
	at java.util.concurrent.FutureTask.run(Unknown Source) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source) ~[?:?]
	at java.lang.Thread.run(Unknown Source) ~[?:?]

Failed to create table origin_ennovation_ods_wzd_laiu8_sr. origin_ennovation_ods_wzd_laiu8_sr, as seen in this passage, the library name and table name are the same when printed.
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

