### PR TITLE
fix: Do not quote CURRENT_TIMESTAMP in DEFAULT clause of buildColumnStmt

### DIFF
--- a/src/main/java/com/starrocks/connector/flink/catalog/StarRocksCatalog.java
+++ b/src/main/java/com/starrocks/connector/flink/catalog/StarRocksCatalog.java
@@ -618,13 +618,23 @@ public class StarRocksCatalog implements Serializable {
         builder.append(" ");
         builder.append(column.isNullable() ? "NULL" : "NOT NULL");
         if (column.getDefaultValue().isPresent()) {
-            builder.append(String.format(" DEFAULT \"%s\"", column.getDefaultValue().get()));
+            String defaultValue = column.getDefaultValue().get();
+            if (isUnquotedDefault(defaultValue, column.getDataType())) {
+                builder.append(String.format(" DEFAULT %s", defaultValue));
+            } else {
+                builder.append(String.format(" DEFAULT \"%s\"", defaultValue));
+            }
         }
 
         if (column.getColumnComment().isPresent()) {
             builder.append(String.format(" COMMENT \"%s\"", column.getColumnComment().get()));
         }
         return builder.toString();
+    }
+
+    private static boolean isUnquotedDefault(String defaultValue, String dataType) {
+        return "CURRENT_TIMESTAMP".equalsIgnoreCase(defaultValue)
+                && "DATETIME".equalsIgnoreCase(dataType);
     }
 
     private String getFullColumnType(

--- a/src/test/java/com/starrocks/connector/flink/it/catalog/StarRocksCatalogTest.java
+++ b/src/test/java/com/starrocks/connector/flink/it/catalog/StarRocksCatalogTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -135,5 +136,40 @@ public class StarRocksCatalogTest extends StarRocksITTestBase {
                 .filter(column -> !dropColumns.contains(column.getColumnName()))
                 .collect(Collectors.toList());
         assertEquals(expectedColumns, newTable.getColumns());
+    }
+
+    @Test
+    public void testCreateTableWithCurrentTimestampDefault() throws Exception {
+        String testTable = "test_current_timestamp_" + genRandomUuid();
+
+        StarRocksColumn c0 = new StarRocksColumn.Builder()
+                .setColumnName("c0")
+                .setOrdinalPosition(0)
+                .setDataType("INT")
+                .setNullable(false)
+                .build();
+
+        StarRocksColumn c1 = new StarRocksColumn.Builder()
+                .setColumnName("c1")
+                .setOrdinalPosition(1)
+                .setDataType("DATETIME")
+                .setNullable(false)
+                .setDefaultValue("CURRENT_TIMESTAMP")
+                .build();
+
+        StarRocksTable table = new StarRocksTable.Builder()
+                .setDatabaseName(DB_NAME)
+                .setTableName(testTable)
+                .setTableType(StarRocksTable.TableType.PRIMARY_KEY)
+                .setColumns(Arrays.asList(c0, c1))
+                .setTableKeys(Collections.singletonList("c0"))
+                .setDistributionKeys(Collections.singletonList("c0"))
+                .build();
+
+        catalog.createTable(table, false);
+
+        StarRocksTable result = catalog.getTable(DB_NAME, testTable).orElse(null);
+        assertNotNull(result);
+        assertEquals(2, result.getColumns().size());
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #485

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
buildColumnStmt() wraps all default values with double quotes unconditionally, which turns SQL keywords like CURRENT_TIMESTAMP into string literals. StarRocks rejects DEFAULT "CURRENT_TIMESTAMP" as an invalid date literal.
```sql
-- Generated (incorrect):
`created_at` DATETIME NOT NULL DEFAULT "CURRENT_TIMESTAMP"

-- Expected:
`created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
```

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

