### PR TITLE
[Enhancement] support lookup data directly.

### DIFF
--- a/src/main/java/com/starrocks/connector/flink/table/source/StarRocksDynamicCachedLookupFunction.java
+++ b/src/main/java/com/starrocks/connector/flink/table/source/StarRocksDynamicCachedLookupFunction.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.starrocks.connector.flink.table.source;
+
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.functions.FunctionContext;
+import org.apache.flink.table.functions.LookupFunction;
+import org.apache.flink.types.Row;
+
+import com.starrocks.connector.flink.table.source.struct.ColumnRichInfo;
+import com.starrocks.connector.flink.table.source.struct.QueryBeXTablets;
+import com.starrocks.connector.flink.table.source.struct.QueryInfo;
+import com.starrocks.connector.flink.table.source.struct.SelectColumn;
+import com.starrocks.connector.flink.tools.EnvUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class StarRocksDynamicCachedLookupFunction extends LookupFunction {
+
+    private static final Logger LOG = LoggerFactory.getLogger(StarRocksDynamicCachedLookupFunction.class);
+
+    private final ColumnRichInfo[] filterRichInfos;
+    private final StarRocksSourceOptions sourceOptions;
+    private QueryInfo queryInfo;
+    private final SelectColumn[] selectColumns;
+    private final List<ColumnRichInfo> columnRichInfos;
+
+    private final long cacheMaxSize;
+    private final long cacheExpireMs;
+    private final int maxRetryTimes;
+
+    // cache for lookup data
+    private Map<Row, List<RowData>> cacheMap;
+
+    private transient long nextLoadTime;
+
+    public StarRocksDynamicCachedLookupFunction(StarRocksSourceOptions sourceOptions,
+                                          ColumnRichInfo[] filterRichInfos,
+                                          List<ColumnRichInfo> columnRichInfos,
+                                          SelectColumn[] selectColumns) {
+        this.sourceOptions = sourceOptions;
+        this.filterRichInfos = filterRichInfos;
+        this.columnRichInfos = columnRichInfos;
+        this.selectColumns = selectColumns;
+
+        this.cacheMaxSize = sourceOptions.getLookupCacheMaxRows();
+        this.cacheExpireMs = sourceOptions.getLookupCacheTTL();
+        this.maxRetryTimes = sourceOptions.getLookupMaxRetries();
+
+        this.cacheMap = new HashMap<>();
+        this.nextLoadTime = -1L;
+    }
+
+    @Override
+    public void open(FunctionContext context) throws Exception {
+        super.open(context);
+        LOG.info("Open lookup function. {}", EnvUtils.getGitInformation());
+    }
+
+    @Override
+    public Collection<RowData> lookup(RowData rowData) {
+        reloadData();
+        Row keyRow = genRow(rowData);
+        return cacheMap.get(keyRow);
+    }
+
+    private Row genRow(RowData rowData) {
+        GenericRowData gRowData = (GenericRowData) rowData;
+        Object[] keyObj = new Object[filterRichInfos.length];
+        for (int i = 0; i < filterRichInfos.length; i ++) {
+            keyObj[i] = gRowData.getField(filterRichInfos[i].getColumnIndexInSchema());
+        }
+        return Row.of(keyObj);
+    }
+
+    private void reloadData() {
+        if (nextLoadTime > System.currentTimeMillis()) {
+            return;
+        }
+        if (nextLoadTime > 0) {
+            LOG.info("Lookup join cache has expired after {} (ms), reloading", this.cacheExpireMs);
+        } else {
+            LOG.info("Populating lookup join cache");
+        }
+        cacheMap.clear();
+
+        String columns = Arrays.stream(selectColumns)
+                .map(col -> "`" + col.getColumnName() + "`")
+                .collect(Collectors.joining(","));
+        String sql = String.format("select %s from `%s`.`%s`", columns,
+                sourceOptions.getDatabaseName(), sourceOptions.getTableName());
+        LOG.info("LookUpFunction SQL [{}]", sql);
+        this.queryInfo = StarRocksSourceCommonFunc.getQueryInfo(this.sourceOptions, sql);
+        List<List<QueryBeXTablets>> lists = StarRocksSourceCommonFunc.splitQueryBeXTablets(1, queryInfo);
+        cacheMap = lists.get(0).parallelStream()
+                .flatMap(beXTablets -> scanBeTablets(beXTablets).stream())
+                .collect(Collectors.groupingBy(this::genRow));
+        nextLoadTime = System.currentTimeMillis() + this.cacheExpireMs;
+    }
+
+    private List<RowData> scanBeTablets(QueryBeXTablets beXTablets) {
+        List<RowData> tmpDataList = new ArrayList<>();
+        RuntimeException exception = null;
+        StarRocksSourceBeReader beReader = new StarRocksSourceBeReader(
+                beXTablets.getBeNode(),
+                columnRichInfos,
+                selectColumns,
+                sourceOptions);
+        try {
+            beReader.openScanner(beXTablets.getTabletIds(), queryInfo.getQueryPlan().getOpaqued_query_plan(),
+                    sourceOptions);
+            beReader.startToRead();
+            while (beReader.hasNext()) {
+                RowData row = beReader.getNext();
+                tmpDataList.add(row);
+            }
+        } catch (Exception e) {
+            LOG.error("Failed to scan tablets for BE node {}", beXTablets.getBeNode(), e);
+            exception = new RuntimeException("Failed to scan tablets for BE node " + beXTablets.getBeNode(), e);
+        } finally {
+            try {
+                beReader.close();
+                LOG.info("Close reader for BE {}", beXTablets.getBeNode());
+            } catch (Exception ie) {
+                LOG.error("Failed to close reader for BE {}", beXTablets.getBeNode(), ie);
+                if (exception == null) {
+                    exception = new RuntimeException("Failed to close reader for BE node " + beXTablets.getBeNode(), ie);
+                }
+            }
+        }
+
+        if (exception != null) {
+            throw exception;
+        }
+        return tmpDataList;
+    }
+
+    @Override
+    public void close() throws Exception {
+        super.close();
+    }
+}

