### PR TITLE
[BugFix] Fix no warehouse specified in transaction load.

### DIFF
--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/TransactionStreamLoader.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/TransactionStreamLoader.java
@@ -60,6 +60,10 @@ public class TransactionStreamLoader extends DefaultStreamLoader {
 
     protected void initTxHeaders(StreamLoadProperties properties) {
         Map<String, String> headers = new HashMap<>();
+        String warehouse = properties.getHeaders().get("warehouse");
+        if (warehouse != null && !warehouse.isEmpty()) {
+            headers.put("warehouse", warehouse);
+        }
         headers.put(HttpHeaders.AUTHORIZATION, StreamLoadUtils.getBasicAuthHeader(properties.getUsername(), properties.getPassword()));
         this.defaultTxnHeaders = headers.entrySet().stream()
                 .map(entry -> new BasicHeader(entry.getKey(), entry.getValue()))


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

There are no `warehouse` property specified in the headers of `api/transaction/{op}` except `api/transaction/load`, which is caused by different headers when initializing.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

