### PR TITLE
[Fix] Correct table name logging in create table error handling

### DIFF
--- a/src/main/java/com/starrocks/connector/flink/catalog/StarRocksCatalog.java
+++ b/src/main/java/com/starrocks/connector/flink/catalog/StarRocksCatalog.java
@@ -284,14 +284,14 @@ public class StarRocksCatalog implements Serializable {
         try {
             executeUpdateStatement(createTableSql);
             LOG.info("Success to create table {}.{}, sql: {}",
-                    table.getDatabaseName(), table.getDatabaseName(), createTableSql);
+                    table.getDatabaseName(), table.getTableName(), createTableSql);
         } catch (Exception e) {
             LOG.error("Failed to create table {}.{}, sql: {}",
-                    table.getDatabaseName(), table.getDatabaseName(), createTableSql, e);
+                    table.getDatabaseName(), table.getTableName(), createTableSql, e);
             throw new StarRocksCatalogException(
                     String.format(
                             "Failed to create table %s.%s",
-                            table.getDatabaseName(), table.getDatabaseName()),
+                            table.getDatabaseName(), table.getTableName()),
                     e);
         }
     }


### PR DESCRIPTION
## What type of PR is this：
- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes table name logging in create table error handling

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

The logging "... to create table dbName.dbName" should be corrected to "... to create table dbName.tableName".

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

