### PR TITLE
[Enhancement] Refine merge commit check label state timeout

### DIFF
--- a/src/main/java/com/starrocks/connector/flink/table/sink/MergeCommitOptions.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/MergeCommitOptions.java
@@ -56,12 +56,16 @@ public class MergeCommitOptions {
             ConfigOptions.key(MERGE_COMMIT_PREFIX + "http.idle-connection-timeout-ms").intType().defaultValue(60000);
     public static final ConfigOption<Integer> NODE_META_UPDATE_INTERVAL_MS =
             ConfigOptions.key(MERGE_COMMIT_PREFIX + "node-meta.update-interval-ms").intType().defaultValue(5000);
-    public static final ConfigOption<Integer> CHECK_STATE_INIT_DELAY_MS =
-            ConfigOptions.key(MERGE_COMMIT_PREFIX + "check-state.init-delay-ms").intType().defaultValue(500);
-    public static final ConfigOption<Integer> CHECK_STATE_INTERVAL_MS =
-            ConfigOptions.key(MERGE_COMMIT_PREFIX + "check-state.interval-ms").intType().defaultValue(500);
-    public static final ConfigOption<Integer> CHECK_STATE_TIMEOUT_MS =
-            ConfigOptions.key(MERGE_COMMIT_PREFIX + "check-state.timeout-ms").intType().defaultValue(60000);
+    public static final ConfigOption<Integer> CHECK_LABEL_STATE_INIT_DELAY_MS =
+            ConfigOptions.key(MERGE_COMMIT_PREFIX + "check-label-state.init-delay-ms").intType().defaultValue(500)
+                    .withDeprecatedKeys(MERGE_COMMIT_PREFIX + "check-state.init-delay-ms");
+    public static final ConfigOption<Integer> CHECK_LABEL_STATE_INTERVAL_MS =
+            ConfigOptions.key(MERGE_COMMIT_PREFIX + "check-label-state.interval-ms").intType().defaultValue(500)
+                    .withDeprecatedKeys(MERGE_COMMIT_PREFIX + "check-state.interval-ms");
+    public static final ConfigOption<Integer> CHECK_LABEL_STATE_TIMEOUT_MS =
+            ConfigOptions.key(MERGE_COMMIT_PREFIX + "check-label-state.timeout-ms").intType().noDefaultValue()
+                    .withDeprecatedKeys(MERGE_COMMIT_PREFIX + "check-state.timeout-ms")
+                    .withDescription("If not set, will use stream load timeout instead");
     public static final ConfigOption<Boolean> BACKEND_DIRECT_CONNECTION =
             ConfigOptions.key(MERGE_COMMIT_PREFIX + "backend-direct-connection").booleanType().defaultValue(false);
 
@@ -108,11 +112,10 @@ public class MergeCommitOptions {
                 defaultTablePropertiesBuilder.chunkLimit(chunkSize);
             }
 
-            // set reties to 0 to release memory as soon as possible and improve performance
+            // set reties to 0 by default to release memory as soon as possible and improve performance
             int maxRetries = options.getOptional(StarRocksSinkOptions.SINK_MAX_RETRIES).orElse(0);
-            streamLoadPropertiesBuilder.setCheckLabelInitDelayMs(options.get(CHECK_STATE_INIT_DELAY_MS))
-                    .setCheckLabelIntervalMs(options.get(CHECK_STATE_INTERVAL_MS))
-                    .setCheckLabelTimeoutMs(options.get(CHECK_STATE_TIMEOUT_MS))
+            streamLoadPropertiesBuilder.setCheckLabelStateInitDelayMs(options.get(CHECK_LABEL_STATE_INIT_DELAY_MS))
+                    .setCheckLabelStateIntervalMs(options.get(CHECK_LABEL_STATE_INTERVAL_MS))
                     .setHttpThreadNum(options.get(HTTP_THREAD_NUM))
                     .setHttpMaxConnectionsPerRoute(options.get(HTTP_MAX_CONNECTIONS))
                     .setHttpTotalMaxConnections(options.get(HTTP_TOTAL_MAX_CONNECTIONS))
@@ -121,6 +124,7 @@ public class MergeCommitOptions {
                     .setMaxInflightRequests(options.get(MAX_INFLIGHT_REQUESTS))
                     .setBackendDirectConnection(options.get(BACKEND_DIRECT_CONNECTION))
                     .maxRetries(maxRetries);
+            options.getOptional(CHECK_LABEL_STATE_TIMEOUT_MS).ifPresent(streamLoadPropertiesBuilder::setCheckLabelStateTimeoutMs);
         }
     }
 }

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/mergecommit/LoadParameters.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/mergecommit/LoadParameters.java
@@ -22,72 +22,25 @@ import com.starrocks.data.load.stream.StreamLoadDataFormat;
 import com.starrocks.data.load.stream.compress.LZ4FrameCompressionCodec;
 import com.starrocks.data.load.stream.properties.StreamLoadTableProperties;
 
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-// Keep inconsistent with fe/fe-core/src/main/java/com/starrocks/data/load/streamload/StreamLoadHttpHeader.java
 public class LoadParameters {
 
-    public static final String HTTP_FORMAT = "format";
-    public static final String HTTP_COLUMNS = "columns";
-    public static final String HTTP_WHERE = "where";
-    public static final String HTTP_MAX_FILTER_RATIO = "max_filter_ratio";
-    public static final String HTTP_TIMEOUT = "timeout";
-    public static final String HTTP_PARTITIONS = "partitions";
-    public static final String HTTP_TEMP_PARTITIONS = "temporary_partitions";
-    public static final String HTTP_NEGATIVE = "negative";
-    public static final String HTTP_STRICT_MODE = "strict_mode";
-    public static final String HTTP_TIMEZONE = "timezone";
-    public static final String HTTP_LOAD_MEM_LIMIT = "load_mem_limit";
-    public static final String HTTP_PARTIAL_UPDATE = "partial_update";
-    public static final String HTTP_PARTIAL_UPDATE_MODE = "partial_update_mode";
-    public static final String HTTP_TRANSMISSION_COMPRESSION_TYPE = "transmission_compression_type";
-    public static final String HTTP_LOAD_DOP = "load_dop";
-    public static final String HTTP_ENABLE_REPLICATED_STORAGE = "enable_replicated_storage";
-    public static final String HTTP_MERGE_CONDITION = "merge_condition";
-    public static final String HTTP_LOG_REJECTED_RECORD_NUM = "log_rejected_record_num";
-    public static final String HTTP_COMPRESSION = "compression";
-    public static final String HTTP_WAREHOUSE = "warehouse";
+    public static final String TIMEOUT = "timeout";
+    public static final int DEFAULT_TIMEOUT_SECONDS = 600;
 
-    // Headers for csv format ============================
-    public static final String HTTP_COLUMN_SEPARATOR = "column_separator";
-    public static final String HTTP_ROW_DELIMITER = "row_delimiter";
-    public static final String HTTP_SKIP_HEADER = "skip_header";
-    public static final String HTTP_TRIM_SPACE = "trim_space";
-    public static final String HTTP_ENCLOSE = "enclose";
-    public static final String HTTP_ESCAPE = "escape";
-
-    // Headers for json format ===========================
-    public static final String HTTP_JSONPATHS = "jsonpaths";
-    public static final String HTTP_JSONROOT = "json_root";
-    public static final String HTTP_STRIP_OUTER_ARRAY = "strip_outer_array";
-
-    // Headers for batch write ==========================
-    public static final String HTTP_ENABLE_BATCH_WRITE = "enable_merge_commit";
-    public static final String HTTP_BATCH_WRITE_ASYNC = "merge_commit_async";
-    public static final String HTTP_BATCH_WRITE_INTERVAL_MS = "merge_commit_interval_ms";
-    public static final String HTTP_BATCH_WRITE_PARALLEL = "merge_commit_parallel";
-
-    public static final List<String> HTTP_HEADER_LIST = Arrays.asList(
-            HTTP_FORMAT, HTTP_COLUMNS, HTTP_WHERE, HTTP_COLUMN_SEPARATOR, HTTP_ROW_DELIMITER, HTTP_SKIP_HEADER,
-            HTTP_TRIM_SPACE, HTTP_ENCLOSE, HTTP_ESCAPE, HTTP_MAX_FILTER_RATIO, HTTP_TIMEOUT, HTTP_PARTITIONS,
-            HTTP_TEMP_PARTITIONS, HTTP_NEGATIVE, HTTP_STRICT_MODE, HTTP_TIMEZONE, HTTP_LOAD_MEM_LIMIT,
-            HTTP_JSONPATHS, HTTP_JSONROOT, HTTP_STRIP_OUTER_ARRAY, HTTP_PARTIAL_UPDATE, HTTP_PARTIAL_UPDATE_MODE,
-            HTTP_TRANSMISSION_COMPRESSION_TYPE, HTTP_LOAD_DOP, HTTP_ENABLE_REPLICATED_STORAGE, HTTP_MERGE_CONDITION,
-            HTTP_LOG_REJECTED_RECORD_NUM, HTTP_COMPRESSION, HTTP_WAREHOUSE, HTTP_ENABLE_BATCH_WRITE,
-            HTTP_BATCH_WRITE_ASYNC, HTTP_BATCH_WRITE_INTERVAL_MS, HTTP_BATCH_WRITE_PARALLEL
-    );
+    public static final String ENABLE_MERGE_COMMIT = "enable_merge_commit";
+    public static final String MERGE_COMMIT_ASYNC = "merge_commit_async";
 
     public static Map<String, String> getParameters(StreamLoadTableProperties properties) {
         Map<String, String> parameters = new HashMap<>();
-        for (String name : HTTP_HEADER_LIST) {
-            Optional<String> value = properties.getProperty(name);
-            value.ifPresent(s -> parameters.put(name, s));
+        parameters.putAll(properties.getCommonProperties());
+        parameters.putAll(properties.getProperties());
+        if (!parameters.containsKey(TIMEOUT)) {
+            parameters.put(TIMEOUT, String.valueOf(DEFAULT_TIMEOUT_SECONDS));
         }
-
         Optional<String> compressionType = properties.getProperty("compression");
         // To enable csv compression, at the connector side, the user need to set two properties:
         // "format = csv" and "compression = <compression type>". It needs to be converted to one

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/mergecommit/MergeCommitManager.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/mergecommit/MergeCommitManager.java
@@ -52,14 +52,11 @@ public class MergeCommitManager implements StreamLoadManager, Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private static final int DEFAULT_FLUSH_TIMEOUT_MS = 180000;
-
     private final StreamLoadProperties properties;
     private final MergeCommitLoader mergeCommitLoader;
     private final int maxRetries;
     private final int retryIntervalInMs;
     private final int flushIntervalMs;
-    private final int flushTimeoutMs;
     private final long maxCacheBytes;
     private final long maxWriteBlockCacheBytes;
     private final Map<TableId, Table> tables = new ConcurrentHashMap<>();
@@ -78,8 +75,6 @@ public class MergeCommitManager implements StreamLoadManager, Serializable {
         this.maxRetries = properties.getMaxRetries();
         this.retryIntervalInMs = properties.getRetryIntervalInMs();
         this.flushIntervalMs = (int) properties.getExpectDelayTime();
-        String timeout = properties.getHeaders().get("timeout");
-        this.flushTimeoutMs = timeout != null ? Integer.parseInt(timeout) * 1000 : DEFAULT_FLUSH_TIMEOUT_MS;
         this.maxCacheBytes = properties.getMaxCacheBytes();
         this.maxWriteBlockCacheBytes = 2 * maxCacheBytes;
         this.exception = new AtomicReference<>();
@@ -298,7 +293,7 @@ public class MergeCommitManager implements StreamLoadManager, Serializable {
             StreamLoadTableProperties tableProperties = properties.getTableProperties(
                     StreamLoadUtils.getTableUniqueKey(database, tableName), database, tableName);
             table = new Table(database, tableName, this, mergeCommitLoader,
-                    tableProperties, maxRetries, retryIntervalInMs, flushIntervalMs, flushTimeoutMs,
+                    tableProperties, maxRetries, retryIntervalInMs, flushIntervalMs,
                     properties.getDefaultTableProperties().getChunkLimit(), properties.getMaxInflightRequests());
             tables.put(tableId, table);
         }

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/mergecommit/fe/LabelStateService.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/mergecommit/fe/LabelStateService.java
@@ -165,7 +165,7 @@ public class LabelStateService implements Closeable {
         LabelMeta newMeta = labelMetas.get(new LabelId(labelMeta.tableId.db, labelMeta.label));
         if (newMeta == null || newMeta != labelMeta) {
             labelMeta.finishTimeMs = System.currentTimeMillis();
-            labelMeta.future.completeExceptionally(new RuntimeException("Label is discarded"));
+            labelMeta.future.completeExceptionally(new RuntimeException(String.format("Label %s is discarded", labelMeta.label)));
             LOG.error("Failed to retry to get label state because label is discarded, db: {}, table: {}, label: {}",
                     labelMeta.tableId.db, labelMeta.tableId.table, labelMeta.label);
             return;
@@ -173,7 +173,8 @@ public class LabelStateService implements Closeable {
 
         if (System.currentTimeMillis() - labelMeta.createTimeMs >= labelMeta.timeoutMs) {
             labelMeta.finishTimeMs = System.currentTimeMillis();
-            labelMeta.future.completeExceptionally(new RuntimeException("Get label state timeout"));
+            labelMeta.future.completeExceptionally(new RuntimeException(
+                    String.format("Get label state timeout, label: %s, timeout: %sms", labelMeta.label, labelMeta.timeoutMs)));
             LOG.error("Failed to retry to get label state because of timeout, db: {}, table: {}, label: {}, timeout: {}ms",
                     labelMeta.tableId.db, labelMeta.tableId.table, labelMeta.label, labelMeta.timeoutMs);
             return;

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/mergecommit/fe/RequestStat.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/mergecommit/fe/RequestStat.java
@@ -44,6 +44,7 @@ public class RequestStat {
         this.windowSizeMs = windowSizeMs;
         this.logger = logger;
         this.startTimeMs = System.currentTimeMillis();
+        this.lastWindowStartMs.set(startTimeMs);
     }
 
     public void addRequest(long latencyNs) {

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/properties/StreamLoadProperties.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/properties/StreamLoadProperties.java
@@ -94,9 +94,9 @@ public class StreamLoadProperties implements Serializable {
     private final boolean sanitizeErrorLog;
 
     // options for merge commit ============================
-    private final int checkLabelInitDelayMs;
-    private final int checkLabelIntervalMs;
-    private final int checkLabelTimeoutMs;
+    private final int checkLabelStateInitDelayMs;
+    private final int checkLabelStateIntervalMs;
+    private final int checkLabelStateTimeoutMs;
     private final int httpThreadNum;
     private final int httpMaxConnectionsPerRoute;
     private final int httpTotalMaxConnections;
@@ -140,9 +140,9 @@ public class StreamLoadProperties implements Serializable {
 
         this.headers = Collections.unmodifiableMap(builder.headers);
         this.sanitizeErrorLog = builder.sanitizeErrorLog;
-        this.checkLabelInitDelayMs = builder.checkLabelInitDelayMs;
-        this.checkLabelIntervalMs = builder.checkLabelIntervalMs;
-        this.checkLabelTimeoutMs = builder.checkLabelTimeoutMs;
+        this.checkLabelStateInitDelayMs = builder.checkLabelStateInitDelayMs;
+        this.checkLabelStateIntervalMs = builder.checkLabelStateIntervalMs;
+        this.checkLabelStateTimeoutMs = builder.checkLabelStateTimeoutMs;
         this.httpThreadNum = builder.httpThreadNum;
         this.httpMaxConnectionsPerRoute = builder.httpMaxConnectionsPerRoute;
         this.httpTotalMaxConnections = builder.httpTotalMaxConnections;
@@ -268,16 +268,16 @@ public class StreamLoadProperties implements Serializable {
         return sanitizeErrorLog;
     }
 
-    public int getCheckLabelInitDelayMs() {
-        return checkLabelInitDelayMs;
+    public int getCheckLabelStateInitDelayMs() {
+        return checkLabelStateInitDelayMs;
     }
 
-    public int getCheckLabelIntervalMs() {
-        return checkLabelIntervalMs;
+    public int getCheckLabelStateIntervalMs() {
+        return checkLabelStateIntervalMs;
     }
 
-    public int getCheckLabelTimeoutMs() {
-        return checkLabelTimeoutMs;
+    public int getCheckLabelStateTimeoutMs() {
+        return checkLabelStateTimeoutMs;
     }
 
     public int getHttpThreadNum() {
@@ -347,16 +347,17 @@ public class StreamLoadProperties implements Serializable {
         private int maxRetries = 0;
         private int retryIntervalInMs = 10000;
         private Map<String, String> headers = new HashMap<>();
-        private int checkLabelInitDelayMs = 300;
-        private int checkLabelIntervalMs = 200;
-        private int checkLabelTimeoutMs = 60000;
+
+        // merge commit options
+        private int checkLabelStateInitDelayMs = 500;
+        private int checkLabelStateIntervalMs = 500;
+        private int checkLabelStateTimeoutMs = -1;
         private int httpThreadNum = 3;
         private int httpMaxConnectionsPerRoute = 3;
         private int httpTotalMaxConnections = 30;
         private int httpIdleConnectionTimeoutMs = 60000;
         private int nodeMetaUpdateIntervalMs = 2000;
         private int maxInflightRequests = -1;
-        private String protocol = "http";
         private boolean backendDirectConnection = false;
         private boolean blackhole = false;
 
@@ -529,18 +530,18 @@ public class StreamLoadProperties implements Serializable {
             return this;
         }
 
-        public Builder setCheckLabelInitDelayMs(int checkLabelInitDelayMs) {
-            this.checkLabelInitDelayMs = checkLabelInitDelayMs;
+        public Builder setCheckLabelStateInitDelayMs(int checkLabelStateInitDelayMs) {
+            this.checkLabelStateInitDelayMs = checkLabelStateInitDelayMs;
             return this;
         }
 
-        public Builder setCheckLabelIntervalMs(int checkLabelIntervalMs) {
-            this.checkLabelIntervalMs = checkLabelIntervalMs;
+        public Builder setCheckLabelStateIntervalMs(int checkLabelStateIntervalMs) {
+            this.checkLabelStateIntervalMs = checkLabelStateIntervalMs;
             return this;
         }
 
-        public Builder setCheckLabelTimeoutMs(int checkLabelTimeoutMs) {
-            this.checkLabelTimeoutMs = checkLabelTimeoutMs;
+        public Builder setCheckLabelStateTimeoutMs(int checkLabelStateTimeoutMs) {
+            this.checkLabelStateTimeoutMs = checkLabelStateTimeoutMs;
             return this;
         }
 
@@ -571,11 +572,6 @@ public class StreamLoadProperties implements Serializable {
 
         public Builder setMaxInflightRequests(int maxInflightRequests) {
             this.maxInflightRequests = maxInflightRequests;
-            return this;
-        }
-
-        public Builder setProtocol(String protocol) {
-            this.protocol = protocol;
             return this;
         }
 

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/StreamLoadManagerV2.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/StreamLoadManagerV2.java
@@ -25,6 +25,7 @@ import com.starrocks.data.load.stream.StreamLoadManager;
 import com.starrocks.data.load.stream.StreamLoadResponse;
 import com.starrocks.data.load.stream.StreamLoadSnapshot;
 import com.starrocks.data.load.stream.StreamLoader;
+import com.starrocks.data.load.stream.mergecommit.LoadParameters;
 import com.starrocks.data.load.stream.mergecommit.MergeCommitManager;
 import com.starrocks.data.load.stream.mergecommit.MetricListener;
 import com.starrocks.data.load.stream.properties.StreamLoadProperties;
@@ -37,7 +38,7 @@ public class StreamLoadManagerV2 implements StreamLoadManager, Serializable {
 
     public StreamLoadManagerV2(StreamLoadProperties properties, boolean enableAutoCommit) {
         boolean enableMergeCommit = properties.getHeaders()
-                .getOrDefault("enable_merge_commit", "false").equalsIgnoreCase("true");
+                .getOrDefault(LoadParameters.ENABLE_MERGE_COMMIT, "false").equalsIgnoreCase("true");
         this.delegateManager = enableMergeCommit ? new MergeCommitManager(properties)
                 : new DefaultStreamLoadManager(properties, enableAutoCommit);
     }

--- a/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/StreamLoadPropertiesTest.java
+++ b/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/StreamLoadPropertiesTest.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.starrocks.data.load.stream;
+
+import com.starrocks.data.load.stream.properties.StreamLoadProperties;
+import com.starrocks.data.load.stream.properties.StreamLoadTableProperties;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class StreamLoadPropertiesTest {
+
+    private StreamLoadProperties.Builder createBaseBuilder() {
+        return StreamLoadProperties.builder()
+                .jdbcUrl("jdbc:mysql://localhost:9030")
+                .loadUrls("http://localhost:8030")
+                .username("root")
+                .password("")
+                .defaultTableProperties(StreamLoadTableProperties.builder()
+                        .database("db").table("tbl").build());
+    }
+
+    @Test
+    public void testCheckLabelStateDefaultValues() {
+        StreamLoadProperties props = createBaseBuilder().build();
+
+        // Verify default values for check label state options
+        assertEquals(500, props.getCheckLabelStateInitDelayMs());
+        assertEquals(500, props.getCheckLabelStateIntervalMs());
+        assertEquals(-1, props.getCheckLabelStateTimeoutMs());
+    }
+
+    @Test
+    public void testSetCheckLabelStateInitDelayMs() {
+        StreamLoadProperties props = createBaseBuilder()
+                .setCheckLabelStateInitDelayMs(1000)
+                .build();
+
+        assertEquals(1000, props.getCheckLabelStateInitDelayMs());
+    }
+
+    @Test
+    public void testSetCheckLabelStateIntervalMs() {
+        StreamLoadProperties props = createBaseBuilder()
+                .setCheckLabelStateIntervalMs(2000)
+                .build();
+
+        assertEquals(2000, props.getCheckLabelStateIntervalMs());
+    }
+
+    @Test
+    public void testSetCheckLabelStateTimeoutMs() {
+        StreamLoadProperties props = createBaseBuilder()
+                .setCheckLabelStateTimeoutMs(60000)
+                .build();
+
+        assertEquals(60000, props.getCheckLabelStateTimeoutMs());
+    }
+
+    @Test
+    public void testSetAllCheckLabelStateOptions() {
+        StreamLoadProperties props = createBaseBuilder()
+                .setCheckLabelStateInitDelayMs(100)
+                .setCheckLabelStateIntervalMs(200)
+                .setCheckLabelStateTimeoutMs(30000)
+                .build();
+
+        assertEquals(100, props.getCheckLabelStateInitDelayMs());
+        assertEquals(200, props.getCheckLabelStateIntervalMs());
+        assertEquals(30000, props.getCheckLabelStateTimeoutMs());
+    }
+
+    @Test
+    public void testMergeCommitHttpOptions() {
+        StreamLoadProperties props = createBaseBuilder()
+                .setHttpThreadNum(5)
+                .setHttpMaxConnectionsPerRoute(10)
+                .setHttpTotalMaxConnections(50)
+                .setHttpIdleConnectionTimeoutMs(30000)
+                .setNodeMetaUpdateIntervalMs(3000)
+                .setMaxInflightRequests(100)
+                .setBackendDirectConnection(true)
+                .build();
+
+        assertEquals(5, props.getHttpThreadNum());
+        assertEquals(10, props.getHttpMaxConnectionsPerRoute());
+        assertEquals(50, props.getHttpTotalMaxConnections());
+        assertEquals(30000, props.getHttpIdleConnectionTimeoutMs());
+        assertEquals(3000, props.getNodeMetaUpdateIntervalMs());
+        assertEquals(100, props.getMaxInflightRequests());
+        assertEquals(true, props.isBackendDirectConnection());
+    }
+
+    @Test
+    public void testMergeCommitHttpOptionsDefaultValues() {
+        StreamLoadProperties props = createBaseBuilder().build();
+
+        assertEquals(3, props.getHttpThreadNum());
+        assertEquals(3, props.getHttpMaxConnectionsPerRoute());
+        assertEquals(30, props.getHttpTotalMaxConnections());
+        assertEquals(60000, props.getHttpIdleConnectionTimeoutMs());
+        assertEquals(2000, props.getNodeMetaUpdateIntervalMs());
+        assertEquals(-1, props.getMaxInflightRequests());
+        assertFalse(props.isBackendDirectConnection());
+    }
+
+    @Test
+    public void testBlackholeOption() {
+        StreamLoadProperties props = createBaseBuilder()
+                .setBlackhole(true)
+                .build();
+
+        assertEquals(true, props.isBlackhole());
+    }
+
+    @Test
+    public void testBlackholeDefaultValue() {
+        StreamLoadProperties props = createBaseBuilder().build();
+
+        assertFalse(props.isBlackhole());
+    }
+}

--- a/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/mergecommit/LoadParametersTest.java
+++ b/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/mergecommit/LoadParametersTest.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.starrocks.data.load.stream.mergecommit;
+
+import com.starrocks.data.load.stream.StreamLoadDataFormat;
+import com.starrocks.data.load.stream.properties.StreamLoadTableProperties;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class LoadParametersTest {
+
+    private Map<String, String> createMap(String... keyValues) {
+        Map<String, String> map = new HashMap<>();
+        for (int i = 0; i < keyValues.length; i += 2) {
+            map.put(keyValues[i], keyValues[i + 1]);
+        }
+        return map;
+    }
+
+    @Test
+    public void testConstants() {
+        assertEquals("timeout", LoadParameters.TIMEOUT);
+        assertEquals(600, LoadParameters.DEFAULT_TIMEOUT_SECONDS);
+        assertEquals("enable_merge_commit", LoadParameters.ENABLE_MERGE_COMMIT);
+        assertEquals("merge_commit_async", LoadParameters.MERGE_COMMIT_ASYNC);
+    }
+
+    @Test
+    public void testGetParametersWithDefaultTimeout() {
+        StreamLoadTableProperties properties = StreamLoadTableProperties.builder()
+                .database("db")
+                .table("table")
+                .streamLoadDataFormat(StreamLoadDataFormat.JSON)
+                .build();
+
+        Map<String, String> parameters = LoadParameters.getParameters(properties);
+
+        // Should contain default timeout
+        assertEquals(String.valueOf(LoadParameters.DEFAULT_TIMEOUT_SECONDS), parameters.get(LoadParameters.TIMEOUT));
+    }
+
+    @Test
+    public void testGetParametersWithCustomTimeout() {
+        StreamLoadTableProperties properties = StreamLoadTableProperties.builder()
+                .database("db")
+                .table("table")
+                .streamLoadDataFormat(StreamLoadDataFormat.JSON)
+                .addProperty("timeout", "300")
+                .build();
+
+        Map<String, String> parameters = LoadParameters.getParameters(properties);
+
+        // Should use custom timeout
+        assertEquals("300", parameters.get(LoadParameters.TIMEOUT));
+    }
+
+    @Test
+    public void testGetParametersWithCommonProperties() {
+        StreamLoadTableProperties properties = StreamLoadTableProperties.builder()
+                .database("db")
+                .table("table")
+                .streamLoadDataFormat(StreamLoadDataFormat.JSON)
+                .addCommonProperties(createMap("key1", "value1", "key2", "value2"))
+                .build();
+
+        Map<String, String> parameters = LoadParameters.getParameters(properties);
+
+        // Should contain common properties
+        assertEquals("value1", parameters.get("key1"));
+        assertEquals("value2", parameters.get("key2"));
+    }
+
+    @Test
+    public void testGetParametersWithPropertiesOverrideCommon() {
+        StreamLoadTableProperties properties = StreamLoadTableProperties.builder()
+                .database("db")
+                .table("table")
+                .streamLoadDataFormat(StreamLoadDataFormat.JSON)
+                .addCommonProperties(createMap("key1", "common_value"))
+                .addProperty("key1", "specific_value")
+                .build();
+
+        Map<String, String> parameters = LoadParameters.getParameters(properties);
+
+        // Specific properties should override common properties
+        assertEquals("specific_value", parameters.get("key1"));
+    }
+
+    @Test
+    public void testGetParametersWithTimeoutInCommonProperties() {
+        StreamLoadTableProperties properties = StreamLoadTableProperties.builder()
+                .database("db")
+                .table("table")
+                .streamLoadDataFormat(StreamLoadDataFormat.JSON)
+                .addCommonProperties(createMap("timeout", "120"))
+                .build();
+
+        Map<String, String> parameters = LoadParameters.getParameters(properties);
+
+        // Should use timeout from common properties
+        assertEquals("120", parameters.get(LoadParameters.TIMEOUT));
+    }
+
+    @Test
+    public void testGetParametersWithCsvLz4Compression() {
+        StreamLoadTableProperties properties = StreamLoadTableProperties.builder()
+                .database("db")
+                .table("table")
+                .streamLoadDataFormat(StreamLoadDataFormat.CSV)
+                .addProperty("compression", "lz4_frame")
+                .build();
+
+        Map<String, String> parameters = LoadParameters.getParameters(properties);
+
+        // Should convert CSV compression to format=lz4
+        assertEquals("lz4", parameters.get("format"));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testGetParametersWithCsvUnsupportedCompression() {
+        StreamLoadTableProperties properties = StreamLoadTableProperties.builder()
+                .database("db")
+                .table("table")
+                .streamLoadDataFormat(StreamLoadDataFormat.CSV)
+                .addProperty("compression", "gzip")
+                .build();
+
+        // Should throw UnsupportedOperationException
+        LoadParameters.getParameters(properties);
+    }
+
+    @Test
+    public void testGetParametersContainsDbAndTable() {
+        StreamLoadTableProperties properties = StreamLoadTableProperties.builder()
+                .database("test_db")
+                .table("test_table")
+                .streamLoadDataFormat(StreamLoadDataFormat.JSON)
+                .build();
+
+        Map<String, String> parameters = LoadParameters.getParameters(properties);
+
+        // Should contain db and table
+        assertEquals("test_db", parameters.get("db"));
+        assertEquals("test_table", parameters.get("table"));
+    }
+}

--- a/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/mergecommit/TableTest.java
+++ b/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/mergecommit/TableTest.java
@@ -1,0 +1,239 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.starrocks.data.load.stream.mergecommit;
+
+import com.starrocks.data.load.stream.StreamLoadDataFormat;
+import com.starrocks.data.load.stream.StreamLoadManager;
+import com.starrocks.data.load.stream.properties.StreamLoadProperties;
+import com.starrocks.data.load.stream.properties.StreamLoadTableProperties;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ScheduledFuture;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class TableTest {
+
+    /**
+     * Mock MergeCommitLoader for testing
+     */
+    private static class MockMergeCommitLoader extends MergeCommitLoader {
+        @Override
+        public ScheduledFuture<?> scheduleFlush(Table table, long chunkId, int delayMs) {
+            return null;
+        }
+
+        @Override
+        public void sendLoad(LoadRequest.RequestRun requestRun, int delayMs) {
+            // no-op
+        }
+
+        @Override
+        public void start(StreamLoadProperties properties, StreamLoadManager manager) {
+            // no-op
+        }
+
+        @Override
+        public void close() {
+            // no-op
+        }
+    }
+
+    /**
+     * Mock MergeCommitManager for testing
+     */
+    private static class MockMergeCommitManager extends MergeCommitManager {
+        public MockMergeCommitManager() {
+            super(createMinimalProperties());
+        }
+
+        private static StreamLoadProperties createMinimalProperties() {
+            return StreamLoadProperties.builder()
+                    .loadUrls("http://localhost:8030")
+                    .username("root")
+                    .password("")
+                    .defaultTableProperties(StreamLoadTableProperties.builder()
+                            .database("db").table("tbl").build())
+                    .build();
+        }
+
+        @Override
+        public void onLoadStart(Table table, long dataSize, int numRows) {
+            // no-op
+        }
+
+        @Override
+        public void onLoadSuccess(Table table, LoadRequest request) {
+            // no-op
+        }
+
+        @Override
+        public void onLoadFailure(Table table, LoadRequest request, Throwable throwable) {
+            // no-op
+        }
+
+        @Override
+        public void releaseCache(LoadRequest request) {
+            // no-op
+        }
+    }
+
+    private Map<String, String> createMap(String... keyValues) {
+        Map<String, String> map = new HashMap<>();
+        for (int i = 0; i < keyValues.length; i += 2) {
+            map.put(keyValues[i], keyValues[i + 1]);
+        }
+        return map;
+    }
+
+    private Table createTable(StreamLoadTableProperties properties) {
+        return new Table(
+                properties.getDatabase(),
+                properties.getTable(),
+                new MockMergeCommitManager(),
+                new MockMergeCommitLoader(),
+                properties,
+                3,      // maxRetries
+                1000,   // retryIntervalInMs
+                5000,   // flushIntervalMs
+                1024 * 1024, // chunkSize
+                10      // maxInflightRequests
+        );
+    }
+
+    @Test
+    public void testGetLoadTimeoutMsWithDefaultTimeout() {
+        StreamLoadTableProperties properties = StreamLoadTableProperties.builder()
+                .database("db")
+                .table("table")
+                .streamLoadDataFormat(StreamLoadDataFormat.JSON)
+                .build();
+
+        Table table = createTable(properties);
+
+        // Default timeout is 600 seconds = 600000 ms
+        assertEquals(LoadParameters.DEFAULT_TIMEOUT_SECONDS * 1000, table.getLoadTimeoutMs());
+    }
+
+    @Test
+    public void testGetLoadTimeoutMsWithCustomTimeout() {
+        StreamLoadTableProperties properties = StreamLoadTableProperties.builder()
+                .database("db")
+                .table("table")
+                .streamLoadDataFormat(StreamLoadDataFormat.JSON)
+                .addProperty("timeout", "300")
+                .build();
+
+        Table table = createTable(properties);
+
+        // Custom timeout is 300 seconds = 300000 ms
+        assertEquals(300 * 1000, table.getLoadTimeoutMs());
+    }
+
+    @Test
+    public void testGetLoadTimeoutMsWithTimeoutInCommonProperties() {
+        StreamLoadTableProperties properties = StreamLoadTableProperties.builder()
+                .database("db")
+                .table("table")
+                .streamLoadDataFormat(StreamLoadDataFormat.JSON)
+                .addCommonProperties(createMap("timeout", "120"))
+                .build();
+
+        Table table = createTable(properties);
+
+        // Timeout from common properties is 120 seconds = 120000 ms
+        assertEquals(120 * 1000, table.getLoadTimeoutMs());
+    }
+
+    @Test
+    public void testGetLoadParameters() {
+        StreamLoadTableProperties properties = StreamLoadTableProperties.builder()
+                .database("db")
+                .table("table")
+                .streamLoadDataFormat(StreamLoadDataFormat.JSON)
+                .addProperty("key1", "value1")
+                .build();
+
+        Table table = createTable(properties);
+
+        Map<String, String> params = table.getLoadParameters();
+        assertEquals("value1", params.get("key1"));
+        assertEquals("db", params.get("db"));
+        assertEquals("table", params.get("table"));
+    }
+
+    @Test
+    public void testIsMergeCommitAsyncDefault() {
+        StreamLoadTableProperties properties = StreamLoadTableProperties.builder()
+                .database("db")
+                .table("table")
+                .streamLoadDataFormat(StreamLoadDataFormat.JSON)
+                .build();
+
+        Table table = createTable(properties);
+
+        // Default should be false
+        assertFalse(table.isMergeCommitAsync());
+    }
+
+    @Test
+    public void testIsMergeCommitAsyncTrue() {
+        StreamLoadTableProperties properties = StreamLoadTableProperties.builder()
+                .database("db")
+                .table("table")
+                .streamLoadDataFormat(StreamLoadDataFormat.JSON)
+                .addProperty("merge_commit_async", "true")
+                .build();
+
+        Table table = createTable(properties);
+
+        assertTrue(table.isMergeCommitAsync());
+    }
+
+    @Test
+    public void testGetDatabaseAndTable() {
+        StreamLoadTableProperties properties = StreamLoadTableProperties.builder()
+                .database("test_db")
+                .table("test_table")
+                .streamLoadDataFormat(StreamLoadDataFormat.JSON)
+                .build();
+
+        Table table = createTable(properties);
+
+        assertEquals("test_db", table.getDatabase());
+        assertEquals("test_table", table.getTable());
+    }
+
+    @Test
+    public void testGetProperties() {
+        StreamLoadTableProperties properties = StreamLoadTableProperties.builder()
+                .database("db")
+                .table("table")
+                .streamLoadDataFormat(StreamLoadDataFormat.JSON)
+                .build();
+
+        Table table = createTable(properties);
+
+        assertEquals(properties, table.getProperties());
+    }
+}


### PR DESCRIPTION
## Why

Merge-commit async label-state checking and stream-load timeout handling had confusing/incorrect configuration behavior and unit inconsistencies (seconds vs ms). This could lead to:
- Wrong async-mode detection due to using the wrong config key
- Premature client-side timeouts when `timeout` is configured in seconds but treated as milliseconds
- Incorrect default timeout being sent to StarRocks (server expects seconds)
- Unclear/faulty fallback behavior when server responses omit `leftTimeMs`

## What

- Renamed configuration keys from `check-state.*` to `check-label-state.*` and updated `MergeCommitOptions` / `StreamLoadProperties` builder APIs.
- Made `check-label-state.timeout-ms` optional:
  - If set: use it as an extra buffer for label-state checking.
  - If unset: fall back to the per-table stream load timeout derived from the stream load `timeout` header (default 600s).
- Refactored merge-commit timeout usage to remove a global flush timeout and rely on per-table `loadTimeoutMs` for inflight wait logic.
- Improved parameter handling in `LoadParameters`:
  - Merge common + specific properties consistently
  - Ensure a correct default `timeout` behavior (seconds for server headers)
  - Map CSV `compression=lz4_frame` to `format=lz4` where appropriate
- Minor robustness/clarity fixes:
  - Clearer `LabelStateService` error messages
  - Initialize `RequestStat` window start correctly
  - Use constants in `StreamLoadManagerV2`
- Added/updated unit tests for new option parsing, timeout derivation, and parameter mapping.

## How

- **Config + API**: Introduced `check-label-state.*` keys and migrated option/property accessors/builders.
- **Timeout model**:
  - Treat stream load `timeout` as **seconds** for server communication.
  - Derive a per-table `loadTimeoutMs` (seconds × 1000) for client-side waits.
  - In async label-state waiting:
    - If server returns `leftTimeMs`, schedule using that value plus optional client buffer.
    - If server does **not** return `leftTimeMs`, do **not** ignore user config; apply a sensible fallback based on per-table load timeout plus buffer semantics.
- **Safety**: Avoid sending millisecond defaults as the HTTP `timeout` header (server expects seconds).

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

