### PR TITLE
#442 Support ignoring deleted Row data when importing primary key table

### DIFF
--- a/src/main/java/com/starrocks/connector/flink/row/sink/StarRocksIRowTransformer.java
+++ b/src/main/java/com/starrocks/connector/flink/row/sink/StarRocksIRowTransformer.java
@@ -32,6 +32,6 @@ public interface StarRocksIRowTransformer<T> extends Serializable {
 
     default void setFastJsonWrapper(JsonWrapper jsonWrapper) {}
 
-    Object[] transform(T record, boolean supportUpsertDelete);
+    Object[] transform(T record, boolean supportUpsertDelete, boolean ignoreDelete);
     
 }

--- a/src/main/java/com/starrocks/connector/flink/table/sink/SinkFunctionFactory.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/SinkFunctionFactory.java
@@ -143,6 +143,7 @@ public class SinkFunctionFactory {
                     sinkOptions.getTableName(),
                     sinkOptions.supportUpsertDelete(),
                     sinkOptions.getIgnoreUpdateBefore(),
+                    sinkOptions.getIgnoreDelete(),
                     serializer,
                     rowTransformer);
             StreamLoadProperties streamLoadProperties = sinkOptions.getProperties(sinkTable);

--- a/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksDynamicSinkFunction.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksDynamicSinkFunction.java
@@ -129,7 +129,7 @@ public class StarRocksDynamicSinkFunction<T> extends StarRocksDynamicSinkFunctio
                 return;
             }
         }
-        String serializedValue = serializer.serialize(rowTransformer.transform(value, sinkOptions.supportUpsertDelete()));
+        String serializedValue = serializer.serialize(rowTransformer.transform(value, sinkOptions.supportUpsertDelete(), sinkOptions.getIgnoreDelete()));
         sinkManager.writeRecords(
                 sinkOptions.getDatabaseName(),
                 sinkOptions.getTableName(),

--- a/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksDynamicSinkFunctionV2.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksDynamicSinkFunctionV2.java
@@ -160,7 +160,7 @@ public class StarRocksDynamicSinkFunctionV2<T> extends StarRocksDynamicSinkFunct
             }
         }
         flushLegacyData();
