### PR TITLE
[BugFix] Add exception check in isSavepointFinished to prevent flush from skipping commit-related exceptions.

### DIFF
--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/StreamLoadManagerV2.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/StreamLoadManagerV2.java
@@ -417,6 +417,7 @@ public class StreamLoadManagerV2 implements StreamLoadManager, Serializable {
     }
 
     private boolean isSavepointFinished() {
+        AssertNotException();
         return currentCacheBytes.compareAndSet(0L, 0L) && (!enableAutoCommit || allRegionsCommitted);
     }
 


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
Fixes [#448](https://github.com/StarRocks/starrocks-connector-for-apache-flink/issues/448)

## Problem Summary(Required) ：

Add exception check in `isSavepointFinished` to prevent `flush` from skipping commit-related exceptions.

- Introduced validation in `isSavepointFinished` to check for exceptions in the `StreamLoadManager` instance's `e` property.
- Ensures that commit failures (e.g., exceptions in `doCommit`) are properly detected and handled.
- Prevents the `flush` function from incorrectly marking operations as successful when commit exceptions occur.
- Improves data integrity by avoiding false-positive flush completions that could lead to upstream and downstream data inconsistencies.
- Stabilizes Flink checkpoints by ensuring they are not marked successful during underlying commit failures.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

