### PR TITLE
[Enhancement] Support to specify warehouse for sr flink source connector

### DIFF
--- a/src/main/java/com/starrocks/connector/flink/manager/StarRocksQueryPlanVisitor.java
+++ b/src/main/java/com/starrocks/connector/flink/manager/StarRocksQueryPlanVisitor.java
@@ -112,6 +112,7 @@ public class StarRocksQueryPlanVisitor implements Serializable {
                 HttpPost post = new HttpPost(url);
                 post.setHeader("Content-Type", "application/json;charset=UTF-8");
                 post.setHeader("Authorization", getBasicAuthHeader(sourceOptions.getUsername(), sourceOptions.getPassword()));
+                post.setHeader("warehouse", sourceOptions.getWarehouseName());
                 post.setEntity(new ByteArrayEntity(body.getBytes()));
                 try (CloseableHttpResponse response = httpClient.execute(post)) {
                     requsetCode = response.getStatusLine().getStatusCode();

--- a/src/main/java/com/starrocks/connector/flink/table/source/StarRocksSourceOptions.java
+++ b/src/main/java/com/starrocks/connector/flink/table/source/StarRocksSourceOptions.java
@@ -33,6 +33,7 @@ public class StarRocksSourceOptions implements Serializable {
     private final ReadableConfig tableOptions;
     private final Map<String, String> tableOptionsMap;
     private final Map<String, String> beScanProps = new HashMap<>();
+    public static final String SOURCE_PROPERTIES_PREFIX = "scan.params.";
 
 
     // required Options
@@ -53,6 +54,9 @@ public class StarRocksSourceOptions implements Serializable {
 
     public static final ConfigOption<String> TABLE_NAME = ConfigOptions.key("table-name")
             .stringType().noDefaultValue().withDescription("Table name");
+
+    public static final ConfigOption<String> WAREHOUSE_NAME = ConfigOptions.key(SOURCE_PROPERTIES_PREFIX + "warehouse")
+            .stringType().noDefaultValue().withDescription("Warehouse name");
     
     
     // optional Options
@@ -103,7 +107,6 @@ public class StarRocksSourceOptions implements Serializable {
             .intType().defaultValue(1).withDescription("the max retry times if lookup database failed.");
 
 
-    public static final String SOURCE_PROPERTIES_PREFIX = "scan.params.";
 
     public StarRocksSourceOptions(ReadableConfig options, Map<String, String> optionsMap) {
         this.tableOptions = options;
@@ -165,6 +168,10 @@ public class StarRocksSourceOptions implements Serializable {
 
     public String getTableName() {
         return tableOptions.get(TABLE_NAME);
+    }
+
+    public String getWarehouseName() {
+        return tableOptions.get(WAREHOUSE_NAME);
     }
 
 


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Support to specify warehouse for sr flink source connector using param `'scan.params.warehouse'='warehosue_name', and then pass the warehouse to fe through http header.

```
CREATE TABLE flink_test
(
    `id` INT,
    `name` STRING,
    `score` INT
)
WITH
(
    'connector'='starrocks',
    'scan-url'='192.168.xxx.xxx:8030',
    'jdbc-url'='jdbc:mysql://192.168.xxx.xxx:9030',
    'username'='xxxxxx',
    'password'='xxxxxx',
    'database-name'='test',
    'table-name'='score_board',
    'scan.params.warehouse'='warehosue_name'
);
```
`
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