-        String serializedValue = serializer.serialize(rowTransformer.transform(value, sinkOptions.supportUpsertDelete()));
+        String serializedValue = serializer.serialize(rowTransformer.transform(value, sinkOptions.supportUpsertDelete(), sinkOptions.getIgnoreDelete()));
         sinkManager.write(
                 null,
                 sinkOptions.getDatabaseName(),

--- a/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksSinkOptions.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksSinkOptions.java
@@ -136,6 +136,11 @@ public class StarRocksSinkOptions implements Serializable {
                     "insert the update_after row in StarRocks, and this options should be set false for this case. Note that how " +
                     "to set this options depends on the user case.");
 
+    public static final ConfigOption<Boolean> SINK_IGNORE_DELETE = ConfigOptions.key("sink.ignore.delete")
+            .booleanType().defaultValue(false).withDescription("Whether to ignore delete records. When set to true, delete operations " +
+                    "will be ignored even for tables with primary keys. This is useful when you want to keep all historical data " +
+                    "in the target table and don't want any records to be deleted. Default is false.");
+
     public static final ConfigOption<Boolean> SINK_ENABLE_EXACTLY_ONCE_LABEL_GEN = ConfigOptions.key("sink.exactly-once.enable-label-gen")
             .booleanType().defaultValue(true).withDescription("Only available when using exactly-once and sink.label-prefix is set. " +
                     "When it's true, the connector will generate label in the format '{labelPrefix}-{tableName}-{subtaskIndex}-{id}'. " +
@@ -319,6 +324,10 @@ public class StarRocksSinkOptions implements Serializable {
 
     public boolean getIgnoreUpdateBefore() {
         return tableOptions.get(SINK_IGNORE_UPDATE_BEFORE);
+    }
+
+    public boolean getIgnoreDelete() {
+        return tableOptions.get(SINK_IGNORE_DELETE);
     }
 
     public static Builder builder() {

--- a/src/main/java/com/starrocks/connector/flink/table/sink/v2/RowDataSerializationSchema.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/v2/RowDataSerializationSchema.java
@@ -39,6 +39,7 @@ public class RowDataSerializationSchema implements RecordSerializationSchema<Row
     private final String tableName;
     boolean supportUpsertDelete;
     boolean ignoreUpdateBefore;
+    boolean ignoreDelete;
     private final StarRocksISerializer serializer;
     private final StarRocksIRowTransformer<RowData> rowTransformer;
     private transient DefaultStarRocksRowData reusableRowData;
@@ -48,12 +49,14 @@ public class RowDataSerializationSchema implements RecordSerializationSchema<Row
             String tableName,
             boolean supportUpsertDelete,
             boolean ignoreUpdateBefore,
+            boolean ignoreDelete,
             StarRocksISerializer serializer,
             StarRocksIRowTransformer<RowData> rowTransformer) {
         this.databaseName = databaseName;
         this.tableName = tableName;
         this.supportUpsertDelete = supportUpsertDelete;
         this.ignoreUpdateBefore = ignoreUpdateBefore;
+        this.ignoreDelete = ignoreDelete;
         this.serializer = serializer;
         this.rowTransformer = rowTransformer;
     }
@@ -79,7 +82,7 @@ public class RowDataSerializationSchema implements RecordSerializationSchema<Row
             // let go the UPDATE_AFTER and INSERT rows for tables who have a group of `unique` or `duplicate` keys.
             return null;
         }
-        String serializedRow = serializer.serialize(rowTransformer.transform(record, supportUpsertDelete));
+        String serializedRow = serializer.serialize(rowTransformer.transform(record, supportUpsertDelete, ignoreDelete));
         reusableRowData.setRow(serializedRow);
         return reusableRowData;
     }

--- a/src/test/java/com/starrocks/connector/flink/row/sink/StarRocksGenericRowTransformerTest.java
+++ b/src/test/java/com/starrocks/connector/flink/row/sink/StarRocksGenericRowTransformerTest.java
@@ -58,7 +58,7 @@ public class StarRocksGenericRowTransformerTest extends StarRocksSinkBaseTest {
         rowTransformer.setRuntimeContext(runtimeCtx);
         rowTransformer.setTableSchema(TABLE_SCHEMA);
         UserInfoForTest rowData = createRowData();
-        String result = StarRocksSerializerFactory.createSerializer(OPTIONS, TABLE_SCHEMA.getFieldNames()).serialize(rowTransformer.transform(rowData, OPTIONS.supportUpsertDelete()));
+        String result = StarRocksSerializerFactory.createSerializer(OPTIONS, TABLE_SCHEMA.getFieldNames()).serialize(rowTransformer.transform(rowData, OPTIONS.supportUpsertDelete(), OPTIONS.getIgnoreDelete()));
 
         Map<String, String> loadProsp = OPTIONS.getSinkStreamLoadProperties();
         String format = loadProsp.get("format");

--- a/src/test/java/com/starrocks/connector/flink/row/sink/StarRocksTableRowTransformerTest.java
+++ b/src/test/java/com/starrocks/connector/flink/row/sink/StarRocksTableRowTransformerTest.java
@@ -48,7 +48,7 @@ public class StarRocksTableRowTransformerTest extends StarRocksSinkBaseTest {
         rowTransformer.setRuntimeContext(runtimeCtx);
         rowTransformer.setTableSchema(TABLE_SCHEMA);
         GenericRowData rowData = createRowData();
-        String result = StarRocksSerializerFactory.createSerializer(OPTIONS, TABLE_SCHEMA.getFieldNames()).serialize(rowTransformer.transform(rowData, OPTIONS.supportUpsertDelete()));
+        String result = StarRocksSerializerFactory.createSerializer(OPTIONS, TABLE_SCHEMA.getFieldNames()).serialize(rowTransformer.transform(rowData, OPTIONS.supportUpsertDelete(), OPTIONS.getIgnoreDelete()));
 
         Map<String, String> loadProsp = OPTIONS.getSinkStreamLoadProperties();
         String format = loadProsp.get("format");


### PR DESCRIPTION
## What type of PR is this：
- [ ] Feature


## Which issues of this PR fixes ：
It is expected that when importing the primary key table, it supports ignoring deleted Row data, especially in the case of FLink-CDC, and it is expected that the full data will be retained when importing to Starrocks.
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

