### PR TITLE
[SecurityFix] Change DefaultStreamLoader start log from info to debug…

### DIFF
--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/DefaultStreamLoader.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/DefaultStreamLoader.java
@@ -119,16 +119,17 @@ public class DefaultStreamLoader implements StreamLoader, Serializable {
                         return thread;
                     });
 
+            log.info("Default Stream Loader start")
             String propertiesStr = "";
             String headerStr = "";
             try {
                 propertiesStr = objectMapper.writeValueAsString(properties);
                 headerStr = objectMapper.writeValueAsString(defaultHeaders);
             } catch (Exception e) {
-                log.warn("Failed to convert properties and headers to json", e);
+                log.debug("Failed to convert properties and headers to json", e);
             }
 
-            log.info("Default Stream Loader start, properties : {}, defaultHeaders : {}",
+            log.debug("properties : {}, defaultHeaders : {}",
                     propertiesStr, headerStr);
         }
     }


### PR DESCRIPTION
… to prevent exposing starrocks credentials

## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #415
## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
This change will prevent to expose starrocks credentials in any logger system, for example if you send the logs to any server like datadog, newrelic or a simple stdout, it is easy to collect the database connection, username and password.
The log is divided in two parts:
- A simple log info message that notifies that the loadstream started.
- In case the log level is debug then you can print all properties in detail (assumming that in production scenarios debug should not be used).
## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

