### PR TITLE
[Enhancement] Enforce merge-commit max concurrent requests and rename config key

### DIFF
--- a/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksSinkOptions.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksSinkOptions.java
@@ -26,6 +26,7 @@ import org.apache.flink.util.Preconditions;
 import com.starrocks.connector.flink.manager.StarRocksSinkTable;
 import com.starrocks.connector.flink.row.sink.StarRocksDelimiterParser;
 import com.starrocks.data.load.stream.StreamLoadDataFormat;
+import com.starrocks.data.load.stream.mergecommit.LoadParameters;
 import com.starrocks.data.load.stream.properties.StreamLoadProperties;
 import com.starrocks.data.load.stream.properties.StreamLoadTableProperties;
 import org.slf4j.Logger;
@@ -485,10 +486,10 @@ public class StarRocksSinkOptions implements Serializable {
     }
 
     private void validateMergeCommit() {
-        if (!"true".equalsIgnoreCase(streamLoadProps.get(MergeCommitOptions.ENABLE_MERGE_COMMIT))) {
+        if (!"true".equalsIgnoreCase(streamLoadProps.get(LoadParameters.ENABLE_MERGE_COMMIT))) {
             return;
         }
-        if (!streamLoadProps.containsKey(MergeCommitOptions.MERGE_COMMIT_INTERVAL_MS)) {
+        if (!streamLoadProps.containsKey(LoadParameters.MERGE_COMMIT_INTERVAL_MS)) {
             throw new IllegalArgumentException("Must set 'sink.properties.merge_commit_interval_ms' when " +
                     "'sink.properties.enable_merge_commit' is true");
         }

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/mergecommit/LoadParameters.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/mergecommit/LoadParameters.java
@@ -32,6 +32,8 @@ public class LoadParameters {
     public static final int DEFAULT_TIMEOUT_SECONDS = 600;
 
     public static final String ENABLE_MERGE_COMMIT = "enable_merge_commit";
+    public static final String MERGE_COMMIT_INTERVAL_MS = "merge_commit_interval_ms";
+    public static final String MERGE_COMMIT_PARALLEL = "merge_commit_parallel";
     public static final String MERGE_COMMIT_ASYNC = "merge_commit_async";
 
     public static Map<String, String> getParameters(StreamLoadTableProperties properties) {

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/mergecommit/MergeCommitManager.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/mergecommit/MergeCommitManager.java
@@ -294,7 +294,7 @@ public class MergeCommitManager implements StreamLoadManager, Serializable {
                     StreamLoadUtils.getTableUniqueKey(database, tableName), database, tableName);
             table = new Table(database, tableName, this, mergeCommitLoader,
                     tableProperties, maxRetries, retryIntervalInMs, flushIntervalMs,
-                    properties.getDefaultTableProperties().getChunkLimit(), properties.getMaxInflightRequests());
+                    properties.getDefaultTableProperties().getChunkLimit(), properties.getMaxConcurrentRequests());
             tables.put(tableId, table);
         }
         return table;

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/properties/StreamLoadProperties.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/properties/StreamLoadProperties.java
@@ -102,7 +102,7 @@ public class StreamLoadProperties implements Serializable {
     private final int httpTotalMaxConnections;
     private final int httpIdleConnectionTimeoutMs;
     private final int nodeMetaUpdateIntervalMs;
-    private final int maxInflightRequests;
+    private final int maxConcurrentRequests;
     private final boolean backendDirectConnection;
     private final boolean blackhole;
 
@@ -148,7 +148,7 @@ public class StreamLoadProperties implements Serializable {
         this.httpTotalMaxConnections = builder.httpTotalMaxConnections;
         this.httpIdleConnectionTimeoutMs = builder.httpIdleConnectionTimeoutMs;
         this.nodeMetaUpdateIntervalMs = builder.nodeMetaUpdateIntervalMs;
-        this.maxInflightRequests = builder.maxInflightRequests;
+        this.maxConcurrentRequests = builder.maxConcurrentRequests;
         this.backendDirectConnection = builder.backendDirectConnection;
         this.blackhole = builder.blackhole;
     }
@@ -300,8 +300,8 @@ public class StreamLoadProperties implements Serializable {
         return nodeMetaUpdateIntervalMs;
     }
 
-    public int getMaxInflightRequests() {
-        return maxInflightRequests;
+    public int getMaxConcurrentRequests() {
+        return maxConcurrentRequests;
     }
 
     public boolean isBackendDirectConnection() {
@@ -357,7 +357,7 @@ public class StreamLoadProperties implements Serializable {
         private int httpTotalMaxConnections = 30;
         private int httpIdleConnectionTimeoutMs = 60000;
         private int nodeMetaUpdateIntervalMs = 2000;
-        private int maxInflightRequests = -1;
+        private int maxConcurrentRequests = -1;
         private boolean backendDirectConnection = false;
         private boolean blackhole = false;
 
@@ -570,8 +570,8 @@ public class StreamLoadProperties implements Serializable {
             return this;
         }
 
-        public Builder setMaxInflightRequests(int maxInflightRequests) {
-            this.maxInflightRequests = maxInflightRequests;
+        public Builder setMaxConcurrentRequests(int maxConcurrentRequests) {
+            this.maxConcurrentRequests = maxConcurrentRequests;
             return this;
         }
 

--- a/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/StreamLoadPropertiesTest.java
+++ b/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/StreamLoadPropertiesTest.java
@@ -95,7 +95,7 @@ public class StreamLoadPropertiesTest {
                 .setHttpTotalMaxConnections(50)
                 .setHttpIdleConnectionTimeoutMs(30000)
                 .setNodeMetaUpdateIntervalMs(3000)
-                .setMaxInflightRequests(100)
+                .setMaxConcurrentRequests(100)
                 .setBackendDirectConnection(true)
                 .build();
 
@@ -104,7 +104,7 @@ public class StreamLoadPropertiesTest {
         assertEquals(50, props.getHttpTotalMaxConnections());
         assertEquals(30000, props.getHttpIdleConnectionTimeoutMs());
         assertEquals(3000, props.getNodeMetaUpdateIntervalMs());
-        assertEquals(100, props.getMaxInflightRequests());
+        assertEquals(100, props.getMaxConcurrentRequests());
         assertEquals(true, props.isBackendDirectConnection());
     }
 
@@ -117,7 +117,7 @@ public class StreamLoadPropertiesTest {
         assertEquals(30, props.getHttpTotalMaxConnections());
         assertEquals(60000, props.getHttpIdleConnectionTimeoutMs());
         assertEquals(2000, props.getNodeMetaUpdateIntervalMs());
-        assertEquals(-1, props.getMaxInflightRequests());
+        assertEquals(-1, props.getMaxConcurrentRequests());
         assertFalse(props.isBackendDirectConnection());
     }
 

--- a/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/mergecommit/TableTest.java
+++ b/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/mergecommit/TableTest.java
@@ -20,19 +20,41 @@ package com.starrocks.data.load.stream.mergecommit;
 
 import com.starrocks.data.load.stream.StreamLoadDataFormat;
 import com.starrocks.data.load.stream.StreamLoadManager;
+import com.starrocks.data.load.stream.StreamLoadResponse;
 import com.starrocks.data.load.stream.properties.StreamLoadProperties;
 import com.starrocks.data.load.stream.properties.StreamLoadTableProperties;
+import org.junit.Before;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 public class TableTest {
+
+    // ==================== Mock classes for basic tests ====================
 
     /**
      * Mock MergeCommitLoader for testing
@@ -98,6 +120,70 @@ public class TableTest {
         }
     }
 
+    // ==================== Mockito-based test infrastructure ====================
+
+    private MergeCommitManager manager;
+    private MergeCommitLoader loader;
+    private SendLoadSpy sendLoadSpy;
+
+    @FunctionalInterface
+    private interface SendLoadObserver {
+        void onSend(LoadRequest.RequestRun requestRun, int count);
+    }
+
+    private static class SendLoadSpy {
+        private final List<LoadRequest.RequestRun> capturedRequests =
+                Collections.synchronizedList(new ArrayList<>());
+        private volatile SendLoadObserver observer = (requestRun, count) -> {};
+
+        public void setObserver(SendLoadObserver observer) {
+            this.observer = observer == null ? (requestRun, count) -> {} : observer;
+        }
+
+        public void install(MergeCommitLoader loader) {
+            doAnswer(invocation -> {
+                LoadRequest.RequestRun requestRun = invocation.getArgument(0);
+                int count;
+                synchronized (capturedRequests) {
+                    capturedRequests.add(requestRun);
+                    count = capturedRequests.size();
+                }
+                observer.onSend(requestRun, count);
+                return null;
+            }).when(loader).sendLoad(any(), anyInt());
+        }
+
+        public int size() {
+            synchronized (capturedRequests) {
+                return capturedRequests.size();
+            }
+        }
+
+        public LoadRequest.RequestRun get(int index) {
+            synchronized (capturedRequests) {
+                return capturedRequests.get(index);
+            }
+        }
+    }
+
+    @Before
+    public void setUp() {
+        manager = mock(MergeCommitManager.class);
+        loader = mock(MergeCommitLoader.class);
+        sendLoadSpy = new SendLoadSpy();
+
+        doNothing().when(manager).onLoadStart(any(), anyLong(), anyInt());
+        doNothing().when(manager).releaseCache(any());
+        doNothing().when(manager).onLoadSuccess(any(), any());
+
+        doReturn(mock(ScheduledFuture.class))
+                .when(loader).scheduleFlush(any(), anyLong(), anyInt());
+
+        sendLoadSpy.install(loader);
+    }
+
+    // ==================== Helper methods ====================
+
     private Map<String, String> createMap(String... keyValues) {
         Map<String, String> map = new HashMap<>();
         for (int i = 0; i < keyValues.length; i += 2) {
@@ -120,6 +206,71 @@ public class TableTest {
                 10      // maxInflightRequests
         );
     }
+
+    private Table createTableWithMockito(int maxConcurrentRequests) {
+        StreamLoadTableProperties props = StreamLoadTableProperties.builder()
+                .database("test_db")
+                .table("test_tbl")
+                .streamLoadDataFormat(StreamLoadDataFormat.JSON)
+                .chunkLimit(100)
+                .build();
+        return new Table(
+                "test_db", "test_tbl", manager, loader, props,
+                0,      // maxRetries
+                0,      // retryIntervalInMs
+                10000,  // flushIntervalMs
+                100,    // chunkSize
+                maxConcurrentRequests);
+    }
+
+    private void completeRequest(LoadRequest.RequestRun requestRun) {
+        requestRun.loadResult = new StreamLoadResponse();
+        requestRun.loadRequest.getTable().loadFinish(requestRun, null);
+    }
+
+    private void writeDataToTriggerFlush(Table table) {
+        // Write enough data to trigger chunk flush (chunkSize = 100)
+        byte[] data = new byte[150];
+        table.write(data);
+    }
+
+    private void triggerFlushes(Table table, int times) {
+        for (int i = 0; i < times; i++) {
+            writeDataToTriggerFlush(table);
+        }
+    }
+
+    private Thread startWriteThread(Table table, CountDownLatch startedLatch) {
+        Thread t = new Thread(() -> {
+            startedLatch.countDown();
+            writeDataToTriggerFlush(table);
+        });
+        t.start();
+        return t;
+    }
+
+    /**
+     * Wait until there is a waiter on the flushCondition, indicating a thread is blocked.
+     */
+    private void waitForWaiterOnFlushCondition(Table table, long timeoutMs) throws Exception {
+        ReentrantLock lock = table.getFlushLockForTest();
+
+        long startTime = System.currentTimeMillis();
+        while (System.currentTimeMillis() - startTime < timeoutMs) {
+            lock.lock();
+            try {
+                if (lock.hasWaiters(table.getFlushConditionForTest())) {
+                    return;
+                }
+            } finally {
+                lock.unlock();
+            }
+            Thread.sleep(10);
+        }
+        throw new AssertionError("Timeout waiting for waiter on flushCondition");
+    }
+
+    // ==================== Basic property tests ====================
 
     @Test
     public void testGetLoadTimeoutMsWithDefaultTimeout() {
@@ -192,8 +343,8 @@ public class TableTest {
 
         Table table = createTable(properties);
 
-        // Default should be false
-        assertFalse(table.isMergeCommitAsync());
+        // Default should be true
+        assertTrue(table.isMergeCommitAsync());
     }
 
     @Test
@@ -235,5 +386,175 @@ public class TableTest {
         Table table = createTable(properties);
 
         assertEquals(properties, table.getProperties());
+    }
+
+    // ==================== Concurrent request tests ====================
+
+    /**
+     * Test: maxConcurrentRequests = -1 disables rate limiting
+     * Expected: All requests are sent immediately without waiting
+     */
+    @Test
+    public void testMaxConcurrentRequestsDisabled() {
+        Table table = createTableWithMockito(-1);
+
+        // Trigger multiple flushes
+        triggerFlushes(table, 3);
+
+        // All 3 requests should be sent immediately
+        assertEquals(3, sendLoadSpy.size());
+
+        verify(loader, times(3)).sendLoad(any(), anyInt());
+    }
+
+    /**
+     * Test: maxConcurrentRequests = 0 serializes requests
+     * Expected: Second request blocks until first completes
+     */
+    @Test
+    public void testMaxConcurrentRequestsZero() throws Exception {
+        Table table = createTableWithMockito(0);
+
+        CountDownLatch firstRequestSent = new CountDownLatch(1);
+        CountDownLatch secondWriteStarted = new CountDownLatch(1);
+        CountDownLatch secondRequestSent = new CountDownLatch(1);
+        AtomicReference<LoadRequest.RequestRun> firstRequest = new AtomicReference<>();
+
+        sendLoadSpy.setObserver((requestRun, count) -> {
+            if (count == 1) {
+                firstRequest.set(requestRun);
+                firstRequestSent.countDown();
+            } else if (count == 2) {
+                secondRequestSent.countDown();
+            }
+        });
+
+        // First write triggers first request
+        writeDataToTriggerFlush(table);
+        assertTrue(firstRequestSent.await(60, TimeUnit.SECONDS));
+
+        // Second write in separate thread (should block)
+        Thread secondWriteThread = startWriteThread(table, secondWriteStarted);
+        assertTrue(secondWriteStarted.await(60, TimeUnit.SECONDS));
+
+        // Wait until the second write thread is blocked on flushCondition
+        waitForWaiterOnFlushCondition(table, 60000);
+
+        // Verify only 1 request sent so far
+        assertEquals(1, sendLoadSpy.size());
+
+        // Complete first request
+        completeRequest(firstRequest.get());
+
+        // Second request should now be sent
+        assertTrue(secondRequestSent.await(1, TimeUnit.SECONDS));
+
+        assertEquals(2, sendLoadSpy.size());
+
+        secondWriteThread.join(1000);
+    }
+
+    /**
+     * Test: maxConcurrentRequests = 2 limits concurrent requests
+     * New semantics: inflightLoadRequests.size() cannot exceed maxConcurrentRequests
+     * So maxConcurrentRequests=2 allows up to 2 inflight requests,
+     * and blocks when trying to add the 3rd (size=2 >= 2)
+     */
+    @Test
+    public void testMaxConcurrentRequestsPositive() throws Exception {
+        Table table = createTableWithMockito(2);
+
+        CountDownLatch twoRequestsSent = new CountDownLatch(2);
+        CountDownLatch thirdWriteStarted = new CountDownLatch(1);
+        CountDownLatch thirdRequestSent = new CountDownLatch(1);
+        AtomicReference<LoadRequest.RequestRun> firstRequest = new AtomicReference<>();
+
+        sendLoadSpy.setObserver((requestRun, count) -> {
+            if (count == 1) {
+                firstRequest.set(requestRun);
+            }
+            if (count <= 2) {
+                twoRequestsSent.countDown();
+            } else if (count == 3) {
+                thirdRequestSent.countDown();
+            }
+        });
+
+        // First two writes - should pass (size < maxConcurrentRequests)
+        writeDataToTriggerFlush(table);
+        writeDataToTriggerFlush(table);
+        assertTrue(twoRequestsSent.await(60, TimeUnit.SECONDS));
+
+        // Third write in separate thread (should block since size=2 >= 2)
+        Thread thirdWriteThread = startWriteThread(table, thirdWriteStarted);
+        assertTrue(thirdWriteStarted.await(1, TimeUnit.SECONDS));
+
+        // Wait until the third write thread is blocked on flushCondition
+        waitForWaiterOnFlushCondition(table, 60000);
+
+        // Verify only 2 requests sent so far
+        assertEquals(2, sendLoadSpy.size());
+
+        // Complete first request (size becomes 1, which is < 2, so unblocks)
+        completeRequest(firstRequest.get());
+
+        // Third request should now be sent
+        assertTrue(thirdRequestSent.await(60, TimeUnit.SECONDS));
+
+        assertEquals(3, sendLoadSpy.size());
+
+        thirdWriteThread.join(1000);
+    }
+
+    /**
+     * Regression test: flush(true) should wait until inflight requests finish.
+     *
+     * Before the fix, flush(true) called waitInflightRequests(0). With the new {@code >=} semantics,
+     * that condition never becomes false (size is never < 0), causing flush(true) to wait until timeout.
+     */
+    @Test
+    public void testFlushWaitsUntilInflightFinished() throws Exception {
+        Table table = createTableWithMockito(2);
+
+        // Trigger 1 inflight request.
+        writeDataToTriggerFlush(table);
+        assertEquals(1, sendLoadSpy.size());
+        LoadRequest.RequestRun requestRun = sendLoadSpy.get(0);
+
+        CountDownLatch flushThreadStarted = new CountDownLatch(1);
+        CountDownLatch flushThreadFinished = new CountDownLatch(1);
+        AtomicReference<Throwable> flushThrowable = new AtomicReference<>();
+        AtomicBoolean flushReturned = new AtomicBoolean(false);
+
+        Thread flushThread = new Thread(() -> {
+            flushThreadStarted.countDown();
+            try {
+                table.flush(true);
+                flushReturned.set(true);
+            } catch (Throwable t) {
+                flushThrowable.set(t);
+            } finally {
+                flushThreadFinished.countDown();
+            }
+        });
+        flushThread.start();
+        assertTrue(flushThreadStarted.await(10, TimeUnit.SECONDS));
+
+        // Ensure flush thread is actually waiting on the condition.
+        waitForWaiterOnFlushCondition(table, 60000);
+        assertTrue(flushThread.isAlive());
+
+        // Complete inflight request; flush(true) should return.
+        completeRequest(requestRun);
+
+        if (!flushThreadFinished.await(10, TimeUnit.SECONDS)) {
+            // Avoid hanging the test suite even if regression happens again.
+            flushThread.interrupt();
+            flushThread.join(5000);
+            throw new AssertionError("flush(true) didn't return after inflight finished");
+        }
+
+        assertTrue(flushReturned.get());
+        assertNull(flushThrowable.get());
     }
 }


### PR DESCRIPTION
### Why
Merge-commit stream-load could exceed the intended request concurrency due to off-by-one / non-blocking behavior, and the existing config name (`max-inflight-requests`) is unclear. This can cause request bursts, unstable throughput, and flush not fully waiting for outstanding work.

### What
- Rename config `sink.merge-commit.max-inflight-requests` → `sink.merge-commit.max-concurrent-requests` (**keep old key as deprecated alias**).
- Enforce concurrency limits consistently:
  - wait while `inflight >= threshold`
  - `flushChunk` blocks until below `maxConcurrentRequests`
  - `flush(true)` waits for all pending requests to complete
- Improve merge-commit parameter handling:
  - default `merge_commit_async` to `true`
  - add/load `merge_commit_interval_ms` and `merge_commit_parallel`
  - validate options via `LoadParameters` constants
- Add/extend unit tests covering concurrency limits and flush behavior.

### How
- Propagate the new option name through `MergeCommitOptions`, `StreamLoadProperties` (builder/getter), `MergeCommitManager`, and `Table`, while still accepting the deprecated key.
- Adjust locking/condition logic so waiting happens at the correct boundary (`>=`), and ensure `flush(true)` uses a “wait until none left” condition.
- Add targeted tests and expose minimal test-only accessors (`getFlushLockForTest` / `getFlushConditionForTest`) to assert concurrency/flush state transitions.

## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

