### PR TITLE
[Enhancement] Adjust default chunk size according to max inflight requests

### DIFF
--- a/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksSinkOptions.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksSinkOptions.java
@@ -51,7 +51,7 @@ public class StarRocksSinkOptions implements Serializable {
 
     private static final long serialVersionUID = 1L;
     private static final long KILO_BYTES_SCALE = 1024L;
-    private static final long MEGA_BYTES_SCALE = KILO_BYTES_SCALE * KILO_BYTES_SCALE;
+    public static final long MEGA_BYTES_SCALE = KILO_BYTES_SCALE * KILO_BYTES_SCALE;
     private static final long GIGA_BYTES_SCALE = MEGA_BYTES_SCALE * KILO_BYTES_SCALE;
 
     public enum StreamLoadFormat {
@@ -541,19 +541,11 @@ public class StarRocksSinkOptions implements Serializable {
             throw new RuntimeException("data format are not support");
         }
 
-        long chunkSize;
-        boolean mergeCommit = "true".equalsIgnoreCase(streamLoadProps.get("enable_merge_commit"));
-        if (mergeCommit) {
-            chunkSize =  tableOptions.get(MergeCommitOptions.CHUNK_SIZE);
-        } else {
-            chunkSize = tableOptions.get(SINK_CHUNK_LIMIT);
-        }
-
         StreamLoadTableProperties.Builder defaultTablePropertiesBuilder = StreamLoadTableProperties.builder()
                 .database(getDatabaseName())
                 .table(getTableName())
                 .streamLoadDataFormat(dataFormat)
-                .chunkLimit(chunkSize)
+                .chunkLimit(getChunkLimit())
                 .enableUpsertDelete(supportUpsertDelete());
 
         if (hasColumnMappingProperty()) {
@@ -620,7 +612,7 @@ public class StarRocksSinkOptions implements Serializable {
                 .retryIntervalInMs(getRetryIntervalMs())
                 .sanitizeErrorLog(isSanitizeErrorLog())
                 .setBlackhole(isBlackhole());
-        MergeCommitOptions.buildMergeCommitOptions(tableOptions, streamLoadProperties, builder);
+        MergeCommitOptions.buildMergeCommitOptions(tableOptions, streamLoadProperties, defaultTablePropertiesBuilder, builder);
         defaultTablePropertiesBuilder.addCommonProperties(streamLoadProperties);
         builder.addHeaders(streamLoadProperties)
                 .defaultTableProperties(defaultTablePropertiesBuilder.build());

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/mergecommit/fe/LabelStateService.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/mergecommit/fe/LabelStateService.java
@@ -164,6 +164,7 @@ public class LabelStateService implements Closeable {
 
         LabelMeta newMeta = labelMetas.get(new LabelId(labelMeta.tableId.db, labelMeta.label));
         if (newMeta == null || newMeta != labelMeta) {
+            labelMeta.finishTimeMs = System.currentTimeMillis();
             labelMeta.future.completeExceptionally(new RuntimeException("Label is discarded"));
             LOG.error("Failed to retry to get label state because label is discarded, db: {}, table: {}, label: {}",
                     labelMeta.tableId.db, labelMeta.tableId.table, labelMeta.label);
@@ -171,6 +172,7 @@ public class LabelStateService implements Closeable {
         }
 
         if (System.currentTimeMillis() - labelMeta.createTimeMs >= labelMeta.timeoutMs) {
+            labelMeta.finishTimeMs = System.currentTimeMillis();
             labelMeta.future.completeExceptionally(new RuntimeException("Get label state timeout"));
             LOG.error("Failed to retry to get label state because of timeout, db: {}, table: {}, label: {}, timeout: {}ms",
                     labelMeta.tableId.db, labelMeta.tableId.table, labelMeta.label, labelMeta.timeoutMs);


### PR DESCRIPTION
## Why
Merge-commit performance depends on how **`chunk.size` (batch size per stream-load)** interacts with **`max-inflight-requests` (allowed concurrency)**. A fixed default chunk size can be suboptimal:
- With **multiple in-flight requests**, large chunks increase overlapping buffer/memory usage and can worsen tail latency.
- With **in-order (single in-flight)**, small chunks waste time on per-request overhead and cap throughput because latency can’t be hidden by concurrency.
 
This PR makes the default chunk sizing match the chosen concurrency model to optimize the throughput vs memory/latency tradeoff.
 
## What
- Derive `sink.merge-commit.chunk.size` dynamically from `sink.merge-commit.max-inflight-requests` **when `chunk.size` is not explicitly set**:- 
    - **async/out-of-order  (max-inflight-requests > 0)**: smaller chunks (20MB) create more requests that can be pipelined, reduce tail latency, and bound memory per outstanding request.
    - **In-order (max-inflight-requests <= 0)**: larger chunks (500MB) amortize per-request overhead and improve steady-state throughput since concurrency can’t hide latency.
 
- `sink.merge-commit.chunk.size` now has **no default** and is **fully respected** if configured by users.
- Change `sink.merge-commit.max-inflight-requests` default to **`Integer.MAX_VALUE`** and clarify that **`<= 0` means in-order**.
- Refactor merge-commit option application:
  - Build/apply `StreamLoadTableProperties` (e.g., `chunkLimit`) separately from `StreamLoadProperties` (retry, label-check, etc.).
- Minor: ensure `finishTimeMs` is set on discarded/timeout paths in `LabelStateService`.
 
## How
- Centralize chunk-size defaulting logic in merge-commit option building and remove merge-commit-specific branching from `StarRocksSinkOptions`.
- Expose `MEGA_BYTES_SCALE` publicly for consistent size conversion.
- Add/refine IT coverage for:
  - Merge-commit **async** mode
  - **backend direct** connection
  - **in-order** mode (`max-inflight-requests=0`)
- Refactor sink DDL construction helper in ITs for maintainability.

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