--- a/src/main/java/com/starrocks/connector/flink/table/source/StarRocksDynamicTableSourceFactory.java
+++ b/src/main/java/com/starrocks/connector/flink/table/source/StarRocksDynamicTableSourceFactory.java
@@ -76,6 +76,7 @@ public final class StarRocksDynamicTableSourceFactory implements DynamicTableSou
         options.add(StarRocksSourceOptions.SCAN_MEM_LIMIT);
         options.add(StarRocksSourceOptions.SCAN_MAX_RETRIES);
         options.add(StarRocksSourceOptions.SCAN_BE_HOST_MAPPING_LIST);
+        options.add(StarRocksSourceOptions.LOOKUP_ENABLE_CACHE);
         options.add(StarRocksSourceOptions.LOOKUP_CACHE_TTL_MS);
         options.add(StarRocksSourceOptions.LOOKUP_CACHE_MAX_ROWS);
         options.add(StarRocksSourceOptions.LOOKUP_MAX_RETRIES);

--- a/src/main/java/com/starrocks/connector/flink/table/source/StarRocksSourceOptions.java
+++ b/src/main/java/com/starrocks/connector/flink/table/source/StarRocksSourceOptions.java
@@ -90,6 +90,9 @@ public class StarRocksSourceOptions implements Serializable {
             .stringType().defaultValue("").withDescription("List of be host mapping");
     
     // lookup Options
+    public static final ConfigOption<Boolean> LOOKUP_ENABLE_CACHE = ConfigOptions.key("lookup.cache.enabled")
+            .booleanType().defaultValue(false).withDescription("Enable cache or not for lookup.");
+
     public static final ConfigOption<Long> LOOKUP_CACHE_MAX_ROWS = ConfigOptions.key("lookup.cache.max-rows")
             .longType().defaultValue(-1L).withDescription(
                             "the max number of rows of lookup cache, over this value, the oldest rows will "
@@ -218,6 +221,10 @@ public class StarRocksSourceOptions implements Serializable {
 
     public String getBeHostMappingList() {
         return tableOptions.get(SCAN_BE_HOST_MAPPING_LIST);
+    }
+
+    public boolean isCacheEnabled() {
+        return tableOptions.get(LOOKUP_ENABLE_CACHE);
     }
 
     public long getLookupCacheMaxRows() {


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Currently, we have a `StarRocksDynamicLookupFunction` which collects all of the data on StarRocks and caches the data until it expires. It is good at handling small-scale data, but bad at handling large-scale data.

The pr rename `StarRocksDynamicLookupFunction` to `StarRocksDynamicCachedLookupFunction`, and add a new `StarRocksDynamicLookupFunction` to execute the query directly.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

