### PR TITLE
[Feature] add multi-table transaction stream load support

### DIFF
--- a/docs/multi-table-transaction-stream-load-en.md
+++ b/docs/multi-table-transaction-stream-load-en.md
@@ -1,0 +1,528 @@
+# StarRocks Flink Connector — Multi-Table Transaction Stream Load
+
+## 1. Use Cases
+
+When a single Flink job writes to multiple tables within the same StarRocks database in one processing cycle, enabling multi-table transaction guarantees:
+
+- **Cross-table atomic commit**: Data written to `orders` and `order_items` within the same commit cycle becomes visible atomically — all or nothing.
+- **Source transaction integrity**: A complete upstream transaction (e.g., from Kafka) is never split across two StarRocks transactions.
+- **Sub-second data freshness**: Data continuously flows into StarRocks via `/api/transaction/load`, and is committed at the interval configured by `sink.buffer-flush.interval-ms`.
+
+Typical scenarios:
+
+- Synchronous writes to a master table `orders` and a detail table `order_items`
+- Event routing to different partition tables (e.g., `events_202601`, `events_202602`)
+- A single job maintaining multiple interrelated downstream result tables
+
+> **Prerequisites**: StarRocks >= 4.0 (multi-table Transaction Stream Load support), Connector >= 1.2.9.
+
+## 2. Core Capabilities
+
+| Capability | Description |
+|---|---|
+| Cross-table atomic commit | All tables within the same flush cycle share one StarRocks transaction label; unified prepare + commit |
+| Source transaction integrity | Commit timing is controlled by the `transactionEnd` flag; commit only occurs at complete source transaction boundaries |
+| Sub-second data visibility | Data is periodically flushed to StarRocks (`/api/transaction/load`); committed when `transactionEnd` + timer conditions are met |
+| N:1 transaction mapping | Multiple source transactions can accumulate in a single StarRocks transaction; no 1:1 requirement |
+| Within-partition ordering | `keyBy(sourcePartition)` ensures transactions from the same partition are processed in order within the same sink subtask |
+
+## 3. Configuration
+
+### 3.1 New Configuration
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `sink.transaction.multi-table.enabled` | Boolean | `false` | Enable multi-table atomic transaction mode |
+| `sink.transaction.multi-table.buffer-size` | Long | `134217728` (128 MB) | Global buffer size in bytes for multi-table transaction mode. When the total buffered data across all tables reaches this threshold, a flush is triggered |
+
+### 3.2 Related Configuration
+
+| Parameter | Recommended Value | Description |
+|---|---|---|
+| `sink.version` | `V2` | Required. V1 does not support transaction stream load |
+| `sink.semantic` | `at-least-once` | Multi-table mode currently supports at-least-once only |
+| `database-name` | `*` | Wildcard to enable dynamic multi-table routing |
+| `table-name` | `*` | Wildcard to enable dynamic multi-table routing |
+| `sink.buffer-flush.interval-ms` | `1000` | Controls the commit cycle (set to 1000 for ~1s freshness) |
+| `sink.properties.format` | `json` | Data format |
+| `sink.properties.strip_outer_array` | `true` | JSON array parsing |
+
+## 4. Interface Definitions
+
+### 4.1 StarRocksRowData
+
+```java
+public interface StarRocksRowData {
+    String getUniqueKey();    // Region routing key (nullable; auto-derived from database.table)
+    String getDatabase();     // Target database
+    String getTable();        // Target table
+    String getRow();          // Row data in JSON format
+
+    /**
+     * Indicates this is the last row of a source transaction batch.
+     * Used by multi-table transaction mode to determine safe commit points:
+     * the connector only commits when the most recent write had this flag set,
+     * ensuring no partial source transaction is committed.
+     */
+    default boolean isTransactionEnd() {
+        return false;
+    }
+
+    /**
+     * Returns the source partition ID for this row.
+     * Used by multi-table transaction mode to track per-partition transaction
+     * boundaries. Returns -1 when partition tracking is not applicable.
+     */
+    default int getSourcePartition() {
+        return -1;
+    }
+}
+```
+
+### 4.2 DefaultStarRocksRowData
+
+```java
+public class DefaultStarRocksRowData implements StarRocksRowData {
+    // Basic fields
+    private String uniqueKey;
+    private String database;
+    private String table;
+    private String row;
+
+    // Multi-table transaction fields
+    private boolean transactionEnd;       // Source transaction end marker
+    private int sourcePartition = -1;     // Source partition ID (for keyBy ordering)
+
+    // Constructors
+    public DefaultStarRocksRowData();
+    public DefaultStarRocksRowData(String database, String table);
+    public DefaultStarRocksRowData(String uniqueKey, String database, String table, String row);
+
+    // Setters
+    public void setUniqueKey(String uniqueKey);
+    public void setDatabase(String database);
+    public void setTable(String table);
+    public void setRow(String row);
+    public void setTransactionEnd(boolean transactionEnd);
+    public void setSourcePartition(int sourcePartition);
+
+    // Getters (inherited from StarRocksRowData)
+    public String getUniqueKey();
+    public String getDatabase();
+    public String getTable();
+    public String getRow();
+    public boolean isTransactionEnd();
+    public int getSourcePartition();
+}
+```
+
+### 4.3 User-Implemented Component
+
+Users need to implement a `KeyedProcessFunction` (referred to as **TransactionAssembler** in this document) that:
+
+1. Keys by source partition and buffers data rows within a transaction
+2. Emits all rows only when the source transaction is closed (e.g., upon receiving `TXN_END`)
+3. Sets `transactionEnd=true` on the last row
+4. Sets `sourcePartition` on every row
+
+No custom SinkFunction is needed — the standard connector API (`SinkFunctionFactory.createSinkFunction()`) handles everything.
+
+## 5. Complete Example
+
+### 5.1 StarRocks Table DDL
+
+```sql
+CREATE DATABASE `test`;
+
+CREATE TABLE `test`.`orders` (
+    `order_id` BIGINT NOT NULL,
+    `customer_id` BIGINT NOT NULL,
+    `total_amount` DECIMAL(10,2) DEFAULT "0",
+    `order_status` VARCHAR(32) DEFAULT ""
+) ENGINE=OLAP PRIMARY KEY(`order_id`)
+DISTRIBUTED BY HASH(`order_id`)
+PROPERTIES("replication_num" = "1");
+
+CREATE TABLE `test`.`order_items` (
+    `item_id` BIGINT NOT NULL,
+    `order_id` BIGINT NOT NULL,
+    `product_name` VARCHAR(128) DEFAULT "",
+    `quantity` INT DEFAULT "0",
+    `price` DECIMAL(10,2) DEFAULT "0"
+) ENGINE=OLAP PRIMARY KEY(`item_id`)
+DISTRIBUTED BY HASH(`item_id`)
+PROPERTIES("replication_num" = "1");
+```
+
+### 5.2 Flink Job Code
+
+```java
+import com.starrocks.connector.flink.table.data.DefaultStarRocksRowData;
+import com.starrocks.connector.flink.table.sink.SinkFunctionFactory;
+import com.starrocks.connector.flink.table.sink.StarRocksSinkOptions;
+import com.starrocks.data.load.stream.properties.StreamLoadTableProperties;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.utils.MultipleParameterTool;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
+import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
+import org.apache.flink.util.Collector;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+public class WriteMultipleTablesWithTransaction {
+
+    // =====================================================
+    // 1. Source Event Model (define per your business logic)
+    // =====================================================
+
+    enum EventType { TXN_BEGIN, DATA, TXN_END }
+
+    static class TxnEvent implements Serializable {
+        private static final long serialVersionUID = 1L;
+
+        int partition;
+        String txnId;
+        EventType type;
+        String database;
+        String table;
+        String json;
+
+        TxnEvent() {}
+
+        TxnEvent(int partition, String txnId, EventType type,
+                 String database, String table, String json) {
+            this.partition = partition;
+            this.txnId = txnId;
+            this.type = type;
+            this.database = database;
+            this.table = table;
+            this.json = json;
+        }
+
+        static TxnEvent begin(int partition, String txnId) {
+            return new TxnEvent(partition, txnId, EventType.TXN_BEGIN, null, null, null);
+        }
+
+        static TxnEvent data(int partition, String txnId, String db, String table, String json) {
+            return new TxnEvent(partition, txnId, EventType.DATA, db, table, json);
+        }
+
+        static TxnEvent end(int partition, String txnId) {
+            return new TxnEvent(partition, txnId, EventType.TXN_END, null, null, null);
+        }
+    }
+
+    // =====================================================
+    // 2. TransactionAssembler — Core User Component
+    // =====================================================
+
+    /**
+     * Buffers DATA events per partition; on TXN_END emits the complete
+     * transaction's rows as individual DefaultStarRocksRowData records.
+     *
+     * Only emits when a source transaction is fully closed (TXN_END received).
+     * All rows are emitted synchronously within one processElement() call,
+     * so they enter the downstream sink buffer without intervening checkpoint barriers.
+     *
+     * Multiple source transactions accumulate in the sink's buffer between
+     * flush cycles — the connector handles grouping them into StarRocks transactions.
+     */
+    static class TransactionAssembler
+            extends KeyedProcessFunction<Integer, TxnEvent, DefaultStarRocksRowData> {
+
+        private transient ListState<TxnEvent> pendingRows;
+
+        @Override
+        public void open(Configuration parameters) throws Exception {
+            ListStateDescriptor<TxnEvent> descriptor = new ListStateDescriptor<>(
+                    "pending-txn-rows", Types.POJO(TxnEvent.class));
+            pendingRows = getRuntimeContext().getListState(descriptor);
+        }
+
+        @Override
+        public void processElement(TxnEvent event, Context ctx,
+                                   Collector<DefaultStarRocksRowData> out) throws Exception {
+            switch (event.type) {
+                case TXN_BEGIN:
+                    pendingRows.clear();
+                    break;
+
+                case DATA:
+                    pendingRows.add(event);
+                    break;
+
+                case TXN_END:
+                    List<TxnEvent> rows = new ArrayList<>();
+                    for (TxnEvent row : pendingRows.get()) {
+                        rows.add(row);
+                    }
+                    int partition = ctx.getCurrentKey();
+                    for (int i = 0; i < rows.size(); i++) {
+                        TxnEvent row = rows.get(i);
+                        DefaultStarRocksRowData rowData = new DefaultStarRocksRowData(
+                                null, row.database, row.table, row.json);
+                        rowData.setSourcePartition(partition);
+                        // Mark the last row as transaction end
+                        if (i == rows.size() - 1) {
+                            rowData.setTransactionEnd(true);
+                        }
+                        out.collect(rowData);
+                    }
+                    pendingRows.clear();
+                    break;
+            }
+        }
+    }
+
+    // =====================================================
+    // 3. Main Program
+    // =====================================================
+
+    public static void main(String[] args) throws Exception {
+        MultipleParameterTool params = MultipleParameterTool.fromArgs(args);
+        String jdbcUrl  = params.get("jdbcUrl", "jdbc:mysql://127.0.0.1:9030");
+        String loadUrl  = params.get("loadUrl", "127.0.0.1:8030");
+        String userName = params.get("userName", "root");
+        String password = params.get("password", "");
+
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.enableCheckpointing(10_000);  // Checkpoint is for recovery only; does not affect commit cycle
+
+        // --- Source ---
+        // Replace with an actual Kafka Source that deserializes into TxnEvent
+        DataStream<TxnEvent> events = env.addSource(/* KafkaSource or MockTxnEventSource */);
+
+        // --- Step 1: Assemble complete transactions per partition ---
+        // TransactionAssembler emits rows only after TXN_END.
+        // Multiple closed source txns accumulate in the sink buffer between flushes.
+        DataStream<DefaultStarRocksRowData> rows = events
+                .keyBy(e -> e.partition)
+                .process(new TransactionAssembler());
+
+        // --- Step 2: Partition-affinity routing to sink ---
+        // keyBy(sourcePartition) routes same-partition data to the same sink subtask.
+        // The connector uses per-partition regions internally, so even when multiple
+        // partitions land on the same sink subtask, transaction boundaries are tracked
+        // independently per partition via PartitionCommitTracker.
+        DataStream<DefaultStarRocksRowData> partitionedRows = rows
+                .keyBy(DefaultStarRocksRowData::getSourcePartition);
+
+        // --- Step 3: Configure the connector ---
+        // sink.transaction.multi-table.enabled=true activates per-partition region
+        // tracking inside StreamLoadManagerV2: each partition's regions are switched
+        // independently when its txnEnd arrives, and commit triggers only when all
+        // active partitions have been switched.
+        StarRocksSinkOptions options = StarRocksSinkOptions.builder()
+                .withProperty("jdbc-url", jdbcUrl)
+                .withProperty("load-url", loadUrl)
+                .withProperty("database-name", "*")               // Wildcard for dynamic multi-table routing
+                .withProperty("table-name", "*")                  // Wildcard for dynamic multi-table routing
+                .withProperty("username", userName)
+                .withProperty("password", password)
+                .withProperty("sink.version", "V2")               // Required: V2
+                .withProperty("sink.semantic", "at-least-once")
+                .withProperty("sink.transaction.multi-table.enabled", "true")  // Enable multi-table txn
+                .withProperty("sink.buffer-flush.interval-ms", "1000")         // ~1s data freshness
+                .withProperty("sink.properties.format", "json")
+                .withProperty("sink.properties.strip_outer_array", "true")
+                .build();
+
+        // Optional: per-table stream load properties
+        StreamLoadTableProperties orderItemsProps = StreamLoadTableProperties.builder()
+                .database("test")
+                .table("order_items")
+                .addProperty("format", "json")
+                .addProperty("strip_outer_array", "true")
+                .addProperty("ignore_json_size", "true")
+                .build();
+        options.addTableProperties(orderItemsProps);
+
+        // --- Step 4: Create and attach the sink ---
+        // Standard connector API — no custom SinkFunction needed.
+        // addSink on the keyBy'd stream ensures partition affinity.
+        SinkFunction<DefaultStarRocksRowData> sink = SinkFunctionFactory.createSinkFunction(options);
+        partitionedRows.addSink(sink);
+
+        env.execute("WriteMultipleTablesWithTransaction");
+    }
+}
+```
+
+### 5.3 Data Flow Topology
+
+```
+Kafka (60 partitions)
+  |
+  v
+keyBy(partition) ———— Ensures same-partition events go to the same subtask
+  |
+  v
+TransactionAssembler (KeyedProcessFunction)
+  |  Buffers DATA events
+  |  On TXN_END: emits all rows (last row has transactionEnd=true)
+  |  Every row carries sourcePartition
+  |
+  v
+keyBy(sourcePartition) ———— Ensures same-partition rows go to the same sink subtask
+  |
+  v
+StarRocksDynamicSinkFunctionV2 (via SinkFunctionFactory.createSinkFunction)
+  |
+  |  +——————————— StreamLoadManagerV2 (multi-table txn mode) ———————————+
+  |  |                                                                   |
+  |  |  Per-partition, per-table regions:                                 |
+  |  |    Region(P0, orders), Region(P0, order_items)                    |
+  |  |    Region(P2, orders), Region(P2, order_items)                    |
+  |  |                                                                   |
+  |  |  write(partition, db, table, row)                                 |
+  |  |    -> routes to Region(partition, db, table)                      |
+  |  |    -> PartitionCommitTracker.onWrite(partition)                   |
+  |  |                                                                   |
+  |  |  setCommitAllowed(partition, txnEnd=true)                         |
+  |  |    -> PartitionCommitTracker.onTxnEnd(partition)                  |
+  |  |    -> if interval elapsed: switchChunk only this partition's       |
+  |  |       regions, mark partition SWITCHED                            |
+  |  |    -> if all partitions SWITCHED: signal manager thread           |
+  |  |                                                                   |
+  |  |  SharedTransactionCoordinator:                                    |
+  |  |    -> eagerly opens shared txn before any flush                   |
+  |  |    -> all autonomous flushes use the shared label                 |
+  |  |    -> recycles idle txn at 80% of server timeout                  |
+  |  |                                                                   |
+  |  |  Manager thread (commitInFlight=true):                            |
+  |  |    -> triggerLoad per region (HTTP /api/transaction/load)         |
+  |  |    -> wait all loads complete                                     |
+  |  |    -> unified prepare + commit via SharedTransactionCoordinator   |
+  |  |    -> reset tracker; evict idle partitions; open next txn         |
+  |  +———————————————————————————————————————————————————————————————————+
+  |
+  v
+StarRocks (test.orders + test.order_items)
+```
+
+## 6. How It Works
+
+### 6.1 Per-Partition Commit Tracking
+
+Each sink subtask may receive data from multiple source partitions (via `keyBy(sourcePartition)`).
+The `PartitionCommitTracker` tracks each partition independently:
+
+1. **onWrite(partition)**: registers the partition as active
+2. **onTxnEnd(partition)**: marks the partition as having completed its current source transaction
+3. **trySwitchAndCommit()**: when the flush interval has elapsed, switches regions for
+   all partitions that have reached txnEnd. Only when **all active partitions** have been
+   switched does it trigger the commit phase.
+
+**Phase 1 (task thread, per-partition switchChunk):**
+
+When a partition's txnEnd arrives and the flush interval has elapsed:
+1. SwitchChunk only **that partition's** regions (not other partitions')
+2. Mark the partition as SWITCHED in the tracker
+3. If all active partitions are SWITCHED: set `commitInFlight=true` and wake the manager thread
+
+**Phase 2 (manager thread, async):**
+
+1. Ensure a shared transaction is open via `SharedTransactionCoordinator`
+2. Wait for any in-flight loads to complete
+3. Trigger HTTP loads for remaining inactive chunks (from `switchChunkForCommit`)
+4. Wait for all loads to complete
+5. Execute unified `prepare + commit` via `SharedTransactionCoordinator`
+6. Clear labels, reset `PartitionCommitTracker` (evict idle partitions), set `commitInFlight=false`
+7. Eagerly open a new shared transaction for the next cycle
+
+### 6.2 Shared Transaction Coordination
+
+All tables within the same commit cycle share a single StarRocks transaction managed by `SharedTransactionCoordinator`:
+
+1. **Eager transaction opening**: A shared transaction is opened eagerly before any autonomous flush, so all HTTP loads use the shared label. This eliminates the data-loss window where an independent-label flush could be orphaned when a shared transaction later overwrites the label.
+2. **Unified prepare + commit**: After all regions' data is loaded, a single `prepare + commit` is executed for the shared label.
+3. **Idle transaction recycling**: If the shared transaction remains open longer than 80% of the StarRocks server-side timeout (default: 480s for a 600s timeout), it is proactively recycled (commit-or-rollback + reopen) to prevent server-side timeout errors.
+
+### 6.3 Evicted Partition Re-registration
+
+After a successful commit, partitions that were SWITCHED but received no new data during the commit phase are evicted from tracking. This prevents idle partitions from permanently blocking `allSwitched()`. When an evicted partition sends a new `txnEnd`, it is automatically re-registered as `TXN_END_RECEIVED` so it participates correctly in the next commit cycle.
+
+### 6.4 Autonomous Flush with Shared Labels
+
+When the buffer cache exceeds `maxCacheBytes`, autonomous flushes are triggered. In multi-table mode, these autonomous flushes use the shared transaction label (not independent labels), ensuring all data — whether flushed by timer-driven commit or by buffer pressure — is part of the same atomic transaction.
+
+### 6.5 Safety Guarantees
+
+| Guarantee | Mechanism |
+|---|---|
+| switchChunk does not split source transactions | switchChunk is per-partition; only triggered when that partition has txnEnd |
+| Commit never includes partial source transactions | Commit waits until ALL active partitions reach txnEnd |
+| Multi-partition safety | Per-partition regions ensure one partition's switchChunk does not affect another's data |
+| Within-partition ordering | `keyBy(sourcePartition)` ensures same-partition data reaches the same sink subtask |
+| Task thread is non-blocking | switchChunk takes ~1ms; HTTP wait is handled asynchronously by the manager thread |
+| Periodic flush continues working | Manager thread buffer-management flushes run normally when `!commitInFlight` |
+| Autonomous flushes are transaction-safe | Autonomous flushes use the shared label; no orphaned independent-label loads |
+| Idle transactions don't timeout | Shared transactions are recycled at 80% of server timeout |
+| Idle partitions don't block commits | Evicted after commit if no new data arrived; re-registered on next txnEnd |
+
+### 6.6 N:1 Transaction Mapping
+
+Multiple source transactions can accumulate in a single StarRocks transaction:
+
+```
+Source txn K1 (3 rows) -> write -> buffer
+Source txn K2 (2 rows) -> write -> buffer   <-- transactionEnd=true + timer ready
+                                              -> switchChunk -> commit
+                                              -> K1 + K2 atomically committed to StarRocks
+```
+
+## 7. Limitations
+
+1. **Requires `sink.version=V2`**: V1 does not support transaction stream load.
+
+2. **At-least-once only**: Failed retries may produce duplicate writes. Multi-table mode guarantees all tables within the same batch succeed or fail together, but does not provide global exactly-once. For PRIMARY KEY tables, duplicate writes are idempotent (upsert).
+
+3. **All tables must be in the same database**: StarRocks multi-table transactions are database-scoped; cross-database transactions are not supported.
+
+4. **Transaction scope is per sink subtask**: Each sink subtask maintains its own StarRocks transaction independently. The atomicity scope is "same subtask + same commit cycle + all tables."
+
+5. **Depends on StarRocks cluster transaction settings**: Monitor running txn limits, prepared timeout (default 600s), and label retention. Ensure `sink.buffer-flush.interval-ms` is significantly shorter than the StarRocks transaction timeout.
+
+6. **Buffer flushes paused during commitInFlight**: While the async commit is in progress (typically 30-200ms), new data stays in active chunks and is not flushed. Under extreme throughput, if the buffer reaches `sink.transaction.multi-table.buffer-size` (default 128 MB), the task thread may briefly block until the commit completes.
+
+7. **Cross-database writes are rejected**: Multi-table transactions validate that all regions belong to the same database. Writing to tables in different databases within the same commit cycle will throw an error.
+
+## 8. Monitoring and Troubleshooting
+
+Recommended metrics:
+- **Flink**: Checkpoint success rate, checkpoint duration, sink flush/commit latency
+- **StarRocks**: Running/prepared txn count, txn timeout occurrences, label conflicts
+
+Common issues:
+
+| Error | Cause | Solution |
+|---|---|---|
+| `transaction not existed` | StarRocks transaction timeout | The connector automatically recycles idle transactions at 80% of server timeout. If this still occurs, check if prepared timeout is too short or flush interval is too large |
+| `too many running txns` | Too many concurrent transactions | Reduce sink parallelism or increase StarRocks `max_running_txn_num_per_db` |
+| `Transaction start failed` | beginTransaction HTTP call failed | Verify load-url connectivity and StarRocks version (requires >= 4.0) |
+| High data visibility latency | Commit conditions not met | Verify upstream data has correct `transactionEnd=true` markers; check that no idle partitions are blocking `allSwitched()` |
+| Cross-database write error | Tables in different databases in same commit cycle | Ensure all tables written in the same job belong to the same StarRocks database |
+
+## 9. Best Practices
+
+1. **TransactionAssembler contract**:
+   - Emit rows only after the source transaction is fully closed
+   - The last row must have `setTransactionEnd(true)`
+   - Every row must have `setSourcePartition(partition)`
+   - All rows must be emitted synchronously within a single `processElement()` call
+
+2. **keyBy before sink is mandatory**: `rows.keyBy(DefaultStarRocksRowData::getSourcePartition).addSink(sink)` — omitting this breaks within-partition transaction ordering.
+
+3. **Checkpoint is decoupled from commit**: Checkpoint interval can be set to a large value (e.g., 60s) for fault recovery; data visibility is governed by `sink.buffer-flush.interval-ms` (e.g., 1000ms).
+
+4. **Keep routing strategies stable**: Avoid single transactions writing to an excessive number of distinct tables, which increases transaction duration and failure probability.
+
+5. **Fault injection testing before production**: Kill TaskManagers / introduce network jitter and verify data correctness after checkpoint recovery.

--- a/docs/multi-table-transaction-stream-load-en.md
+++ b/docs/multi-table-transaction-stream-load-en.md
@@ -613,6 +613,8 @@ second instead of ~100.
 
 8. **Cross-database writes are rejected**: Multi-table transactions validate that all regions belong to the same database. Writing to tables in different databases within the same commit cycle will throw an error.
 
+9. **Incompatible with merge commit**: `sink.properties.enable_merge_commit=true` cannot be combined with `sink.transaction.multi-table.enabled=true`. Merge commit routes writes through `MergeCommitManager`, which lacks the partition-aware `write(int, ...)` / `setCommitAllowed(int, ...)` hooks that multi-table mode relies on for transaction boundaries. The connector fails fast at validation time if both are enabled.
+
 ## 8. Monitoring and Troubleshooting
 
 Recommended metrics:

--- a/docs/multi-table-transaction-stream-load-en.md
+++ b/docs/multi-table-transaction-stream-load-en.md
@@ -382,26 +382,46 @@ StarRocksDynamicSinkFunctionV2 (via SinkFunctionFactory.createSinkFunction)
   |  |    Region(P0, orders), Region(P0, order_items)                    |
   |  |    Region(P2, orders), Region(P2, order_items)                    |
   |  |                                                                   |
-  |  |  write(partition, db, table, row)                                 |
-  |  |    -> routes to Region(partition, db, table)                      |
-  |  |    -> PartitionCommitTracker.onWrite(partition)                   |
+  |  |  Each region tracks:                                              |
+  |  |    - activeChunk / inactiveChunks                                 |
+  |  |    - lastSwitchTimeMs      (for miniInterval batching)            |
+  |  |    - activeChunkCleanBoundary (true iff last task event is txnEnd)|
   |  |                                                                   |
-  |  |  setCommitAllowed(partition, txnEnd=true)                         |
+  |  |  write(partition, db, table, row)  [task thread]                  |
+  |  |    -> routes to Region(partition, db, table)                      |
+  |  |    -> write0 sets activeChunkCleanBoundary = false                |
+  |  |    -> In multi-table mode write0 does NOT switchChunk, so         |
+  |  |       activeChunk only freezes at a txnEnd boundary               |
+  |  |                                                                   |
+  |  |  setCommitAllowed(partition, txnEnd=true)  [task thread]          |
+  |  |    -> region.tryMiniIntervalSwitch():                             |
+  |  |         sets activeChunkCleanBoundary = true                      |
+  |  |         if (now - lastSwitchTimeMs >= miniInterval                |
+  |  |             && activeChunk has data): switchChunkForCommit        |
+  |  |         else: data batches into activeChunk with subsequent       |
+  |  |               completed source transactions (N:1 mapping)         |
   |  |    -> PartitionCommitTracker.onTxnEnd(partition)                  |
-  |  |    -> if interval elapsed: switchChunk only this partition's       |
-  |  |       regions, mark partition SWITCHED                            |
-  |  |    -> if all partitions SWITCHED: signal manager thread           |
   |  |                                                                   |
   |  |  SharedTransactionCoordinator:                                    |
   |  |    -> eagerly opens shared txn before any flush                   |
   |  |    -> all autonomous flushes use the shared label                 |
   |  |    -> recycles idle txn at 80% of server timeout                  |
   |  |                                                                   |
+  |  |  Manager thread (every scanningFrequency):                        |
+  |  |    -> tryForceCleanSwitch per region:                             |
+  |  |         if cleanBoundary && has data && miniInterval elapsed      |
+  |  |             -> switchChunkForCommit (source-idle fallback)        |
+  |  |    -> tryStartTimerDrivenCommit:                                  |
+  |  |         if commitInterval elapsed && hasDataLoaded                |
+  |  |             -> set commitInFlight = true                          |
+  |  |    -> autonomous flush: drain inactiveChunks via streamLoad       |
+  |  |       (never touches activeChunk in multi-table mode)             |
+  |  |                                                                   |
   |  |  Manager thread (commitInFlight=true):                            |
-  |  |    -> triggerLoad per region (HTTP /api/transaction/load)         |
+  |  |    -> triggerLoadIfNeeded per region (HTTP /api/transaction/load) |
   |  |    -> wait all loads complete                                     |
-  |  |    -> unified prepare + commit via SharedTransactionCoordinator   |
-  |  |    -> reset tracker; evict idle partitions; open next txn         |
+  |  |    -> unified commit via SharedTransactionCoordinator             |
+  |  |    -> reset tracker; open next shared txn                         |
   |  +———————————————————————————————————————————————————————————————————+
   |
   v
@@ -410,74 +430,170 @@ StarRocks (test.orders + test.order_items)
 
 ## 6. How It Works
 
-### 6.1 Per-Partition Commit Tracking
+### 6.1 Chunk Lifecycle and miniInterval Batching
 
-Each sink subtask may receive data from multiple source partitions (via `keyBy(sourcePartition)`).
-The `PartitionCommitTracker` tracks each partition independently:
+Each `(partition, table)` region has one `activeChunk` (currently accepting
+writes) and a FIFO of `inactiveChunks` (frozen data, pending HTTP load). In
+multi-table transaction mode, the **only** way data moves from `activeChunk`
+into `inactiveChunks` is via `switchChunkForCommit`, which is called from
+exactly three sites:
 
-1. **onWrite(partition)**: registers the partition as active
-2. **onTxnEnd(partition)**: marks the partition as having completed its current source transaction
-3. **trySwitchAndCommit()**: when the flush interval has elapsed, switches regions for
-   all partitions that have reached txnEnd. Only when **all active partitions** have been
-   switched does it trigger the commit phase.
+1. **Task thread, on txnEnd** — via `region.tryMiniIntervalSwitch()` inside
+   `setCommitAllowed(partition, true)`. This is the common path.
+2. **Manager thread, source-idle fallback** — via `region.tryForceCleanSwitch()`
+   on every scan cycle, for regions whose `activeChunk` has been sitting idle
+   at a clean transaction boundary.
+3. **Manager thread, savepoint/recycle** — force-switch all regions after
+   verifying every region is at a clean boundary.
 
-**Phase 1 (task thread, per-partition switchChunk):**
+To avoid one HTTP load per source transaction in high-throughput CDC, the task
+thread only performs a switch when at least `miniSwitchIntervalMs` has elapsed
+since the previous switch on the same region. `miniSwitchIntervalMs` is
+computed as `min(1000 ms, max(100 ms, commitInterval / 10))`, so a 1-second
+commit interval batches at 100 ms while a 30-second interval caps batching at
+1 second. Within a miniInterval window, multiple completed source transactions
+accumulate into the same `activeChunk` (N:1 mapping) and are frozen together
+on the next switch.
 
-When a partition's txnEnd arrives and the flush interval has elapsed:
-1. SwitchChunk only **that partition's** regions (not other partitions')
-2. Mark the partition as SWITCHED in the tracker
-3. If all active partitions are SWITCHED: set `commitInFlight=true` and wake the manager thread
+Each region carries two fields that drive these decisions:
 
-**Phase 2 (manager thread, async):**
+- `lastSwitchTimeMs` — epoch ms of the most recent switch. Initially 0, so the
+  very first txnEnd after region creation always triggers a switch.
+- `activeChunkCleanBoundary` — `true` iff the most recent task-thread event on
+  this region was either an `onTxnEnd` or a `switchChunk`. `false` after any
+  `write()`. The manager thread's `tryForceCleanSwitch` only runs when this
+  flag is `true`, so it can never freeze partial source-transaction data.
 
-1. Ensure a shared transaction is open via `SharedTransactionCoordinator`
-2. Wait for any in-flight loads to complete
-3. Trigger HTTP loads for remaining inactive chunks (from `switchChunkForCommit`)
-4. Wait for all loads to complete
-5. Execute unified `prepare + commit` via `SharedTransactionCoordinator`
-6. Clear labels, reset `PartitionCommitTracker` (evict idle partitions), set `commitInFlight=false`
-7. Eagerly open a new shared transaction for the next cycle
+### 6.2 Task Thread — Write and txnEnd
 
-### 6.2 Shared Transaction Coordination
+```
+invoke(record)                                           [Flink task thread]
+  |
+  |  if record is a data row:
+  |      write(partition, db, table, row)
+  |          region.write(row) → addRow(); cleanBoundary = false
+  |
+  |  if record carries transactionEnd=true:
+  |      setCommitAllowed(partition, true)
+  |          for each region owned by this partition:
+  |              region.tryMiniIntervalSwitch():
+  |                  cleanBoundary = true       // always (txnEnd observed)
+  |                  if (now - lastSwitchTimeMs >= miniInterval
+  |                      && activeChunk has data):
+  |                      switchChunkForCommit()  // freezes activeChunk
+  |          partitionTracker.onTxnEnd(partition)  // safety bookkeeping only
+```
+
+The task thread is the sole serializer of `write()` and `setCommitAllowed()`
+events, which is why both the `cleanBoundary` mark and the conditional switch
+must run here (not deferred to the manager thread): `cleanBoundary` must
+reflect the most recent task-thread event at all times, or the manager's
+idle-fallback could race a write and freeze partial data.
+
+### 6.3 Manager Thread — Time-Driven Commit
+
+The manager thread runs a scan loop at `scanningFrequency`. Each iteration:
+
+1. **Ensure shared transaction**: open a new one (eager) or proactively
+   recycle the current one if it is approaching the StarRocks server-side
+   timeout (80% of `timeout` header, default 480 s).
+2. **Source-idle fallback**: call `region.tryForceCleanSwitch()` on every
+   region to freeze any `activeChunk` that is clean and has been idle for at
+   least `miniInterval`. This handles the "source paused after a few txnEnds"
+   case where the task thread stopped before issuing a fresh switch.
+3. **Time-driven commit trigger**: call `tryStartTimerDrivenCommit()`, which
+   sets `commitInFlight=true` if **both** conditions hold:
+   - `now - lastCommitTimeMs >= commitInterval` (the configured
+     `sink.buffer-flush.interval-ms`).
+   - There is data to commit — either `txnCoordinator.hasDataLoaded()` is
+     true or at least one region still has pending inactiveChunks.
+4. **Autonomous flush**: drain any region whose `inactiveChunks` is
+   non-empty via the `FlushAndCommitStrategy`. Multi-table mode's `flush()`
+   only streams out already-frozen inactive chunks — it **never** touches
+   `activeChunk`. This preserves the invariant that every chunk reaching
+   StarRocks under the shared label comes from completed source transactions.
+
+When `commitInFlight=true` the main loop enters `processMultiTableCommit`,
+which waits for in-flight loads, triggers loads for any remaining inactive
+chunks, runs the unified commit via `SharedTransactionCoordinator`, updates
+`lastCommitTimeMs`, resets the tracker, and opens a new shared transaction
+for the next cycle.
+
+### 6.4 Shared Transaction Coordination
 
 All tables within the same commit cycle share a single StarRocks transaction managed by `SharedTransactionCoordinator`:
 
 1. **Eager transaction opening**: A shared transaction is opened eagerly before any autonomous flush, so all HTTP loads use the shared label. This eliminates the data-loss window where an independent-label flush could be orphaned when a shared transaction later overwrites the label.
-2. **Unified prepare + commit**: After all regions' data is loaded, a single `prepare + commit` is executed for the shared label.
-3. **Idle transaction recycling**: If the shared transaction remains open longer than 80% of the StarRocks server-side timeout (default: 480s for a 600s timeout), it is proactively recycled (commit-or-rollback + reopen) to prevent server-side timeout errors.
+2. **Unified commit**: After all regions' data is loaded, a single `commit` is executed for the shared label. Multi-table transactions skip the `prepare` step because StarRocks does not support `TXN_PREPARE` in multi-table mode.
+3. **Idle transaction recycling**: If the shared transaction remains open longer than 80% of the StarRocks server-side timeout (default: 480s for a 600s timeout), it is proactively recycled (commit-or-rollback + reopen) to prevent server-side timeout errors. Recycle fails fast if any region has in-progress transaction data (clean-boundary violation) or any partition has written data without ever receiving a txnEnd.
 
-### 6.3 Evicted Partition Re-registration
+### 6.5 PartitionCommitTracker (Safety Bookkeeping)
 
-After a successful commit, partitions that were SWITCHED but received no new data during the commit phase are evicted from tracking. This prevents idle partitions from permanently blocking `allSwitched()`. When an evicted partition sends a new `txnEnd`, it is automatically re-registered as `TXN_END_RECEIVED` so it participates correctly in the next commit cycle.
+In the current design, commit timing is driven entirely by the commit
+interval and the per-region clean-boundary flags. `PartitionCommitTracker`
+is reduced to an informational/safety aid:
 
-### 6.4 Autonomous Flush with Shared Labels
+- `onWrite(partition)` registers a partition as `ACTIVE` on first write.
+- `onTxnEnd(partition)` transitions the partition to `TXN_END_SEEN`
+  (sticky — subsequent writes do **not** demote it back to `ACTIVE`).
+- `getPartitionsWithoutTxnEnd()` lists partitions that have written data
+  but never received a txnEnd. Used by savepoint and recycle to fail fast
+  on upstream contract violations (a source transaction that never closed).
+- `reset()` clears all partitions at the end of a commit cycle.
 
-When the buffer cache exceeds `maxCacheBytes`, autonomous flushes are triggered. In multi-table mode, these autonomous flushes use the shared transaction label (not independent labels), ensuring all data — whether flushed by timer-driven commit or by buffer pressure — is part of the same atomic transaction.
+The tracker no longer drives switch/commit decisions, does not track a
+`SWITCHED` state, and does not manage pending txnEnd signals. Partitions
+that stop producing data after a commit are simply cleared by `reset()`;
+if they resume later, the next `onWrite` re-registers them.
 
-### 6.5 Safety Guarantees
+### 6.6 Autonomous Flush with Shared Labels
+
+When a region's `inactiveChunks` becomes non-empty, the manager thread's
+autonomous-flush loop streams it to StarRocks via
+`/api/transaction/load` under the **current shared label**. Because the
+shared transaction is always opened before any data is loaded, there is no
+window where data could be loaded under an independent (orphaned) label.
+In multi-table mode, `flush()` never triggers a `switchChunk` — it only
+drains already-frozen inactive chunks — so the invariant "every chunk
+reaching StarRocks under the shared label comes from completed source
+transactions" holds unconditionally.
+
+### 6.7 Safety Guarantees
 
 | Guarantee | Mechanism |
 |---|---|
-| switchChunk does not split source transactions | switchChunk is per-partition; only triggered when that partition has txnEnd |
-| Commit never includes partial source transactions | Commit waits until ALL active partitions reach txnEnd |
-| Multi-partition safety | Per-partition regions ensure one partition's switchChunk does not affect another's data |
-| Within-partition ordering | `keyBy(sourcePartition)` ensures same-partition data reaches the same sink subtask |
-| Task thread is non-blocking | switchChunk takes ~1ms; HTTP wait is handled asynchronously by the manager thread |
-| Periodic flush continues working | Manager thread buffer-management flushes run normally when `!commitInFlight` |
-| Autonomous flushes are transaction-safe | Autonomous flushes use the shared label; no orphaned independent-label loads |
-| Idle transactions don't timeout | Shared transactions are recycled at 80% of server timeout |
-| Idle partitions don't block commits | Evicted after commit if no new data arrived; re-registered on next txnEnd |
+| switchChunk does not split source transactions | `switchChunkForCommit` is only called at a clean transaction boundary (on txnEnd or when `activeChunkCleanBoundary=true`) |
+| Commit never includes partial source transactions | Every chunk reaching StarRocks originates from `switchChunkForCommit`; autonomous flush never switches `activeChunk` in multi-table mode |
+| Per-partition isolation | Each `(partition, table)` has its own region; one partition's switch never affects another's data |
+| Within-partition ordering | `keyBy(sourcePartition)` routes same-partition rows to the same sink subtask |
+| Task thread is non-blocking | `tryMiniIntervalSwitch` is O(regions-in-partition); HTTP work happens asynchronously on the manager thread |
+| Source-idle data visibility | Manager thread's `tryForceCleanSwitch` freezes clean `activeChunk`s after `miniInterval` of idleness, so data remains visible within `commitInterval + miniInterval` even if the source pauses |
+| Autonomous flushes are transaction-safe | Every load uses the shared label; every frozen chunk is from completed source transactions |
+| Idle transactions don't timeout | Shared transactions are recycled at 80% of server timeout; recycle fails fast on in-progress data |
+| Per-partition independent commit | A partition with a completed source transaction commits on the next commit interval, independent of other partitions' in-progress transactions |
 
-### 6.6 N:1 Transaction Mapping
+### 6.8 N:1 Transaction Mapping
 
-Multiple source transactions can accumulate in a single StarRocks transaction:
+Multiple source transactions can accumulate in a single StarRocks transaction
+via the miniInterval batching mechanism:
 
 ```
-Source txn K1 (3 rows) -> write -> buffer
-Source txn K2 (2 rows) -> write -> buffer   <-- transactionEnd=true + timer ready
-                                              -> switchChunk -> commit
-                                              -> K1 + K2 atomically committed to StarRocks
+Source txn K1 (3 rows) -> write -> activeChunk -> txnEnd (1st switch)
+Source txn K2 (2 rows) -> write -> activeChunk -> txnEnd (inside miniInterval: no switch)
+Source txn K3 (4 rows) -> write -> activeChunk -> txnEnd (inside miniInterval: no switch)
+                                                  (miniInterval elapsed → next switch batches K2+K3)
+                                                  -> ...
+commitInterval elapsed
+                                                  -> commit(label=A)
+                                                  -> K1 + K2 + K3 atomically committed to StarRocks
 ```
+
+Because the commit decision is time-driven (not tied to a specific txnEnd),
+the connector amortizes HTTP-load and begin/commit overhead across many
+small source transactions without any configuration changes. For a CDC
+source emitting 100 txnEnds per second with `commitInterval=1 s`,
+`miniInterval=100 ms`, the connector issues at most ~10 load calls per
+second instead of ~100.
 
 ## 7. Limitations
 
@@ -487,13 +603,15 @@ Source txn K2 (2 rows) -> write -> buffer   <-- transactionEnd=true + timer read
 
 3. **All tables must be in the same database**: StarRocks multi-table transactions are database-scoped; cross-database transactions are not supported.
 
-4. **Transaction scope is per sink subtask**: Each sink subtask maintains its own StarRocks transaction independently. The atomicity scope is "same subtask + same commit cycle + all tables."
+4. **Transaction scope is per sink subtask + per partition**: Each sink subtask maintains its own StarRocks transaction independently. Atomicity is guaranteed **within a single source transaction** (all rows for one txnEnd on one partition, across all tables that partition writes to). Data visibility across **different** source partitions can interleave: once partition P0's source transaction has fully arrived and the commit interval has elapsed, P0's data is committed even if partition P1's source transaction is still in progress. Applications that require cross-partition atomicity at the StarRocks level must either use a single source partition or coordinate commits upstream.
 
-5. **Depends on StarRocks cluster transaction settings**: Monitor running txn limits, prepared timeout (default 600s), and label retention. Ensure `sink.buffer-flush.interval-ms` is significantly shorter than the StarRocks transaction timeout.
+5. **Data visibility latency**: Governed by `sink.buffer-flush.interval-ms` and the internal `miniInterval = min(1000, max(100, commitInterval/10))`. In a continuously flowing CDC stream, an individual row becomes visible in StarRocks within roughly `commitInterval + miniInterval` of its source commit. During a source pause, previously-committed data remains visible while any row between the last switch and the pause becomes visible after one more `miniInterval` (handled by the manager-thread clean-boundary fallback).
 
-6. **Buffer flushes paused during commitInFlight**: While the async commit is in progress (typically 30-200ms), new data stays in active chunks and is not flushed. Under extreme throughput, if the buffer reaches `sink.transaction.multi-table.buffer-size` (default 128 MB), the task thread may briefly block until the commit completes.
+6. **Depends on StarRocks cluster transaction settings**: Monitor running txn limits, prepared timeout (default 600s), and label retention. Ensure `sink.buffer-flush.interval-ms` is significantly shorter than the StarRocks transaction timeout.
 
-7. **Cross-database writes are rejected**: Multi-table transactions validate that all regions belong to the same database. Writing to tables in different databases within the same commit cycle will throw an error.
+7. **activeChunk memory growth under long source transactions**: Because multi-table mode disables chunk-size-triggered internal switching (to preserve the clean-transaction-boundary invariant), `activeChunk` can grow until the next txnEnd arrives. Memory is bounded by `sink.transaction.multi-table.buffer-size` (soft) and `2 × buffer-size` (hard via `blockIfCacheFull`). Exceptionally large source transactions will throttle the task thread via back-pressure; if this becomes routine, either split the source transactions upstream or increase `sink.transaction.multi-table.buffer-size`.
+
+8. **Cross-database writes are rejected**: Multi-table transactions validate that all regions belong to the same database. Writing to tables in different databases within the same commit cycle will throw an error.
 
 ## 8. Monitoring and Troubleshooting
 
@@ -508,7 +626,7 @@ Common issues:
 | `transaction not existed` | StarRocks transaction timeout | The connector automatically recycles idle transactions at 80% of server timeout. If this still occurs, check if prepared timeout is too short or flush interval is too large |
 | `too many running txns` | Too many concurrent transactions | Reduce sink parallelism or increase StarRocks `max_running_txn_num_per_db` |
 | `Transaction start failed` | beginTransaction HTTP call failed | Verify load-url connectivity and StarRocks version (requires >= 4.0) |
-| High data visibility latency | Commit conditions not met | Verify upstream data has correct `transactionEnd=true` markers; check that no idle partitions are blocking `allSwitched()` |
+| High data visibility latency | Commit conditions not met | Verify upstream data has correct `transactionEnd=true` markers; expect up to `commitInterval + miniInterval` latency per row. If latency exceeds this budget, check the manager thread is not stuck in a recycle or in-flight load (see `StarRocks-Sink-Manager` logs) |
 | Cross-database write error | Tables in different databases in same commit cycle | Ensure all tables written in the same job belong to the same StarRocks database |
 
 ## 9. Best Practices

--- a/examples/src/main/java/com/starrocks/connector/flink/examples/datastream/WriteMultipleTablesWithTransaction.java
+++ b/examples/src/main/java/com/starrocks/connector/flink/examples/datastream/WriteMultipleTablesWithTransaction.java
@@ -1,0 +1,295 @@
+/*
+ * Copyright 2021-present StarRocks, Inc. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.starrocks.connector.flink.examples.datastream;
+
+import com.starrocks.connector.flink.table.data.DefaultStarRocksRowData;
+import com.starrocks.connector.flink.table.sink.SinkFunctionFactory;
+import com.starrocks.connector.flink.table.sink.StarRocksSinkOptions;
+import com.starrocks.data.load.stream.properties.StreamLoadTableProperties;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.utils.MultipleParameterTool;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
+import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
+import org.apache.flink.util.Collector;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Demonstrates multi-table atomic transaction write to StarRocks using the standard
+ * connector API ({@code SinkFunctionFactory.createSinkFunction}).
+ *
+ * <p>With {@code sink.transaction.multi-table.enabled=true}, the connector's internal
+ * {@code StreamLoadManagerV2} uses a single StarRocks transaction label across all
+ * tables. Multiple Kafka transactions accumulate in the buffer, and on timer-based
+ * flush, all tables are atomically committed together via a single prepare+commit.
+ *
+ * <h2>Architecture</h2>
+ * <pre>
+ * Kafka Source
+ *   → keyBy(partition)
+ *   → TransactionAssembler (buffers until TXN_END, emits per-row)
+ *   → keyBy(sourcePartition) → StarRocksDynamicSinkFunctionV2
+ *       internally: StreamLoadManagerV2 with multi-table transaction mode
+ *       → per-partition, per-table regions (PartitionCommitTracker)
+ *       → commit only when ALL active partitions reach txnEnd + interval elapsed
+ *       → each region sends data via /api/transaction/load
+ *       → per-region prepare + commit
+ * </pre>
+ *
+ * <h2>Key guarantees</h2>
+ * <ul>
+ *   <li>Multiple Kafka transactions can map to one StarRocks transaction (N:1)</li>
+ *   <li>TransactionAssembler ensures only complete Kafka transactions are emitted</li>
+ *   <li>Per-partition regions prevent one partition's switchChunk from affecting another</li>
+ *   <li>Commit waits for all active partitions to reach txnEnd boundary</li>
+ *   <li>Timer-based flush via {@code sink.buffer-flush.interval-ms}</li>
+ * </ul>
+ *
+ * <h2>Prerequisites</h2>
+ * <p>StarRocks >= 4.0, connector >= 1.2.9
+ * <pre>
+ * CREATE DATABASE `test`;
+ *
+ * CREATE TABLE `test`.`orders` (
+ *     `order_id` BIGINT NOT NULL,
+ *     `customer_id` BIGINT NOT NULL,
+ *     `total_amount` DECIMAL(10,2) DEFAULT "0",
+ *     `order_status` VARCHAR(32) DEFAULT ""
+ * ) ENGINE=OLAP PRIMARY KEY(`order_id`)
+ * DISTRIBUTED BY HASH(`order_id`)
+ * PROPERTIES("replication_num" = "1");
+ *
+ * CREATE TABLE `test`.`order_items` (
+ *     `item_id` BIGINT NOT NULL,
+ *     `order_id` BIGINT NOT NULL,
+ *     `product_name` VARCHAR(128) DEFAULT "",
+ *     `quantity` INT DEFAULT "0",
+ *     `price` DECIMAL(10,2) DEFAULT "0"
+ * ) ENGINE=OLAP PRIMARY KEY(`item_id`)
+ * DISTRIBUTED BY HASH(`item_id`)
+ * PROPERTIES("replication_num" = "1");
+ * </pre>
+ */
+public class WriteMultipleTablesWithTransaction {
+
+    // ==================== Event Model ====================
+
+    enum EventType { TXN_BEGIN, DATA, TXN_END }
+
+    static class TxnEvent implements Serializable {
+        private static final long serialVersionUID = 1L;
+
+        int partition;
+        String txnId;
+        EventType type;
+        String database;
+        String table;
+        String json;
+
+        TxnEvent() {}
+
+        TxnEvent(int partition, String txnId, EventType type,
+                 String database, String table, String json) {
+            this.partition = partition;
+            this.txnId = txnId;
+            this.type = type;
+            this.database = database;
+            this.table = table;
+            this.json = json;
+        }
+
+        static TxnEvent begin(int partition, String txnId) {
+            return new TxnEvent(partition, txnId, EventType.TXN_BEGIN, null, null, null);
+        }
+
+        static TxnEvent data(int partition, String txnId, String db, String table, String json) {
+            return new TxnEvent(partition, txnId, EventType.DATA, db, table, json);
+        }
+
+        static TxnEvent end(int partition, String txnId) {
+            return new TxnEvent(partition, txnId, EventType.TXN_END, null, null, null);
+        }
+    }
+
+    // ==================== Mock Source ====================
+
+    static class MockTxnEventSource extends RichParallelSourceFunction<TxnEvent> {
+        private volatile boolean running = true;
+
+        @Override
+        public void run(SourceContext<TxnEvent> ctx) throws Exception {
+            int partition = getRuntimeContext().getIndexOfThisSubtask();
+
+            for (int txn = 0; txn < 3 && running; txn++) {
+                String txnId = "txn-" + partition + "-" + txn;
+                ctx.collect(TxnEvent.begin(partition, txnId));
+
+                ctx.collect(TxnEvent.data(partition, txnId, "test", "orders",
+                        String.format("{\"order_id\":%d, \"customer_id\":%d, " +
+                                        "\"total_amount\":%.2f, \"order_status\":\"created\"}",
+                                partition * 1000L + txn, txn + 100L, 99.99 + txn)));
+
+                ctx.collect(TxnEvent.data(partition, txnId, "test", "order_items",
+                        String.format("{\"item_id\":%d, \"order_id\":%d, " +
+                                        "\"product_name\":\"product-%d\", \"quantity\":%d, \"price\":%.2f}",
+                                partition * 10000L + txn * 10,
+                                partition * 1000L + txn, txn, txn + 1, 49.99 + txn)));
+
+                ctx.collect(TxnEvent.end(partition, txnId));
+            }
+        }
+
+        @Override
+        public void cancel() {
+            running = false;
+        }
+    }
+
+    // ==================== Transaction Assembler ====================
+
+    /**
+     * Buffers DATA events per partition; on TXN_END emits the complete
+     * transaction's rows as individual {@link DefaultStarRocksRowData} records.
+     *
+     * <p>Only emits when a Kafka transaction is fully closed (TXN_END received).
+     * All rows are emitted synchronously within one {@code processElement()} call,
+     * so they enter the downstream sink buffer without intervening checkpoint barriers.
+     *
+     * <p>Multiple Kafka transactions accumulate in the sink's buffer between
+     * flush cycles—the connector handles grouping them into StarRocks transactions.
+     */
+    static class TransactionAssembler
+            extends KeyedProcessFunction<Integer, TxnEvent, DefaultStarRocksRowData> {
+
+        private transient ListState<TxnEvent> pendingRows;
+
+        @Override
+        public void open(Configuration parameters) throws Exception {
+            ListStateDescriptor<TxnEvent> descriptor = new ListStateDescriptor<>(
+                    "pending-txn-rows", Types.POJO(TxnEvent.class));
+            pendingRows = getRuntimeContext().getListState(descriptor);
+        }
+
+        @Override
+        public void processElement(TxnEvent event, Context ctx,
+                                   Collector<DefaultStarRocksRowData> out) throws Exception {
+            switch (event.type) {
+                case TXN_BEGIN:
+                    pendingRows.clear();
+                    break;
+
+                case DATA:
+                    pendingRows.add(event);
+                    break;
+
+                case TXN_END:
+                    List<TxnEvent> rows = new ArrayList<>();
+                    for (TxnEvent row : pendingRows.get()) {
+                        rows.add(row);
+                    }
+                    int partition = ctx.getCurrentKey();
+                    for (int i = 0; i < rows.size(); i++) {
+                        TxnEvent row = rows.get(i);
+                        DefaultStarRocksRowData rowData = new DefaultStarRocksRowData(
+                                null, row.database, row.table, row.json);
+                        rowData.setSourcePartition(partition);
+                        if (i == rows.size() - 1) {
+                            rowData.setTransactionEnd(true);
+                        }
+                        out.collect(rowData);
+                    }
+                    pendingRows.clear();
+                    break;
+            }
+        }
+    }
+
+    // ==================== Main ====================
+
+    public static void main(String[] args) throws Exception {
+        MultipleParameterTool params = MultipleParameterTool.fromArgs(args);
+        String jdbcUrl = params.get("jdbcUrl", "jdbc:mysql://127.0.0.1:9030");
+        String loadUrl = params.get("loadUrl", "127.0.0.1:8030");
+        String userName = params.get("userName", "root");
+        String password = params.get("password", "");
+
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.enableCheckpointing(10_000);
+
+        DataStream<TxnEvent> events = env.addSource(new MockTxnEventSource());
+
+        // TransactionAssembler emits rows only after TXN_END.
+        // Multiple closed Kafka txns accumulate in the sink buffer between flushes.
+        DataStream<DefaultStarRocksRowData> rows = events
+                .keyBy(e -> e.partition)
+                .process(new TransactionAssembler());
+
+        // keyBy(sourcePartition) routes same-partition data to the same sink subtask.
+        // The connector uses per-partition regions internally, so even when multiple
+        // partitions land on the same sink subtask, transaction boundaries are tracked
+        // independently per partition via PartitionCommitTracker.
+        DataStream<DefaultStarRocksRowData> partitionedRows = rows
+                .keyBy(DefaultStarRocksRowData::getSourcePartition);
+
+        // sink.transaction.multi-table.enabled=true activates per-partition region
+        // tracking inside StreamLoadManagerV2: each partition's regions are switched
+        // independently when its txnEnd arrives, and commit triggers only when all
+        // active partitions have been switched.
+        StarRocksSinkOptions options = StarRocksSinkOptions.builder()
+                .withProperty("jdbc-url", jdbcUrl)
+                .withProperty("load-url", loadUrl)
+                .withProperty("database-name", "*")
+                .withProperty("table-name", "*")
+                .withProperty("username", userName)
+                .withProperty("password", password)
+                .withProperty("sink.version", "V2")
+                .withProperty("sink.semantic", "at-least-once")
+                .withProperty("sink.transaction.multi-table.enabled", "true")
+                .withProperty("sink.buffer-flush.interval-ms", "1000")
+                .withProperty("sink.properties.format", "json")
+                .withProperty("sink.properties.strip_outer_array", "true")
+                .build();
+
+        StreamLoadTableProperties orderItemsProps = StreamLoadTableProperties.builder()
+                .database("test")
+                .table("order_items")
+                .addProperty("format", "json")
+                .addProperty("strip_outer_array", "true")
+                .addProperty("ignore_json_size", "true")
+                .build();
+        options.addTableProperties(orderItemsProps);
+
+        // Standard connector API — no custom SinkFunction needed.
+        // addSink on the keyBy'd stream ensures partition affinity.
+        SinkFunction<DefaultStarRocksRowData> sink = SinkFunctionFactory.createSinkFunction(options);
+        partitionedRows.addSink(sink);
+
+        env.execute("WriteMultipleTablesWithTransaction");
+    }
+}

--- a/src/main/java/com/starrocks/connector/flink/table/data/DefaultStarRocksRowData.java
+++ b/src/main/java/com/starrocks/connector/flink/table/data/DefaultStarRocksRowData.java
@@ -25,6 +25,8 @@ public class DefaultStarRocksRowData implements StarRocksRowData {
     private String database;
     private String table;
     private String row;
+    private boolean transactionEnd;
+    private int sourcePartition = -1;
 
     public DefaultStarRocksRowData() {
 
@@ -79,5 +81,23 @@ public class DefaultStarRocksRowData implements StarRocksRowData {
     @Override
     public String getRow() {
         return row;
+    }
+
+    public void setTransactionEnd(boolean transactionEnd) {
+        this.transactionEnd = transactionEnd;
+    }
+
+    @Override
+    public boolean isTransactionEnd() {
+        return transactionEnd;
+    }
+
+    public void setSourcePartition(int sourcePartition) {
+        this.sourcePartition = sourcePartition;
+    }
+
+    @Override
+    public int getSourcePartition() {
+        return sourcePartition;
     }
 }

--- a/src/main/java/com/starrocks/connector/flink/table/data/StarRocksRowData.java
+++ b/src/main/java/com/starrocks/connector/flink/table/data/StarRocksRowData.java
@@ -27,4 +27,23 @@ public interface StarRocksRowData {
     String getTable();
     String getRow();
 
+    /**
+     * Indicates this is the last row of a source transaction batch.
+     * Used by multi-table transaction mode to determine safe commit points:
+     * the connector only commits when the most recent write had this flag set,
+     * ensuring no partial source transaction is committed.
+     */
+    default boolean isTransactionEnd() {
+        return false;
+    }
+
+    /**
+     * Returns the source partition ID for this row.
+     * Used by multi-table transaction mode to track per-partition transaction
+     * boundaries. Returns {@code -1} when partition tracking is not applicable.
+     */
+    default int getSourcePartition() {
+        return -1;
+    }
+
 }

--- a/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksDynamicSinkFunctionV2.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksDynamicSinkFunctionV2.java
@@ -136,14 +136,22 @@ public class StarRocksDynamicSinkFunctionV2<T> extends StarRocksDynamicSinkFunct
                 return;
             } else if (value instanceof StarRocksRowData) {
                 StarRocksRowData data = (StarRocksRowData) value;
+                int partition = data.getSourcePartition();
                 if (Strings.isNullOrEmpty(data.getDatabase())
                         || Strings.isNullOrEmpty(data.getTable())
                         || data.getRow() == null) {
-                    log.warn(String.format("json row data not fulfilled. {database: %s, table: %s, dataRows: %s}",
-                            data.getDatabase(), data.getTable(), data.getRow() == null ? "null" : "Redacted"));
+                    if (data.isTransactionEnd()) {
+                        log.debug("[MultiTxn] invoke: control-only txnEnd row, partition={}", partition);
+                        sinkManager.setCommitAllowed(partition, true);
+                    }
                     return;
                 }
-                sinkManager.write(data.getUniqueKey(), data.getDatabase(), data.getTable(), data.getRow());
+                if (partition >= 0) {
+                    sinkManager.write(partition, data.getDatabase(), data.getTable(), data.getRow());
+                    sinkManager.setCommitAllowed(partition, data.isTransactionEnd());
+                } else {
+                    sinkManager.write(data.getUniqueKey(), data.getDatabase(), data.getTable(), data.getRow());
+                }
                 return;
             }
             // raw data sink

--- a/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksDynamicSinkFunctionV2.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksDynamicSinkFunctionV2.java
@@ -137,6 +137,25 @@ public class StarRocksDynamicSinkFunctionV2<T> extends StarRocksDynamicSinkFunct
             } else if (value instanceof StarRocksRowData) {
                 StarRocksRowData data = (StarRocksRowData) value;
                 int partition = data.getSourcePartition();
+                // Fail fast: in multi-table transaction mode every StarRocksRowData
+                // (including control-only txnEnd markers) must carry a non-negative
+                // source partition. A data row with partition=-1 would otherwise fall
+                // through to the legacy write(uniqueKey, ...) path, whose activeChunk
+                // is never switched mid-transaction and never receives a txnEnd signal,
+                // eventually stalling the task thread on blockIfCacheFull. A control-
+                // only txnEnd row with partition=-1 would invoke setCommitAllowed(-1,
+                // true), which silently targets a non-existent partition: the real
+                // regions where data was written never receive their txnEnd signal
+                // and their chunks remain stuck until backpressure or timeout. Gating
+                // both branches here closes both holes.
+                if (partition < 0 && sinkOptions.isMultiTableTransactionEnabled()) {
+                    throw new IllegalStateException(
+                            "Multi-table transaction mode requires a non-negative source "
+                                    + "partition on every StarRocksRowData, but received partition="
+                                    + partition + " for database=" + data.getDatabase()
+                                    + ", table=" + data.getTable() + ". Update the serializer "
+                                    + "to override StarRocksRowData#getSourcePartition().");
+                }
                 if (Strings.isNullOrEmpty(data.getDatabase())
                         || Strings.isNullOrEmpty(data.getTable())
                         || data.getRow() == null) {
@@ -150,22 +169,6 @@ public class StarRocksDynamicSinkFunctionV2<T> extends StarRocksDynamicSinkFunct
                     sinkManager.write(partition, data.getDatabase(), data.getTable(), data.getRow());
                     sinkManager.setCommitAllowed(partition, data.isTransactionEnd());
                 } else {
-                    // Fail fast: in multi-table transaction mode a negative partition would
-                    // route the row to the legacy write(uniqueKey, ...) path, which does not
-                    // participate in partition-scoped setCommitAllowed tracking. The region
-                    // it targets still runs with multiTableTransactionEnabled=true, so its
-                    // activeChunk is never switched (size/row-based switching is disabled
-                    // and no txnEnd will ever arrive for it), which ultimately stalls the
-                    // task thread on blockIfCacheFull. Require callers/serializers to set
-                    // a non-negative source partition instead of silently downgrading.
-                    if (sinkOptions.isMultiTableTransactionEnabled()) {
-                        throw new IllegalStateException(
-                                "Multi-table transaction mode requires a non-negative source "
-                                        + "partition on every StarRocksRowData, but received partition="
-                                        + partition + " for database=" + data.getDatabase()
-                                        + ", table=" + data.getTable() + ". Update the serializer "
-                                        + "to override StarRocksRowData#getSourcePartition().");
-                    }
                     sinkManager.write(data.getUniqueKey(), data.getDatabase(), data.getTable(), data.getRow());
                 }
                 return;

--- a/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksDynamicSinkFunctionV2.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksDynamicSinkFunctionV2.java
@@ -150,6 +150,22 @@ public class StarRocksDynamicSinkFunctionV2<T> extends StarRocksDynamicSinkFunct
                     sinkManager.write(partition, data.getDatabase(), data.getTable(), data.getRow());
                     sinkManager.setCommitAllowed(partition, data.isTransactionEnd());
                 } else {
+                    // Fail fast: in multi-table transaction mode a negative partition would
+                    // route the row to the legacy write(uniqueKey, ...) path, which does not
+                    // participate in partition-scoped setCommitAllowed tracking. The region
+                    // it targets still runs with multiTableTransactionEnabled=true, so its
+                    // activeChunk is never switched (size/row-based switching is disabled
+                    // and no txnEnd will ever arrive for it), which ultimately stalls the
+                    // task thread on blockIfCacheFull. Require callers/serializers to set
+                    // a non-negative source partition instead of silently downgrading.
+                    if (sinkOptions.isMultiTableTransactionEnabled()) {
+                        throw new IllegalStateException(
+                                "Multi-table transaction mode requires a non-negative source "
+                                        + "partition on every StarRocksRowData, but received partition="
+                                        + partition + " for database=" + data.getDatabase()
+                                        + ", table=" + data.getTable() + ". Update the serializer "
+                                        + "to override StarRocksRowData#getSourcePartition().");
+                    }
                     sinkManager.write(data.getUniqueKey(), data.getDatabase(), data.getTable(), data.getRow());
                 }
                 return;

--- a/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksSinkOptions.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksSinkOptions.java
@@ -117,6 +117,20 @@ public class StarRocksSinkOptions implements Serializable {
     public static final ConfigOption<Boolean> SINK_AT_LEAST_ONCE_USE_TRANSACTION_LOAD = ConfigOptions.key("sink.at-least-once.use-transaction-stream-load")
             .booleanType().defaultValue(true).withDescription("Whether to use transaction stream load for at-least-once when it's available.");
 
+    public static final ConfigOption<Boolean> SINK_MULTI_TABLE_TXN_ENABLED = ConfigOptions.key("sink.transaction.multi-table.enabled")
+            .booleanType().defaultValue(false).withDescription("Whether to enable multi-table atomic transaction. " +
+                    "When enabled, all tables written within the same flush cycle share one StarRocks transaction label, " +
+                    "and are atomically committed together. Requires StarRocks >= 4.0 and sink.version=V2. " +
+                    "Only at-least-once semantics is supported; exactly-once is not compatible with multi-table transactions.");
+
+    public static final ConfigOption<Long> SINK_MULTI_TABLE_TXN_BUFFER_SIZE =
+            ConfigOptions.key("sink.transaction.multi-table.buffer-size")
+                    .longType()
+                    .defaultValue(128L * MEGA_BYTES_SCALE)
+                    .withDescription("Global buffer size in bytes for multi-table transaction mode. " +
+                            "When the total buffered data across all tables reaches this threshold, " +
+                            "a flush is triggered. Default is 128MB.");
+
     public static final ConfigOption<Integer> SINK_MAX_RETRIES = ConfigOptions.key("sink.max-retries")
             .intType().defaultValue(3).withDescription("Max flushing retry times of the row batch.");
 
@@ -214,7 +228,7 @@ public class StarRocksSinkOptions implements Serializable {
         }
 
         for (StreamLoadTableProperties properties : tablePropertiesList) {
-            dbTables.add(Tuple2.of(properties.getDatabase(), getTableName()));
+            dbTables.add(Tuple2.of(properties.getDatabase(), properties.getTable()));
         }
 
         return new ArrayList<>(dbTables);
@@ -226,6 +240,7 @@ public class StarRocksSinkOptions implements Serializable {
         validateSinkSemantic();
         validateParamsRange();
         validateMergeCommit();
+        validateMultiTableTransaction();
     }
 
     public void setTableSchemaFieldNames(String[] fieldNames) {
@@ -347,6 +362,14 @@ public class StarRocksSinkOptions implements Serializable {
 
     public boolean getSinkAtLeastOnceUseTransactionStreamLoad() {
         return tableOptions.get(SINK_AT_LEAST_ONCE_USE_TRANSACTION_LOAD);
+    }
+
+    public boolean isMultiTableTransactionEnabled() {
+        return tableOptions.get(SINK_MULTI_TABLE_TXN_ENABLED);
+    }
+
+    public long getMultiTableTransactionBufferSize() {
+        return tableOptions.get(SINK_MULTI_TABLE_TXN_BUFFER_SIZE);
     }
 
     public Map<String, String> getSinkStreamLoadProperties() {
@@ -506,6 +529,17 @@ public class StarRocksSinkOptions implements Serializable {
         }
     }
 
+    private void validateMultiTableTransaction() {
+        if (!tableOptions.get(SINK_MULTI_TABLE_TXN_ENABLED)) {
+            return;
+        }
+        if (sinkSemantic == StarRocksSinkSemantic.EXACTLY_ONCE) {
+            throw new ValidationException(
+                    "Multi-table transaction stream load does not support exactly-once semantics. " +
+                    "Please use at-least-once semantics with '" + SINK_MULTI_TABLE_TXN_ENABLED.key() + "'.");
+        }
+    }
+
     private void parseSinkStreamLoadProperties() {
         tableOptionsMap.keySet().stream()
                 .filter(key -> key.startsWith(SINK_PROPERTIES_PREFIX))
@@ -638,6 +672,12 @@ public class StarRocksSinkOptions implements Serializable {
                         || getSinkAtLeastOnceUseTransactionStreamLoad())) {
             builder.enableTransaction();
             log.info("Enable transaction stream load");
+        }
+        if (isMultiTableTransactionEnabled()) {
+            builder.enableTransaction();
+            builder.enableMultiTableTransaction();
+            builder.multiTableTransactionBufferSize(getMultiTableTransactionBufferSize());
+            log.info("Enable multi-table transaction stream load");
         }
         return builder.build();
     }

--- a/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksSinkOptions.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksSinkOptions.java
@@ -538,6 +538,11 @@ public class StarRocksSinkOptions implements Serializable {
                     "Multi-table transaction stream load does not support exactly-once semantics. " +
                     "Please use at-least-once semantics with '" + SINK_MULTI_TABLE_TXN_ENABLED.key() + "'.");
         }
+        if (SinkFunctionFactory.SinkVersion.V1.name().equalsIgnoreCase(tableOptions.get(SINK_VERSION))) {
+            throw new ValidationException(
+                    "Multi-table transaction stream load requires sink.version=V2 or AUTO. " +
+                    "Current sink.version='V1'.");
+        }
     }
 
     private void parseSinkStreamLoadProperties() {

--- a/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksSinkOptions.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/StarRocksSinkOptions.java
@@ -543,6 +543,12 @@ public class StarRocksSinkOptions implements Serializable {
                     "Multi-table transaction stream load requires sink.version=V2 or AUTO. " +
                     "Current sink.version='V1'.");
         }
+        if ("true".equalsIgnoreCase(streamLoadProps.get(LoadParameters.ENABLE_MERGE_COMMIT))) {
+            throw new ValidationException(
+                    "Multi-table transaction stream load is incompatible with merge commit. " +
+                    "Please disable '" + SINK_PROPERTIES_PREFIX + LoadParameters.ENABLE_MERGE_COMMIT +
+                    "' when '" + SINK_MULTI_TABLE_TXN_ENABLED.key() + "' is enabled.");
+        }
     }
 
     private void parseSinkStreamLoadProperties() {

--- a/src/main/java/com/starrocks/connector/flink/table/sink/v2/StarRocksWriter.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/v2/StarRocksWriter.java
@@ -140,7 +140,19 @@ public class StarRocksWriter<InputT>
         if (rowData == null) {
             return;
         }
-        sinkManager.write(rowData.getUniqueKey(), rowData.getDatabase(), rowData.getTable(), rowData.getRow());
+        int partition = rowData.getSourcePartition();
+        if (rowData.getRow() == null) {
+            if (rowData.isTransactionEnd()) {
+                sinkManager.setCommitAllowed(partition, true);
+            }
+            return;
+        }
+        if (partition >= 0) {
+            sinkManager.write(partition, rowData.getDatabase(), rowData.getTable(), rowData.getRow());
+            sinkManager.setCommitAllowed(partition, rowData.isTransactionEnd());
+        } else {
+            sinkManager.write(rowData.getUniqueKey(), rowData.getDatabase(), rowData.getTable(), rowData.getRow());
+        }
         totalReceivedRows += 1;
         if (totalReceivedRows % 100 == 1) {
             LOG.debug("Received raw record: {}", element);

--- a/src/main/java/com/starrocks/connector/flink/table/sink/v2/StarRocksWriter.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/v2/StarRocksWriter.java
@@ -141,6 +141,24 @@ public class StarRocksWriter<InputT>
             return;
         }
         int partition = rowData.getSourcePartition();
+        // Fail fast: in multi-table transaction mode every StarRocksRowData (including
+        // control-only txnEnd markers) must carry a non-negative source partition.
+        // A data row with partition=-1 would otherwise fall through to the legacy
+        // write(uniqueKey, ...) path, whose activeChunk is never switched mid-
+        // transaction and never receives a txnEnd signal, eventually stalling the
+        // task thread on blockIfCacheFull. A control-only txnEnd row with partition=-1
+        // would invoke setCommitAllowed(-1, true), which silently targets a non-
+        // existent partition: the real regions where data was written never receive
+        // their txnEnd signal and their chunks remain stuck until backpressure or
+        // timeout. Gating both branches here closes both holes.
+        if (partition < 0 && sinkOptions.isMultiTableTransactionEnabled()) {
+            throw new IllegalStateException(
+                    "Multi-table transaction mode requires a non-negative source "
+                            + "partition on every StarRocksRowData, but received partition="
+                            + partition + " for database=" + rowData.getDatabase()
+                            + ", table=" + rowData.getTable() + ". Update the serializer "
+                            + "to override StarRocksRowData#getSourcePartition().");
+        }
         if (rowData.getRow() == null) {
             if (rowData.isTransactionEnd()) {
                 sinkManager.setCommitAllowed(partition, true);
@@ -151,22 +169,6 @@ public class StarRocksWriter<InputT>
             sinkManager.write(partition, rowData.getDatabase(), rowData.getTable(), rowData.getRow());
             sinkManager.setCommitAllowed(partition, rowData.isTransactionEnd());
         } else {
-            // Fail fast: in multi-table transaction mode a negative partition would
-            // route the row to the legacy write(uniqueKey, ...) path, which does not
-            // participate in partition-scoped setCommitAllowed tracking. The region
-            // it targets still runs with multiTableTransactionEnabled=true, so its
-            // activeChunk is never switched (size/row-based switching is disabled
-            // and no txnEnd will ever arrive for it), which ultimately stalls the
-            // task thread on blockIfCacheFull. Require callers/serializers to set
-            // a non-negative source partition instead of silently downgrading.
-            if (sinkOptions.isMultiTableTransactionEnabled()) {
-                throw new IllegalStateException(
-                        "Multi-table transaction mode requires a non-negative source "
-                                + "partition on every StarRocksRowData, but received partition="
-                                + partition + " for database=" + rowData.getDatabase()
-                                + ", table=" + rowData.getTable() + ". Update the serializer "
-                                + "to override StarRocksRowData#getSourcePartition().");
-            }
             sinkManager.write(rowData.getUniqueKey(), rowData.getDatabase(), rowData.getTable(), rowData.getRow());
         }
         totalReceivedRows += 1;

--- a/src/main/java/com/starrocks/connector/flink/table/sink/v2/StarRocksWriter.java
+++ b/src/main/java/com/starrocks/connector/flink/table/sink/v2/StarRocksWriter.java
@@ -151,6 +151,22 @@ public class StarRocksWriter<InputT>
             sinkManager.write(partition, rowData.getDatabase(), rowData.getTable(), rowData.getRow());
             sinkManager.setCommitAllowed(partition, rowData.isTransactionEnd());
         } else {
+            // Fail fast: in multi-table transaction mode a negative partition would
+            // route the row to the legacy write(uniqueKey, ...) path, which does not
+            // participate in partition-scoped setCommitAllowed tracking. The region
+            // it targets still runs with multiTableTransactionEnabled=true, so its
+            // activeChunk is never switched (size/row-based switching is disabled
+            // and no txnEnd will ever arrive for it), which ultimately stalls the
+            // task thread on blockIfCacheFull. Require callers/serializers to set
+            // a non-negative source partition instead of silently downgrading.
+            if (sinkOptions.isMultiTableTransactionEnabled()) {
+                throw new IllegalStateException(
+                        "Multi-table transaction mode requires a non-negative source "
+                                + "partition on every StarRocksRowData, but received partition="
+                                + partition + " for database=" + rowData.getDatabase()
+                                + ", table=" + rowData.getTable() + ". Update the serializer "
+                                + "to override StarRocksRowData#getSourcePartition().");
+            }
             sinkManager.write(rowData.getUniqueKey(), rowData.getDatabase(), rowData.getTable(), rowData.getRow());
         }
         totalReceivedRows += 1;

--- a/src/test/java/com/starrocks/connector/flink/it/StarRocksITTestBase.java
+++ b/src/test/java/com/starrocks/connector/flink/it/StarRocksITTestBase.java
@@ -60,21 +60,59 @@ public abstract class StarRocksITTestBase {
     protected static Connection DB_CONNECTION;
     protected static Set<String> DATABASE_SET_TO_CLEAN;
 
+    /**
+     * External TSP / manual cluster: JVM properties first, then env (e.g. CI).
+     * When both HTTP and JDBC are set, Testcontainers is skipped.
+     */
+    private static String resolveFeConfig(String propKey, String envKey, String defaultValue) {
+        String v = System.getProperty(propKey);
+        if (v != null && !v.isEmpty()) {
+            return v;
+        }
+        v = System.getenv(envKey);
+        if (v != null && !v.isEmpty()) {
+            return v;
+        }
+        return defaultValue;
+    }
+
     @BeforeClass
     public static void setUp() throws Exception {
         if (!DEBUG_MODE) {
-            try {
-                StarRocksTestEnvironment env = StarRocksTestEnvironment.getInstance();
-                env.startIfNeeded();
-                HTTP_URLS = env.getHttpAddress();
-                JDBC_URLS = env.getJdbcUrl();
-                USERNAME = env.getUsername();
-                PASSWORD = env.getPassword();
-            } catch (Throwable t) {
-                LOG.warn("Failed to start StarRocks container, ITs may be skipped if no external cluster is provided.", t);
+            String extHttp = resolveFeConfig("it.starrocks.fe.http", "SR_HTTP_URLS", null);
+            String extJdbc = resolveFeConfig("it.starrocks.fe.jdbc", "SR_JDBC_URLS", null);
+            if (extHttp != null && extJdbc != null) {
+                HTTP_URLS = extHttp;
+                JDBC_URLS = extJdbc;
+                USERNAME = resolveFeConfig("it.starrocks.username", "SR_USERNAME", "root");
+                PASSWORD = resolveFeConfig("it.starrocks.password", "SR_PASSWORD", "");
+                LOG.info("Using external StarRocks cluster: http={}, jdbc={}", HTTP_URLS, JDBC_URLS);
+            } else {
+                try {
+                    StarRocksTestEnvironment env = StarRocksTestEnvironment.getInstance();
+                    env.startIfNeeded();
+                    String h = env.getHttpAddress();
+                    String j = env.getJdbcUrl();
+                    if (h != null && j != null) {
+                        HTTP_URLS = h;
+                        JDBC_URLS = j;
+                        USERNAME = env.getUsername();
+                        PASSWORD = env.getPassword();
+                        LOG.info("Using StarRocks Testcontainer: http={}, jdbc={}", HTTP_URLS, JDBC_URLS);
+                    } else {
+                        LOG.warn(
+                                "StarRocks Testcontainer did not expose addresses (start may have failed). "
+                                        + "Set -Dit.starrocks.fe.http / -Dit.starrocks.fe.jdbc or SR_HTTP_URLS / SR_JDBC_URLS for TSP.");
+                    }
+                } catch (Throwable t) {
+                    LOG.warn("Failed to start StarRocks container, ITs may be skipped if no external cluster is provided.", t);
+                }
             }
         }
-        assertTrue(HTTP_URLS != null && JDBC_URLS != null);
+        assertTrue(
+                "HTTP_URLS and JDBC_URLS must be set. For TSP use -Dit.starrocks.fe.http=host:8030 "
+                        + "-Dit.starrocks.fe.jdbc=jdbc:mysql://host:9030 or SR_HTTP_URLS / SR_JDBC_URLS.",
+                HTTP_URLS != null && !HTTP_URLS.isEmpty() && JDBC_URLS != null && !JDBC_URLS.isEmpty());
 
         DB_NAME = "sr_test_" + genRandomUuid();
         try {

--- a/src/test/java/com/starrocks/connector/flink/it/StarRocksITTestBase.java
+++ b/src/test/java/com/starrocks/connector/flink/it/StarRocksITTestBase.java
@@ -28,6 +28,8 @@ import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.starrocks.data.load.stream.StarRocksVersion;
+
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
@@ -168,6 +170,26 @@ public abstract class StarRocksITTestBase {
 
     protected static String getJdbcUrl() {
         return JDBC_URLS;
+    }
+
+    protected static StarRocksVersion getStarRocksVersion() {
+        try (Statement statement = DB_CONNECTION.createStatement();
+             ResultSet rs = statement.executeQuery("SELECT current_version()")) {
+            if (rs.next()) {
+                return StarRocksVersion.parse(rs.getString(1));
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to query StarRocks version", e);
+        }
+        return null;
+    }
+
+    protected static boolean isStarRocksVersionAtLeast(int major, int minor) {
+        StarRocksVersion v = getStarRocksVersion();
+        if (v == null) {
+            return false;
+        }
+        return v.getMajor() > major || (v.getMajor() == major && v.getMinor() >= minor);
     }
 
     public static class TransactionInfo {

--- a/src/test/java/com/starrocks/connector/flink/it/StarRocksITTestBase.java
+++ b/src/test/java/com/starrocks/connector/flink/it/StarRocksITTestBase.java
@@ -38,6 +38,7 @@ import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.UUID;
 
@@ -210,16 +211,22 @@ public abstract class StarRocksITTestBase {
         return JDBC_URLS;
     }
 
-    protected static StarRocksVersion getStarRocksVersion() {
+    /** Raw string from {@code SELECT current_version()} (may be unparsable for dev builds). */
+    protected static String getStarRocksVersionRaw() {
         try (Statement statement = DB_CONNECTION.createStatement();
              ResultSet rs = statement.executeQuery("SELECT current_version()")) {
             if (rs.next()) {
-                return StarRocksVersion.parse(rs.getString(1));
+                return rs.getString(1);
             }
         } catch (Exception e) {
-            LOG.warn("Failed to query StarRocks version", e);
+            LOG.warn("Failed to query StarRocks version string", e);
         }
         return null;
+    }
+
+    protected static StarRocksVersion getStarRocksVersion() {
+        String raw = getStarRocksVersionRaw();
+        return raw == null ? null : StarRocksVersion.parse(raw);
     }
 
     protected static boolean isStarRocksVersionAtLeast(int major, int minor) {
@@ -228,6 +235,22 @@ public abstract class StarRocksITTestBase {
             return false;
         }
         return v.getMajor() > major || (v.getMajor() == major && v.getMinor() >= minor);
+    }
+
+    /**
+     * Multi-table transaction ITs: require released {@code >= 4.0}, or a development build whose
+     * {@code current_version()} string contains {@code main} (typical for main-branch TSP clusters).
+     */
+    protected static boolean isMultiTableTransactionClusterSupported() {
+        String raw = getStarRocksVersionRaw();
+        if (raw == null) {
+            return false;
+        }
+        if (raw.toLowerCase(Locale.ROOT).contains("main")) {
+            return true;
+        }
+        StarRocksVersion v = StarRocksVersion.parse(raw);
+        return v != null && v.getMajor() >= 4;
     }
 
     public static class TransactionInfo {

--- a/src/test/java/com/starrocks/connector/flink/it/sink/MultiTableTransactionITTest.java
+++ b/src/test/java/com/starrocks/connector/flink/it/sink/MultiTableTransactionITTest.java
@@ -1,0 +1,1449 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.starrocks.connector.flink.it.sink;
+
+import com.starrocks.connector.flink.it.StarRocksITTestBase;
+import com.starrocks.connector.flink.table.data.DefaultStarRocksRowData;
+import com.starrocks.connector.flink.table.data.StarRocksRowData;
+import com.starrocks.connector.flink.table.sink.SinkFunctionFactory;
+import com.starrocks.connector.flink.table.sink.StarRocksSinkOptions;
+import com.starrocks.connector.flink.table.sink.v2.RecordSerializationSchema;
+import com.starrocks.connector.flink.table.sink.v2.StarRocksSink;
+import com.starrocks.connector.flink.table.sink.v2.StarRocksSinkContext;
+import com.starrocks.data.load.stream.properties.StreamLoadTableProperties;
+import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.starrocks.connector.flink.it.sink.StarRocksTableUtils.scanTable;
+import static com.starrocks.connector.flink.it.sink.StarRocksTableUtils.verifyResult;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Integration tests for multi-table atomic transaction stream load.
+ *
+ * <p>Requires StarRocks >= 4.0 for multi-table transaction support.
+ *
+ * <p>Run against an external cluster:
+ * <pre>
+ *   mvn test -Dtest=MultiTableTransactionITTest \
+ *     -Dit.starrocks.fe.http=172.26.95.228:8030 \
+ *     -Dit.starrocks.fe.jdbc=jdbc:mysql://172.26.95.228:9030
+ * </pre>
+ *
+ * <h2>Test coverage</h2>
+ * <ol>
+ *   <li>{@link #testEndToEndMultiPartition} — end-to-end write with parallelism=2 and
+ *       per-partition routing; verifies data correctness across two tables.</li>
+ *   <li>{@link #testNoFlushBeforeTxnEnd} — transaction consistency: data must NOT be
+ *       visible before txnEnd, and MUST be visible shortly after.</li>
+ *   <li>{@link #testMultipleConsecutiveTransactions} — consecutive transaction isolation:
+ *       txn-2 data must not be committed until txn-2's own txnEnd arrives (re-arm logic).</li>
+ *   <li>{@link #testEmptyTransaction} — boundary: a txnEnd with no preceding data must
+ *       not cause errors.</li>
+ *   <li>{@link #testAtomicVisibilityAcrossTables} — atomicity: both tables become visible
+ *       simultaneously via a single shared StarRocks transaction label.</li>
+ *   <li>{@link #testPartialPartitionTxnEndBlocking} — blocking: when only one of two
+ *       partitions has sent txnEnd, data must NOT be committed.</li>
+ *   <li>{@link #testCheckpointTriggeredFlushDataIntegrity} — checkpoint: Flink checkpoint
+ *       triggers flush(), all buffered data must be committed completely.</li>
+ *   <li>{@link #testTransactionWithinSingleCheckpoint} — checkpoint: when the entire
+ *       transaction (data + txnEnd) completes before the checkpoint barrier, the
+ *       checkpoint succeeds and data is committed correctly.</li>
+ *   <li>{@link #testTransactionSpansTwoCheckpointsFails} — checkpoint: when a transaction
+ *       is still open (no txnEnd) when the checkpoint barrier arrives, the job must
+ *       fail with an {@link IllegalStateException} indicating active partitions.</li>
+ * </ol>
+ */
+public class MultiTableTransactionITTest extends StarRocksITTestBase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MultiTableTransactionITTest.class);
+
+    /**
+     * Flush interval used in timing-sensitive tests (ms).
+     * Must be larger than the SDK's minimum scanningFrequency (50 ms).
+     */
+    private static final int FLUSH_INTERVAL_MS = 500;
+
+    /**
+     * How long to wait after a txnEnd row is emitted before asserting that data
+     * is visible in StarRocks (ms).
+     *
+     * <p>With the event-driven commit implementation, the task thread executes
+     * {@code switchChunk} immediately on txnEnd, then the manager thread drives:
+     * HTTP load (~100 ms) → prepare (~50 ms) → commit (~50 ms).
+     * We add a 2 s buffer for CI/network variance.
+     */
+    private static final long COMMIT_PROPAGATION_MS = 2_000L;
+
+    /**
+     * Max time to wait for {@link StreamExecutionEnvironment#execute(String)} when it runs
+     * on the test thread's behalf in a worker thread. Prevents an indefinite hang (no Surefire
+     * "[INFO] Results:") if the Flink job or sink never completes.
+     */
+    private static final long FLINK_EXECUTE_TIMEOUT_MS = 30_000L;
+
+    // -------------------------------------------------------------------------
+    // DDL helpers
+    // -------------------------------------------------------------------------
+
+    private String createOrdersTable() throws Exception {
+        String tableName = "orders_" + genRandomUuid();
+        executeSrSQL(String.format(
+                "CREATE TABLE `%s`.`%s` (" +
+                        "order_id BIGINT NOT NULL," +
+                        "customer_id BIGINT NOT NULL," +
+                        "total_amount DECIMAL(10,2) DEFAULT '0'," +
+                        "order_status VARCHAR(32) DEFAULT ''" +
+                        ") ENGINE=OLAP PRIMARY KEY(order_id) " +
+                        "DISTRIBUTED BY HASH(order_id) BUCKETS 4 " +
+                        "PROPERTIES (\"replication_num\" = \"1\")",
+                DB_NAME, tableName));
+        return tableName;
+    }
+
+    private String createOrderItemsTable() throws Exception {
+        String tableName = "order_items_" + genRandomUuid();
+        executeSrSQL(String.format(
+                "CREATE TABLE `%s`.`%s` (" +
+                        "item_id BIGINT NOT NULL," +
+                        "order_id BIGINT NOT NULL," +
+                        "product_name VARCHAR(128) DEFAULT ''," +
+                        "quantity INT DEFAULT '0'," +
+                        "price DECIMAL(10,2) DEFAULT '0'" +
+                        ") ENGINE=OLAP PRIMARY KEY(item_id) " +
+                        "DISTRIBUTED BY HASH(item_id) BUCKETS 4 " +
+                        "PROPERTIES (\"replication_num\" = \"1\")",
+                DB_NAME, tableName));
+        return tableName;
+    }
+
+    // -------------------------------------------------------------------------
+    // Test cases
+    // -------------------------------------------------------------------------
+
+    /**
+     * End-to-end test: two source partitions, sink parallelism = 2.
+     *
+     * <p>Verifies the core routing contract: {@code keyBy(sourcePartition)} ensures
+     * each sink subtask handles exactly one partition, so one partition's data is
+     * always processed by the same sink instance.
+     *
+     * <ul>
+     *   <li>Partition 0 → {@code orders} table (2 rows + txnEnd)</li>
+     *   <li>Partition 1 → {@code order_items} table (3 rows + txnEnd)</li>
+     * </ul>
+     *
+     * <p>After the job finishes ({@code close()} flushes remaining data), both
+     * tables must contain the expected rows.
+     */
+    @Test
+    public void testEndToEndMultiPartition() throws Exception {
+        String ordersTable = createOrdersTable();
+        String orderItemsTable = createOrderItemsTable();
+
+        StreamExecutionEnvironment env = buildEnv(2);
+
+        DataStream<DefaultStarRocksRowData> partition0 = env.fromElements(
+                row(DB_NAME, ordersTable,
+                        "{\"order_id\":1,\"customer_id\":100,\"total_amount\":99.99,\"order_status\":\"created\"}",
+                        0, false),
+                row(DB_NAME, ordersTable,
+                        "{\"order_id\":2,\"customer_id\":101,\"total_amount\":25.00,\"order_status\":\"created\"}",
+                        0, true)
+        ).returns(TypeInformation.of(DefaultStarRocksRowData.class));
+
+        DataStream<DefaultStarRocksRowData> partition1 = env.fromElements(
+                row(DB_NAME, orderItemsTable,
+                        "{\"item_id\":1,\"order_id\":1,\"product_name\":\"widget\",\"quantity\":2,\"price\":49.99}",
+                        1, false),
+                row(DB_NAME, orderItemsTable,
+                        "{\"item_id\":2,\"order_id\":1,\"product_name\":\"gadget\",\"quantity\":1,\"price\":50.00}",
+                        1, false),
+                row(DB_NAME, orderItemsTable,
+                        "{\"item_id\":3,\"order_id\":2,\"product_name\":\"doohickey\",\"quantity\":3,\"price\":25.00}",
+                        1, true)
+        ).returns(TypeInformation.of(DefaultStarRocksRowData.class));
+
+        partition0.union(partition1)
+                .keyBy(DefaultStarRocksRowData::getSourcePartition)
+                .addSink(buildSink(ordersTable, orderItemsTable, FLUSH_INTERVAL_MS))
+                .setParallelism(2);
+
+        runFlinkJobWithTimeout(env, "testEndToEndMultiPartition");
+
+        verifyResult(
+                Arrays.asList(
+                        Arrays.asList(1L, 100L, new BigDecimal("99.99"), "created"),
+                        Arrays.asList(2L, 101L, new BigDecimal("25.00"), "created")),
+                scanTable(DB_CONNECTION, DB_NAME, ordersTable));
+
+        verifyResult(
+                Arrays.asList(
+                        Arrays.asList(1L, 1L, "widget",    2, new BigDecimal("49.99")),
+                        Arrays.asList(2L, 1L, "gadget",    1, new BigDecimal("50.00")),
+                        Arrays.asList(3L, 2L, "doohickey", 3, new BigDecimal("25.00"))),
+                scanTable(DB_CONNECTION, DB_NAME, orderItemsTable));
+    }
+
+    /**
+     * Transaction consistency timing test — the core correctness guarantee.
+     *
+     * <p>Verifies that data is NOT visible in StarRocks before the txnEnd marker
+     * arrives, even after the flush interval has elapsed multiple times.
+     * Only after txnEnd is received should the data become visible.
+     *
+     * <p>Timeline:
+     * <pre>
+     *   t=0              source emits data rows (no txnEnd)
+     *   t=2×interval     assert tables EMPTY  ← flush timer fired but no commit
+     *   t=2×interval     emit txnEnd          ← event-driven commit triggered
+     *   t=2×interval+Δ   assert tables have data (Δ ≈ network round-trip)
+     * </pre>
+     *
+     * <p>This test validates the event-driven {@code setCommitAllowed} path in
+     * {@code DefaultStreamLoadManager}: on txnEnd the task thread immediately calls
+     * {@code switchChunkForCommit()} on all regions and signals the manager thread,
+     * which then drives flush → prepare → commit without waiting for the age timer.
+     */
+    @Test
+    public void testNoFlushBeforeTxnEnd() throws Exception {
+        String ordersTable = createOrdersTable();
+        String orderItemsTable = createOrderItemsTable();
+
+        TxnEndControlledSource.reset(DB_NAME, ordersTable, orderItemsTable);
+
+        StreamExecutionEnvironment env = buildEnv(1);
+        env.addSource(new TxnEndControlledSource())
+                .setParallelism(1)
+                .returns(TypeInformation.of(DefaultStarRocksRowData.class))
+                .keyBy(DefaultStarRocksRowData::getSourcePartition)
+                .addSink(buildSink(ordersTable, orderItemsTable, FLUSH_INTERVAL_MS))
+                .setParallelism(1);
+
+        Thread jobThread = new Thread(() -> {
+            try {
+                env.execute("testNoFlushBeforeTxnEnd");
+            } catch (Exception e) {
+                LOG.warn("Job thread finished (may be expected on cancel)", e);
+            }
+        }, "flink-job-thread");
+        jobThread.start();
+
+        try {
+            // Wait 2× flush interval — the age-based timer fires but commitAllowed=false
+            Thread.sleep(2L * FLUSH_INTERVAL_MS);
+
+            assertEquals("orders must be empty before txnEnd",
+                    0, scanTable(DB_CONNECTION, DB_NAME, ordersTable).size());
+            assertEquals("order_items must be empty before txnEnd",
+                    0, scanTable(DB_CONNECTION, DB_NAME, orderItemsTable).size());
+
+            LOG.info("Confirmed: no data visible before txnEnd. Sending txnEnd signal.");
+            TxnEndControlledSource.SEND_TXN_END_LATCH.countDown();
+
+            assertTrue("txnEnd row should be emitted within 10 s",
+                    TxnEndControlledSource.TXN_END_EMITTED_LATCH.await(10, TimeUnit.SECONDS));
+
+            // Event-driven commit: switchChunk already done on task thread;
+            // manager thread only needs one HTTP round-trip to flush + prepare + commit.
+            Thread.sleep(COMMIT_PROPAGATION_MS);
+
+            List<List<Object>> ordersAfter = scanTable(DB_CONNECTION, DB_NAME, ordersTable);
+            List<List<Object>> itemsAfter  = scanTable(DB_CONNECTION, DB_NAME, orderItemsTable);
+
+            assertEquals("orders must have 1 row after txnEnd", 1, ordersAfter.size());
+            assertEquals("order_items must have 2 rows after txnEnd", 2, itemsAfter.size());
+
+            verifyResult(
+                    Arrays.asList(Arrays.asList(1L, 100L, new BigDecimal("99.99"), "created")),
+                    ordersAfter);
+            verifyResult(
+                    Arrays.asList(
+                            Arrays.asList(1L, 1L, "widget", 2, new BigDecimal("49.99")),
+                            Arrays.asList(2L, 1L, "gadget", 1, new BigDecimal("50.00"))),
+                    itemsAfter);
+
+            LOG.info("Confirmed: data visible after txnEnd. Transaction consistency verified.");
+        } finally {
+            jobThread.interrupt();
+            jobThread.join(5_000);
+        }
+    }
+
+    /**
+     * Consecutive transaction isolation test.
+     *
+     * <p>Verifies that after txn-1 commits, txn-2's data is NOT visible until
+     * txn-2's own txnEnd arrives. This exercises the "re-arm" logic: after a
+     * commit cycle completes, {@code commitInFlight} is reset to {@code false}
+     * so the next source transaction is blocked until its own txnEnd marker.
+     *
+     * <p>Timeline:
+     * <pre>
+     *   t=0              txn-1 data emitted
+     *   t=2×interval     assert EMPTY  (no txnEnd yet)
+     *   t=2×interval     emit txn-1 txnEnd → commit
+     *   t=2×interval+Δ   assert 1 row  (txn-1 visible, txn-2 not started)
+     *   t=...            txn-2 data emitted (commitInFlight re-armed to false)
+     *   t=...+2×interval assert still 1 row (txn-2 data buffered, no txnEnd)
+     *   t=...            emit txn-2 txnEnd → commit
+     *   t=...+Δ          assert 2 rows (both txns visible)
+     * </pre>
+     */
+    @Test
+    public void testMultipleConsecutiveTransactions() throws Exception {
+        String ordersTable = createOrdersTable();
+        String orderItemsTable = createOrderItemsTable();
+
+        MultiTxnControlledSource.reset(DB_NAME, ordersTable, orderItemsTable);
+
+        StreamExecutionEnvironment env = buildEnv(1);
+        env.addSource(new MultiTxnControlledSource())
+                .setParallelism(1)
+                .returns(TypeInformation.of(DefaultStarRocksRowData.class))
+                .keyBy(DefaultStarRocksRowData::getSourcePartition)
+                .addSink(buildSink(ordersTable, orderItemsTable, FLUSH_INTERVAL_MS))
+                .setParallelism(1);
+
+        Thread jobThread = new Thread(() -> {
+            try {
+                env.execute("testMultipleConsecutiveTransactions");
+            } catch (Exception e) {
+                LOG.warn("Job thread finished (may be expected on cancel)", e);
+            }
+        }, "flink-job-thread");
+        jobThread.start();
+
+        try {
+            // ---- Phase 1: txn-1 data emitted, no txnEnd yet ----
+            Thread.sleep(2L * FLUSH_INTERVAL_MS);
+            assertEquals("orders empty before txn-1 txnEnd",
+                    0, scanTable(DB_CONNECTION, DB_NAME, ordersTable).size());
+
+            // Allow txn-1 to commit
+            MultiTxnControlledSource.TXN1_END_LATCH.countDown();
+            assertTrue("txn-1 end emitted within 10 s",
+                    MultiTxnControlledSource.TXN1_END_EMITTED_LATCH.await(10, TimeUnit.SECONDS));
+            Thread.sleep(COMMIT_PROPAGATION_MS);
+
+            // txn-1 data must now be visible
+            List<List<Object>> afterTxn1 = scanTable(DB_CONNECTION, DB_NAME, ordersTable);
+            assertEquals("orders must have 1 row after txn-1", 1, afterTxn1.size());
+            verifyResult(
+                    Arrays.asList(Arrays.asList(1L, 100L, new BigDecimal("10.00"), "created")),
+                    afterTxn1);
+
+            // ---- Phase 2: txn-2 data emitted, no txnEnd yet ----
+            // commitInFlight was reset to false after txn-1 commit
+            Thread.sleep(2L * FLUSH_INTERVAL_MS);
+            List<List<Object>> midTxn2 = scanTable(DB_CONNECTION, DB_NAME, ordersTable);
+            assertEquals("orders must still have only 1 row (txn-2 not committed yet)",
+                    1, midTxn2.size());
+
+            // Allow txn-2 to commit
+            MultiTxnControlledSource.TXN2_END_LATCH.countDown();
+            assertTrue("txn-2 end emitted within 10 s",
+                    MultiTxnControlledSource.TXN2_END_EMITTED_LATCH.await(10, TimeUnit.SECONDS));
+            Thread.sleep(COMMIT_PROPAGATION_MS);
+
+            // Both txn-1 and txn-2 data must be visible
+            List<List<Object>> afterTxn2 = scanTable(DB_CONNECTION, DB_NAME, ordersTable);
+            assertEquals("orders must have 2 rows after txn-2", 2, afterTxn2.size());
+            verifyResult(
+                    Arrays.asList(
+                            Arrays.asList(1L, 100L, new BigDecimal("10.00"), "created"),
+                            Arrays.asList(2L, 101L, new BigDecimal("20.00"), "created")),
+                    afterTxn2);
+
+            LOG.info("Confirmed: consecutive transaction isolation verified.");
+        } finally {
+            jobThread.interrupt();
+            jobThread.join(5_000);
+        }
+    }
+
+    /**
+     * Boundary test: a txnEnd row with no preceding data rows must not cause
+     * an error and must leave the tables empty.
+     */
+    @Test
+    public void testEmptyTransaction() throws Exception {
+        String ordersTable = createOrdersTable();
+        String orderItemsTable = createOrderItemsTable();
+
+        StreamExecutionEnvironment env = buildEnv(1);
+        // Only a txnEnd row, no actual data
+        env.fromElements(
+                row(DB_NAME, ordersTable, null, 0, true)
+        ).returns(TypeInformation.of(DefaultStarRocksRowData.class))
+                .keyBy(DefaultStarRocksRowData::getSourcePartition)
+                .addSink(buildSink(ordersTable, orderItemsTable, FLUSH_INTERVAL_MS));
+
+        runFlinkJobWithTimeout(env, "testEmptyTransaction");
+
+        assertEquals("orders must be empty after empty transaction",
+                0, scanTable(DB_CONNECTION, DB_NAME, ordersTable).size());
+        assertEquals("order_items must be empty after empty transaction",
+                0, scanTable(DB_CONNECTION, DB_NAME, orderItemsTable).size());
+    }
+
+    /**
+     * Atomicity test: verifies that both tables become visible via a single
+     * shared StarRocks transaction label.
+     *
+     * <p>This is the strongest atomicity guarantee: after txnEnd triggers a commit,
+     * we verify via {@code show proc '/transactions/{db}/finished'} that there is
+     * exactly one COMMITTED transaction for both tables' data, and both tables
+     * become non-empty at the same query point.
+     *
+     * <p>Timeline:
+     * <pre>
+     *   t=0              source emits rows to BOTH orders and order_items (no txnEnd)
+     *   t=2×interval     assert both tables EMPTY
+     *   t=2×interval     emit txnEnd
+     *   t=2×interval+Δ   assert both tables non-empty simultaneously
+     *   t=2×interval+Δ   verify exactly 1 finished transaction with the label prefix
+     * </pre>
+     */
+    @Test
+    public void testAtomicVisibilityAcrossTables() throws Exception {
+        String ordersTable = createOrdersTable();
+        String orderItemsTable = createOrderItemsTable();
+
+        String labelPrefix = "test-atomic-" + genRandomUuid().substring(0, 8) + "-";
+
+        AtomicVisibilitySource.reset(DB_NAME, ordersTable, orderItemsTable);
+
+        StreamExecutionEnvironment env = buildEnv(1);
+        env.addSource(new AtomicVisibilitySource())
+                .setParallelism(1)
+                .returns(TypeInformation.of(DefaultStarRocksRowData.class))
+                .keyBy(DefaultStarRocksRowData::getSourcePartition)
+                .addSink(buildSinkWithLabelPrefix(ordersTable, orderItemsTable,
+                        FLUSH_INTERVAL_MS, labelPrefix))
+                .setParallelism(1);
+
+        Thread jobThread = new Thread(() -> {
+            try {
+                env.execute("testAtomicVisibilityAcrossTables");
+            } catch (Exception e) {
+                LOG.warn("Job thread finished (may be expected on cancel)", e);
+            }
+        }, "flink-job-thread");
+        jobThread.start();
+
+        try {
+            // Wait for data to be buffered but not committed
+            Thread.sleep(2L * FLUSH_INTERVAL_MS);
+
+            assertEquals("orders must be empty before txnEnd",
+                    0, scanTable(DB_CONNECTION, DB_NAME, ordersTable).size());
+            assertEquals("order_items must be empty before txnEnd",
+                    0, scanTable(DB_CONNECTION, DB_NAME, orderItemsTable).size());
+
+            // Signal txnEnd
+            AtomicVisibilitySource.SEND_TXN_END_LATCH.countDown();
+            assertTrue("txnEnd row should be emitted within 10 s",
+                    AtomicVisibilitySource.TXN_END_EMITTED_LATCH.await(10, TimeUnit.SECONDS));
+
+            Thread.sleep(COMMIT_PROPAGATION_MS);
+
+            // Both tables must be non-empty at the same query point
+            List<List<Object>> ordersAfter = scanTable(DB_CONNECTION, DB_NAME, ordersTable);
+            List<List<Object>> itemsAfter = scanTable(DB_CONNECTION, DB_NAME, orderItemsTable);
+
+            assertEquals("orders must have 1 row after txnEnd", 1, ordersAfter.size());
+            assertEquals("order_items must have 2 rows after txnEnd", 2, itemsAfter.size());
+
+            // Verify atomicity: exactly 1 finished transaction with our label prefix
+            List<TransactionInfo> txns = getFinishedTransactionInfo(labelPrefix);
+            LOG.info("Finished transactions with prefix '{}': {}", labelPrefix, txns.size());
+            for (TransactionInfo txn : txns) {
+                LOG.info("  txn: label={}, status={}", txn.label, txn.transactionStatus);
+            }
+
+            // Filter for COMMITTED (not ABORTED) transactions
+            long committedCount = txns.stream()
+                    .filter(t -> "COMMITTED".equalsIgnoreCase(t.transactionStatus)
+                            || "VISIBLE".equalsIgnoreCase(t.transactionStatus))
+                    .count();
+            assertEquals("Exactly 1 committed transaction expected (shared label for both tables)",
+                    1, committedCount);
+
+            LOG.info("Confirmed: cross-table atomic visibility with single shared transaction.");
+        } finally {
+            jobThread.interrupt();
+            jobThread.join(5_000);
+        }
+    }
+
+    /**
+     * Partial partition blocking test: when two partitions are active but only
+     * one has sent txnEnd, data must NOT be committed.
+     *
+     * <p>This validates that {@code PartitionCommitTracker.allSwitched()} correctly
+     * blocks the commit until ALL active partitions have reached txnEnd.
+     *
+     * <p>Timeline:
+     * <pre>
+     *   t=0              P0 emits data + txnEnd; P1 emits data only (no txnEnd)
+     *   t=3×interval     assert BOTH tables EMPTY (P1 blocks the commit)
+     *   t=3×interval     P1 sends txnEnd
+     *   t=3×interval+Δ   assert both tables have data
+     * </pre>
+     */
+    @Test
+    public void testPartialPartitionTxnEndBlocking() throws Exception {
+        String ordersTable = createOrdersTable();
+        String orderItemsTable = createOrderItemsTable();
+
+        PartialPartitionSource.reset(DB_NAME, ordersTable, orderItemsTable);
+
+        StreamExecutionEnvironment env = buildEnv(1);
+        env.addSource(new PartialPartitionSource())
+                .setParallelism(1)
+                .returns(TypeInformation.of(DefaultStarRocksRowData.class))
+                .keyBy(DefaultStarRocksRowData::getSourcePartition)
+                .addSink(buildSink(ordersTable, orderItemsTable, FLUSH_INTERVAL_MS))
+                .setParallelism(1);
+
+        Thread jobThread = new Thread(() -> {
+            try {
+                env.execute("testPartialPartitionTxnEndBlocking");
+            } catch (Exception e) {
+                LOG.warn("Job thread finished (may be expected on cancel)", e);
+            }
+        }, "flink-job-thread");
+        jobThread.start();
+
+        try {
+            // Wait for P0 data + txnEnd and P1 data (no txnEnd) to be processed
+            assertTrue("Phase 1 should complete within 10 s",
+                    PartialPartitionSource.PHASE1_DONE_LATCH.await(10, TimeUnit.SECONDS));
+
+            // Wait extra flush intervals to ensure the timer fires multiple times
+            Thread.sleep(3L * FLUSH_INTERVAL_MS);
+
+            // P1 has NOT sent txnEnd → allSwitched() is false → no commit
+            assertEquals("orders must be empty (P1 blocks commit)",
+                    0, scanTable(DB_CONNECTION, DB_NAME, ordersTable).size());
+            assertEquals("order_items must be empty (P1 blocks commit)",
+                    0, scanTable(DB_CONNECTION, DB_NAME, orderItemsTable).size());
+
+            LOG.info("Confirmed: partial partition txnEnd correctly blocks commit.");
+
+            // Now let P1 send txnEnd
+            PartialPartitionSource.P1_TXN_END_LATCH.countDown();
+            assertTrue("P1 txnEnd should be emitted within 10 s",
+                    PartialPartitionSource.P1_TXN_END_EMITTED_LATCH.await(10, TimeUnit.SECONDS));
+
+            Thread.sleep(COMMIT_PROPAGATION_MS);
+
+            // Now both partitions have txnEnd → data should be committed
+            List<List<Object>> ordersAfter = scanTable(DB_CONNECTION, DB_NAME, ordersTable);
+            List<List<Object>> itemsAfter = scanTable(DB_CONNECTION, DB_NAME, orderItemsTable);
+
+            assertEquals("orders must have 1 row after both partitions txnEnd",
+                    1, ordersAfter.size());
+            assertEquals("order_items must have 1 row after both partitions txnEnd",
+                    1, itemsAfter.size());
+
+            verifyResult(
+                    Arrays.asList(Arrays.asList(1L, 100L, new BigDecimal("50.00"), "created")),
+                    ordersAfter);
+            verifyResult(
+                    Arrays.asList(Arrays.asList(1L, 1L, "widget", 2, new BigDecimal("25.00"))),
+                    itemsAfter);
+
+            LOG.info("Confirmed: data visible after all partitions sent txnEnd.");
+        } finally {
+            jobThread.interrupt();
+            jobThread.join(5_000);
+        }
+    }
+
+    /**
+     * Flush data integrity test with a large flush interval.
+     *
+     * <p>Verifies that when the timer-driven flush never fires (because the flush
+     * interval is very large), the {@code finish()} → {@code flush()} savepoint
+     * path still commits all buffered multi-table data correctly.
+     *
+     * <p>The source emits data to two tables with a txnEnd marker on the last row,
+     * then the bounded source finishes. The sink's {@code finish()} calls
+     * {@code flush()}, which acts as a savepoint and must commit everything.
+     * After the job completes, both tables must have all expected rows.
+     */
+    @Test
+    public void testCheckpointTriggeredFlushDataIntegrity() throws Exception {
+        String ordersTable = createOrdersTable();
+        String orderItemsTable = createOrderItemsTable();
+
+        StreamExecutionEnvironment env = buildEnv(1);
+        // Use a very large flush interval so the timer never fires —
+        // only the flush() from finish()/close() should commit the data.
+        int largeFlushInterval = 60_000;
+
+        // Emit data to two tables with txnEnd on the last row, then source finishes.
+        // The sink's finish() will call flush(), which must commit everything.
+        env.fromElements(
+                row(DB_NAME, ordersTable,
+                        "{\"order_id\":1,\"customer_id\":100,\"total_amount\":10.00,\"order_status\":\"created\"}",
+                        0, false),
+                row(DB_NAME, ordersTable,
+                        "{\"order_id\":2,\"customer_id\":101,\"total_amount\":20.00,\"order_status\":\"created\"}",
+                        0, false),
+                row(DB_NAME, orderItemsTable,
+                        "{\"item_id\":1,\"order_id\":1,\"product_name\":\"widget\",\"quantity\":3,\"price\":10.00}",
+                        0, false),
+                row(DB_NAME, orderItemsTable,
+                        "{\"item_id\":2,\"order_id\":2,\"product_name\":\"gadget\",\"quantity\":1,\"price\":20.00}",
+                        0, true)
+        ).returns(TypeInformation.of(DefaultStarRocksRowData.class))
+                .keyBy(DefaultStarRocksRowData::getSourcePartition)
+                .addSink(buildSink(ordersTable, orderItemsTable, largeFlushInterval))
+                .setParallelism(1);
+
+        // finish()/close() triggers flush(); bounded wait so a hang still yields a test failure + Results
+        runFlinkJobWithTimeout(env, "testCheckpointTriggeredFlushDataIntegrity");
+
+        // All data must be committed by the savepoint path
+        List<List<Object>> ordersAfter = scanTable(DB_CONNECTION, DB_NAME, ordersTable);
+        List<List<Object>> itemsAfter = scanTable(DB_CONNECTION, DB_NAME, orderItemsTable);
+
+        verifyResult(
+                Arrays.asList(
+                        Arrays.asList(1L, 100L, new BigDecimal("10.00"), "created"),
+                        Arrays.asList(2L, 101L, new BigDecimal("20.00"), "created")),
+                ordersAfter);
+
+        verifyResult(
+                Arrays.asList(
+                        Arrays.asList(1L, 1L, "widget", 3, new BigDecimal("10.00")),
+                        Arrays.asList(2L, 2L, "gadget", 1, new BigDecimal("20.00"))),
+                itemsAfter);
+
+        LOG.info("Confirmed: flush committed all multi-table data via savepoint path.");
+    }
+
+    /**
+     * Checkpoint test: transaction fits entirely within one checkpoint.
+     *
+     * <p>Verifies that when the source emits data rows followed by a txnEnd marker
+     * <em>before</em> the Flink checkpoint barrier arrives, the checkpoint succeeds
+     * and all data is committed correctly to StarRocks.
+     *
+     * <p>This exercises the happy path of the checkpoint + multi-table transaction
+     * interaction: by the time {@code flush()} is called during {@code snapshotState()},
+     * all partitions have already received txnEnd, so {@code getActivePartitions()}
+     * returns an empty list and the shared transaction commits successfully.
+     *
+     * <p>Timeline:
+     * <pre>
+     *   t=0              source emits data + txnEnd for both tables
+     *   t=Δ              txnEnd triggers event-driven commit → data committed
+     *   t=checkpoint     checkpoint barrier arrives → flush() finds no active partitions → OK
+     *   t=finish         job finishes → verify data in StarRocks
+     * </pre>
+     */
+    @Test
+    public void testTransactionWithinSingleCheckpoint() throws Exception {
+        String ordersTable = createOrdersTable();
+        String orderItemsTable = createOrderItemsTable();
+
+        CheckpointTxnWithinSource.reset(DB_NAME, ordersTable, orderItemsTable);
+
+        File checkpointDir = temporaryFolder.newFolder();
+        StreamExecutionEnvironment env = buildEnvWithCheckpointing(1, checkpointDir.toURI().toString());
+
+        env.addSource(new CheckpointTxnWithinSource())
+                .setParallelism(1)
+                .returns(TypeInformation.of(DefaultStarRocksRowData.class))
+                .keyBy(DefaultStarRocksRowData::getSourcePartition)
+                .addSink(buildSink(ordersTable, orderItemsTable, FLUSH_INTERVAL_MS))
+                .setParallelism(1);
+
+        runFlinkJobWithTimeout(env, "testTransactionWithinSingleCheckpoint");
+
+        // Verify all data committed successfully
+        verifyResult(
+                Arrays.asList(
+                        Arrays.asList(1L, 100L, new BigDecimal("10.00"), "created"),
+                        Arrays.asList(2L, 101L, new BigDecimal("20.00"), "created")),
+                scanTable(DB_CONNECTION, DB_NAME, ordersTable));
+
+        verifyResult(
+                Arrays.asList(
+                        Arrays.asList(1L, 1L, "widget", 2, new BigDecimal("10.00")),
+                        Arrays.asList(2L, 2L, "gadget", 1, new BigDecimal("20.00"))),
+                scanTable(DB_CONNECTION, DB_NAME, orderItemsTable));
+
+        LOG.info("Confirmed: transaction within single checkpoint committed successfully.");
+    }
+
+    /**
+     * Checkpoint test: transaction spans two checkpoints — must fail.
+     *
+     * <p>Verifies that when a source transaction is still open (no txnEnd marker
+     * received) when the Flink checkpoint barrier arrives, the job fails with an
+     * {@link IllegalStateException}. This enforces the contract that upstream must
+     * complete all transactions before the checkpoint barrier.
+     *
+     * <p>The source emits data rows without txnEnd, then waits long enough for a
+     * checkpoint to fire. The checkpoint's {@code snapshotState()} calls
+     * {@code flush()}, which detects active partitions and throws:
+     * <pre>
+     *   [MultiTxn] Partitions [...] still have uncommitted transaction data
+     *   at checkpoint.
+     * </pre>
+     *
+     * <p>Timeline:
+     * <pre>
+     *   t=0              source emits data rows (no txnEnd)
+     *   t=checkpoint     checkpoint barrier arrives → flush() finds active partitions → FAIL
+     * </pre>
+     */
+    @Test
+    public void testTransactionSpansTwoCheckpointsFails() throws Exception {
+        String ordersTable = createOrdersTable();
+        String orderItemsTable = createOrderItemsTable();
+
+        CheckpointTxnSpansSource.reset(DB_NAME, ordersTable, orderItemsTable);
+
+        File checkpointDir = temporaryFolder.newFolder();
+        // Short checkpoint interval so the barrier fires quickly
+        StreamExecutionEnvironment env = buildEnvWithCheckpointing(1, checkpointDir.toURI().toString());
+
+        env.addSource(new CheckpointTxnSpansSource())
+                .setParallelism(1)
+                .returns(TypeInformation.of(DefaultStarRocksRowData.class))
+                .keyBy(DefaultStarRocksRowData::getSourcePartition)
+                .addSink(buildSink(ordersTable, orderItemsTable, FLUSH_INTERVAL_MS))
+                .setParallelism(1);
+
+        AtomicReference<Throwable> executionError = new AtomicReference<>();
+        Thread jobThread = new Thread(() -> {
+            try {
+                env.execute("testTransactionSpansTwoCheckpointsFails");
+            } catch (Throwable t) {
+                executionError.set(t);
+            }
+        }, "flink-job-testTransactionSpansTwoCheckpointsFails");
+        jobThread.start();
+        jobThread.join(FLINK_EXECUTE_TIMEOUT_MS);
+
+        if (jobThread.isAlive()) {
+            jobThread.interrupt();
+            jobThread.join(5_000);
+        }
+
+        // The job must have failed
+        Throwable error = executionError.get();
+        assertTrue("Job should fail when transaction spans checkpoint, but completed successfully",
+                error != null);
+
+        // Unwrap to find the IllegalStateException about active partitions
+        Throwable cause = error;
+        boolean foundExpectedError = false;
+        while (cause != null) {
+            if (cause instanceof IllegalStateException
+                    && cause.getMessage() != null
+                    && cause.getMessage().contains("uncommitted transaction data at checkpoint")) {
+                foundExpectedError = true;
+                break;
+            }
+            cause = cause.getCause();
+        }
+
+        assertTrue("Expected IllegalStateException about uncommitted transaction data at checkpoint, "
+                        + "but got: " + error.getMessage(),
+                foundExpectedError);
+
+        // Tables should be empty — the transaction was never committed
+        assertEquals("orders must be empty after failed checkpoint",
+                0, scanTable(DB_CONNECTION, DB_NAME, ordersTable).size());
+        assertEquals("order_items must be empty after failed checkpoint",
+                0, scanTable(DB_CONNECTION, DB_NAME, orderItemsTable).size());
+
+        LOG.info("Confirmed: transaction spanning checkpoint correctly rejected with IllegalStateException.");
+    }
+
+    // -------------------------------------------------------------------------
+    // Item 13: SinkV2 API (new unified Flink Sink API) multi-table test
+    // -------------------------------------------------------------------------
+
+    /**
+     * End-to-end test using the new Flink Sink V2 API ({@link StarRocksSink} +
+     * {@link com.starrocks.connector.flink.table.sink.v2.StarRocksWriter} +
+     * {@link com.starrocks.connector.flink.table.sink.v2.StarRocksCommitter})
+     * instead of the legacy {@code SinkFunction} API.
+     *
+     * <p>This verifies that multi-table transactions work correctly through the
+     * two-phase commit path: {@code StarRocksWriter.write()} routes data by
+     * partition → {@code flush(endOfInput=true)} triggers savepoint → data committed.
+     *
+     * <p>Uses {@code sinkTo()} instead of {@code addSink()}.
+     */
+    @Test
+    public void testEndToEndSinkV2Api() throws Exception {
+        String ordersTable = createOrdersTable();
+        String orderItemsTable = createOrderItemsTable();
+
+        StreamExecutionEnvironment env = buildEnv(1);
+
+        env.fromElements(
+                row(DB_NAME, ordersTable,
+                        "{\"order_id\":1,\"customer_id\":100,\"total_amount\":88.88,\"order_status\":\"created\"}",
+                        0, false),
+                row(DB_NAME, ordersTable,
+                        "{\"order_id\":2,\"customer_id\":101,\"total_amount\":55.55,\"order_status\":\"pending\"}",
+                        0, false),
+                row(DB_NAME, orderItemsTable,
+                        "{\"item_id\":1,\"order_id\":1,\"product_name\":\"alpha\",\"quantity\":2,\"price\":44.44}",
+                        0, false),
+                row(DB_NAME, orderItemsTable,
+                        "{\"item_id\":2,\"order_id\":2,\"product_name\":\"beta\",\"quantity\":1,\"price\":55.55}",
+                        0, true)
+        ).returns(TypeInformation.of(DefaultStarRocksRowData.class))
+                .keyBy(DefaultStarRocksRowData::getSourcePartition)
+                .sinkTo(buildSinkV2(ordersTable, orderItemsTable, FLUSH_INTERVAL_MS))
+                .setParallelism(1);
+
+        runFlinkJobWithTimeout(env, "testEndToEndSinkV2Api");
+
+        verifyResult(
+                Arrays.asList(
+                        Arrays.asList(1L, 100L, new BigDecimal("88.88"), "created"),
+                        Arrays.asList(2L, 101L, new BigDecimal("55.55"), "pending")),
+                scanTable(DB_CONNECTION, DB_NAME, ordersTable));
+
+        verifyResult(
+                Arrays.asList(
+                        Arrays.asList(1L, 1L, "alpha", 2, new BigDecimal("44.44")),
+                        Arrays.asList(2L, 2L, "beta",  1, new BigDecimal("55.55"))),
+                scanTable(DB_CONNECTION, DB_NAME, orderItemsTable));
+    }
+
+    /**
+     * SinkV2 API test with 2 partitions, verifying that keyBy + sinkTo
+     * correctly routes data from different partitions.
+     */
+    @Test
+    public void testSinkV2ApiMultiPartition() throws Exception {
+        String ordersTable = createOrdersTable();
+        String orderItemsTable = createOrderItemsTable();
+
+        StreamExecutionEnvironment env = buildEnv(2);
+
+        DataStream<DefaultStarRocksRowData> partition0 = env.fromElements(
+                row(DB_NAME, ordersTable,
+                        "{\"order_id\":1,\"customer_id\":100,\"total_amount\":10.00,\"order_status\":\"created\"}",
+                        0, false),
+                row(DB_NAME, ordersTable,
+                        "{\"order_id\":2,\"customer_id\":101,\"total_amount\":20.00,\"order_status\":\"created\"}",
+                        0, true)
+        ).returns(TypeInformation.of(DefaultStarRocksRowData.class));
+
+        DataStream<DefaultStarRocksRowData> partition1 = env.fromElements(
+                row(DB_NAME, orderItemsTable,
+                        "{\"item_id\":1,\"order_id\":1,\"product_name\":\"widget\",\"quantity\":2,\"price\":5.00}",
+                        1, false),
+                row(DB_NAME, orderItemsTable,
+                        "{\"item_id\":2,\"order_id\":2,\"product_name\":\"gadget\",\"quantity\":3,\"price\":6.67}",
+                        1, true)
+        ).returns(TypeInformation.of(DefaultStarRocksRowData.class));
+
+        partition0.union(partition1)
+                .keyBy(DefaultStarRocksRowData::getSourcePartition)
+                .sinkTo(buildSinkV2(ordersTable, orderItemsTable, FLUSH_INTERVAL_MS))
+                .setParallelism(2);
+
+        runFlinkJobWithTimeout(env, "testSinkV2ApiMultiPartition");
+
+        verifyResult(
+                Arrays.asList(
+                        Arrays.asList(1L, 100L, new BigDecimal("10.00"), "created"),
+                        Arrays.asList(2L, 101L, new BigDecimal("20.00"), "created")),
+                scanTable(DB_CONNECTION, DB_NAME, ordersTable));
+
+        verifyResult(
+                Arrays.asList(
+                        Arrays.asList(1L, 1L, "widget", 2, new BigDecimal("5.00")),
+                        Arrays.asList(2L, 2L, "gadget", 3, new BigDecimal("6.67"))),
+                scanTable(DB_CONNECTION, DB_NAME, orderItemsTable));
+    }
+
+    // -------------------------------------------------------------------------
+    // Controlled source functions (use static fields to avoid ClosureCleaner)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Source for {@link #testNoFlushBeforeTxnEnd}.
+     *
+     * <p>Phase 1: emits data rows without txnEnd (sink must not commit).
+     * Phase 2: waits for {@link #SEND_TXN_END_LATCH}, then emits the txnEnd marker.
+     */
+    private static class TxnEndControlledSource
+            extends RichParallelSourceFunction<DefaultStarRocksRowData> {
+
+        private static final long serialVersionUID = 1L;
+
+        static volatile CountDownLatch SEND_TXN_END_LATCH;
+        static volatile CountDownLatch TXN_END_EMITTED_LATCH;
+        static volatile String DB;
+        static volatile String ORDERS_TABLE;
+        static volatile String ORDER_ITEMS_TABLE;
+
+        static void reset(String db, String ordersTable, String orderItemsTable) {
+            DB = db;
+            ORDERS_TABLE = ordersTable;
+            ORDER_ITEMS_TABLE = orderItemsTable;
+            SEND_TXN_END_LATCH    = new CountDownLatch(1);
+            TXN_END_EMITTED_LATCH = new CountDownLatch(1);
+        }
+
+        @Override
+        public void run(SourceContext<DefaultStarRocksRowData> ctx) throws Exception {
+            // Phase 1: data rows, no txnEnd
+            ctx.collect(row(DB, ORDERS_TABLE,
+                    "{\"order_id\":1,\"customer_id\":100,\"total_amount\":99.99,\"order_status\":\"created\"}",
+                    0, false));
+            ctx.collect(row(DB, ORDER_ITEMS_TABLE,
+                    "{\"item_id\":1,\"order_id\":1,\"product_name\":\"widget\",\"quantity\":2,\"price\":49.99}",
+                    0, false));
+            ctx.collect(row(DB, ORDER_ITEMS_TABLE,
+                    "{\"item_id\":2,\"order_id\":1,\"product_name\":\"gadget\",\"quantity\":1,\"price\":50.00}",
+                    0, false));
+
+            SEND_TXN_END_LATCH.await();
+
+            // Phase 2: txnEnd marker (null row = no data, just signal end-of-transaction)
+            ctx.collect(row(DB, ORDERS_TABLE, null, 0, true));
+            TXN_END_EMITTED_LATCH.countDown();
+        }
+
+        @Override
+        public void cancel() {
+            CountDownLatch l = SEND_TXN_END_LATCH;
+            if (l != null) l.countDown();
+        }
+    }
+
+    /**
+     * Source for {@link #testMultipleConsecutiveTransactions}.
+     *
+     * <p>Emits two back-to-back transactions, each gated by its own latch pair so
+     * the test thread can control exactly when each txnEnd is delivered.
+     */
+    private static class MultiTxnControlledSource
+            extends RichParallelSourceFunction<DefaultStarRocksRowData> {
+
+        private static final long serialVersionUID = 1L;
+
+        static volatile CountDownLatch TXN1_END_LATCH;
+        static volatile CountDownLatch TXN1_END_EMITTED_LATCH;
+        static volatile CountDownLatch TXN2_END_LATCH;
+        static volatile CountDownLatch TXN2_END_EMITTED_LATCH;
+        static volatile String DB;
+        static volatile String ORDERS_TABLE;
+
+        static void reset(String db, String ordersTable, String orderItemsTable) {
+            DB = db;
+            ORDERS_TABLE = ordersTable;
+            TXN1_END_LATCH          = new CountDownLatch(1);
+            TXN1_END_EMITTED_LATCH  = new CountDownLatch(1);
+            TXN2_END_LATCH          = new CountDownLatch(1);
+            TXN2_END_EMITTED_LATCH  = new CountDownLatch(1);
+        }
+
+        @Override
+        public void run(SourceContext<DefaultStarRocksRowData> ctx) throws Exception {
+            // txn-1 data
+            ctx.collect(row(DB, ORDERS_TABLE,
+                    "{\"order_id\":1,\"customer_id\":100,\"total_amount\":10.00,\"order_status\":\"created\"}",
+                    0, false));
+
+            TXN1_END_LATCH.await();
+            ctx.collect(row(DB, ORDERS_TABLE, null, 0, true));  // txn-1 end
+            TXN1_END_EMITTED_LATCH.countDown();
+
+            // txn-2 data (commitInFlight re-armed to false after txn-1 commit)
+            ctx.collect(row(DB, ORDERS_TABLE,
+                    "{\"order_id\":2,\"customer_id\":101,\"total_amount\":20.00,\"order_status\":\"created\"}",
+                    0, false));
+
+            TXN2_END_LATCH.await();
+            ctx.collect(row(DB, ORDERS_TABLE, null, 0, true));  // txn-2 end
+            TXN2_END_EMITTED_LATCH.countDown();
+        }
+
+        @Override
+        public void cancel() {
+            CountDownLatch l1 = TXN1_END_LATCH;
+            CountDownLatch l2 = TXN2_END_LATCH;
+            if (l1 != null) l1.countDown();
+            if (l2 != null) l2.countDown();
+        }
+    }
+
+    /**
+     * Source for {@link #testAtomicVisibilityAcrossTables}.
+     *
+     * <p>Emits data rows to both orders and order_items in a single partition,
+     * then waits for the test thread to signal txnEnd.
+     */
+    private static class AtomicVisibilitySource
+            extends RichParallelSourceFunction<DefaultStarRocksRowData> {
+
+        private static final long serialVersionUID = 1L;
+
+        static volatile CountDownLatch SEND_TXN_END_LATCH;
+        static volatile CountDownLatch TXN_END_EMITTED_LATCH;
+        static volatile String DB;
+        static volatile String ORDERS_TABLE;
+        static volatile String ORDER_ITEMS_TABLE;
+
+        static void reset(String db, String ordersTable, String orderItemsTable) {
+            DB = db;
+            ORDERS_TABLE = ordersTable;
+            ORDER_ITEMS_TABLE = orderItemsTable;
+            SEND_TXN_END_LATCH    = new CountDownLatch(1);
+            TXN_END_EMITTED_LATCH = new CountDownLatch(1);
+        }
+
+        @Override
+        public void run(SourceContext<DefaultStarRocksRowData> ctx) throws Exception {
+            // Emit data to both tables in partition 0
+            ctx.collect(row(DB, ORDERS_TABLE,
+                    "{\"order_id\":1,\"customer_id\":100,\"total_amount\":88.88,\"order_status\":\"pending\"}",
+                    0, false));
+            ctx.collect(row(DB, ORDER_ITEMS_TABLE,
+                    "{\"item_id\":1,\"order_id\":1,\"product_name\":\"alpha\",\"quantity\":1,\"price\":44.44}",
+                    0, false));
+            ctx.collect(row(DB, ORDER_ITEMS_TABLE,
+                    "{\"item_id\":2,\"order_id\":1,\"product_name\":\"beta\",\"quantity\":2,\"price\":22.22}",
+                    0, false));
+
+            SEND_TXN_END_LATCH.await();
+            ctx.collect(row(DB, ORDERS_TABLE, null, 0, true));
+            TXN_END_EMITTED_LATCH.countDown();
+        }
+
+        @Override
+        public void cancel() {
+            CountDownLatch l = SEND_TXN_END_LATCH;
+            if (l != null) l.countDown();
+        }
+    }
+
+    /**
+     * Source for {@link #testPartialPartitionTxnEndBlocking}.
+     *
+     * <p>Phase 1: P0 writes to orders + txnEnd; P1 writes to order_items (no txnEnd).
+     * Phase 2: waits for latch, then P1 sends txnEnd.
+     */
+    private static class PartialPartitionSource
+            extends RichParallelSourceFunction<DefaultStarRocksRowData> {
+
+        private static final long serialVersionUID = 1L;
+
+        static volatile CountDownLatch PHASE1_DONE_LATCH;
+        static volatile CountDownLatch P1_TXN_END_LATCH;
+        static volatile CountDownLatch P1_TXN_END_EMITTED_LATCH;
+        static volatile String DB;
+        static volatile String ORDERS_TABLE;
+        static volatile String ORDER_ITEMS_TABLE;
+
+        static void reset(String db, String ordersTable, String orderItemsTable) {
+            DB = db;
+            ORDERS_TABLE = ordersTable;
+            ORDER_ITEMS_TABLE = orderItemsTable;
+            PHASE1_DONE_LATCH       = new CountDownLatch(1);
+            P1_TXN_END_LATCH        = new CountDownLatch(1);
+            P1_TXN_END_EMITTED_LATCH = new CountDownLatch(1);
+        }
+
+        @Override
+        public void run(SourceContext<DefaultStarRocksRowData> ctx) throws Exception {
+            // P0: write to orders + txnEnd
+            ctx.collect(row(DB, ORDERS_TABLE,
+                    "{\"order_id\":1,\"customer_id\":100,\"total_amount\":50.00,\"order_status\":\"created\"}",
+                    0, false));
+            ctx.collect(row(DB, ORDERS_TABLE, null, 0, true));  // P0 txnEnd
+
+            // P1: write to order_items, NO txnEnd yet
+            ctx.collect(row(DB, ORDER_ITEMS_TABLE,
+                    "{\"item_id\":1,\"order_id\":1,\"product_name\":\"widget\",\"quantity\":2,\"price\":25.00}",
+                    1, false));
+
+            // Signal test thread that phase 1 is done
+            PHASE1_DONE_LATCH.countDown();
+
+            // Wait for test thread to verify blocking, then send P1 txnEnd
+            P1_TXN_END_LATCH.await();
+            ctx.collect(row(DB, ORDER_ITEMS_TABLE, null, 1, true));  // P1 txnEnd
+            P1_TXN_END_EMITTED_LATCH.countDown();
+        }
+
+        @Override
+        public void cancel() {
+            CountDownLatch l1 = PHASE1_DONE_LATCH;
+            CountDownLatch l2 = P1_TXN_END_LATCH;
+            if (l1 != null) l1.countDown();
+            if (l2 != null) l2.countDown();
+        }
+    }
+
+    /**
+     * Source for {@link #testTransactionWithinSingleCheckpoint}.
+     *
+     * <p>Emits data to both tables followed by a txnEnd marker, then stays alive
+     * long enough for at least one Flink checkpoint to succeed before finishing.
+     */
+    private static class CheckpointTxnWithinSource
+            extends RichParallelSourceFunction<DefaultStarRocksRowData> {
+
+        private static final long serialVersionUID = 1L;
+
+        static volatile String DB;
+        static volatile String ORDERS_TABLE;
+        static volatile String ORDER_ITEMS_TABLE;
+
+        static void reset(String db, String ordersTable, String orderItemsTable) {
+            DB = db;
+            ORDERS_TABLE = ordersTable;
+            ORDER_ITEMS_TABLE = orderItemsTable;
+        }
+
+        private volatile boolean running = true;
+
+        @Override
+        public void run(SourceContext<DefaultStarRocksRowData> ctx) throws Exception {
+            // Emit data to both tables
+            ctx.collect(row(DB, ORDERS_TABLE,
+                    "{\"order_id\":1,\"customer_id\":100,\"total_amount\":10.00,\"order_status\":\"created\"}",
+                    0, false));
+            ctx.collect(row(DB, ORDERS_TABLE,
+                    "{\"order_id\":2,\"customer_id\":101,\"total_amount\":20.00,\"order_status\":\"created\"}",
+                    0, false));
+            ctx.collect(row(DB, ORDER_ITEMS_TABLE,
+                    "{\"item_id\":1,\"order_id\":1,\"product_name\":\"widget\",\"quantity\":2,\"price\":10.00}",
+                    0, false));
+            ctx.collect(row(DB, ORDER_ITEMS_TABLE,
+                    "{\"item_id\":2,\"order_id\":2,\"product_name\":\"gadget\",\"quantity\":1,\"price\":20.00}",
+                    0, false));
+
+            // txnEnd — transaction is complete before any checkpoint fires
+            ctx.collect(row(DB, ORDERS_TABLE, null, 0, true));
+
+            // Stay alive long enough for at least one checkpoint to complete,
+            // then finish so the job terminates.
+            long waited = 0;
+            while (running && waited < 5_000) {
+                Thread.sleep(100);
+                waited += 100;
+            }
+        }
+
+        @Override
+        public void cancel() {
+            running = false;
+        }
+    }
+
+    /**
+     * Source for {@link #testTransactionSpansTwoCheckpointsFails}.
+     *
+     * <p>Emits data rows without txnEnd, then blocks until cancelled.
+     * This guarantees that a Flink checkpoint will fire while the transaction
+     * is still open, which must trigger an {@link IllegalStateException}.
+     */
+    private static class CheckpointTxnSpansSource
+            extends RichParallelSourceFunction<DefaultStarRocksRowData> {
+
+        private static final long serialVersionUID = 1L;
+
+        static volatile String DB;
+        static volatile String ORDERS_TABLE;
+        static volatile String ORDER_ITEMS_TABLE;
+
+        static void reset(String db, String ordersTable, String orderItemsTable) {
+            DB = db;
+            ORDERS_TABLE = ordersTable;
+            ORDER_ITEMS_TABLE = orderItemsTable;
+        }
+
+        private volatile boolean running = true;
+
+        @Override
+        public void run(SourceContext<DefaultStarRocksRowData> ctx) throws Exception {
+            // Emit data to both tables — deliberately NO txnEnd
+            ctx.collect(row(DB, ORDERS_TABLE,
+                    "{\"order_id\":1,\"customer_id\":100,\"total_amount\":50.00,\"order_status\":\"created\"}",
+                    0, false));
+            ctx.collect(row(DB, ORDER_ITEMS_TABLE,
+                    "{\"item_id\":1,\"order_id\":1,\"product_name\":\"widget\",\"quantity\":3,\"price\":16.67}",
+                    0, false));
+
+            // Block until cancelled — the checkpoint barrier WILL arrive
+            // while the transaction is still open (no txnEnd sent)
+            while (running) {
+                Thread.sleep(100);
+            }
+        }
+
+        @Override
+        public void cancel() {
+            running = false;
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Shared builder helpers
+    // -------------------------------------------------------------------------
+
+    private StreamExecutionEnvironment buildEnv(int parallelism) {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setRuntimeMode(RuntimeExecutionMode.STREAMING);
+        env.setParallelism(parallelism);
+        // Checkpointing is intentionally disabled. The tests that verify
+        // "no data visible before txnEnd" rely on precise timing and would
+        // break if a Flink checkpoint triggered an early commit.  The
+        // savepoint code path is still exercised through finish() / close()
+        // which call sinkManager.flush().
+        return env;
+    }
+
+    private StreamExecutionEnvironment buildEnvWithCheckpointing(int parallelism, String checkpointDir) {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setRuntimeMode(RuntimeExecutionMode.STREAMING);
+        env.setParallelism(parallelism);
+        env.enableCheckpointing(1000);
+        env.getCheckpointConfig().setCheckpointStorage(checkpointDir);
+        env.setRestartStrategy(RestartStrategies.noRestart());
+        return env;
+    }
+
+    /**
+     * Runs {@code env.execute(jobName)} on a separate thread and fails if it does not return
+     * within {@link #FLINK_EXECUTE_TIMEOUT_MS}. Avoids blocking the Surefire thread forever
+     * when the job deadlocks.
+     */
+    private void runFlinkJobWithTimeout(StreamExecutionEnvironment env, String jobName) throws Exception {
+        AtomicReference<Throwable> executionError = new AtomicReference<>();
+        Thread jobThread = new Thread(() -> {
+            try {
+                env.execute(jobName);
+            } catch (Throwable t) {
+                executionError.set(t);
+            }
+        }, "flink-job-" + jobName);
+        jobThread.start();
+        jobThread.join(FLINK_EXECUTE_TIMEOUT_MS);
+        if (jobThread.isAlive()) {
+            jobThread.interrupt();
+            throw new AssertionError(String.format(
+                    "Flink job '%s' did not finish within %d ms (stuck in execute?); thread interrupted",
+                    jobName, FLINK_EXECUTE_TIMEOUT_MS));
+        }
+        Throwable t = executionError.get();
+        if (t != null) {
+            if (t instanceof Exception) {
+                throw (Exception) t;
+            }
+            if (t instanceof Error) {
+                throw (Error) t;
+            }
+            throw new Exception(t);
+        }
+    }
+
+    private SinkFunction<DefaultStarRocksRowData> buildSink(
+            String ordersTable, String orderItemsTable, int flushIntervalMs) {
+        StarRocksSinkOptions options = StarRocksSinkOptions.builder()
+                .withProperty("jdbc-url", getJdbcUrl())
+                .withProperty("load-url", getHttpUrls())
+                .withProperty("database-name", "*")
+                .withProperty("table-name", "*")
+                .withProperty("username", USERNAME)
+                .withProperty("password", PASSWORD)
+                .withProperty("sink.version", "V2")
+                .withProperty("sink.semantic", "at-least-once")
+                .withProperty("sink.transaction.multi-table.enabled", "true")
+                .withProperty("sink.buffer-flush.interval-ms", String.valueOf(flushIntervalMs))
+                .withProperty("sink.properties.format", "json")
+                .withProperty("sink.properties.strip_outer_array", "true")
+                .build();
+
+        options.addTableProperties(StreamLoadTableProperties.builder()
+                .database(DB_NAME)
+                .table(ordersTable)
+                .addProperty("format", "json")
+                .addProperty("strip_outer_array", "true")
+                .addProperty("ignore_json_size", "true")
+                .build());
+
+        options.addTableProperties(StreamLoadTableProperties.builder()
+                .database(DB_NAME)
+                .table(orderItemsTable)
+                .addProperty("format", "json")
+                .addProperty("strip_outer_array", "true")
+                .addProperty("ignore_json_size", "true")
+                .build());
+
+        return SinkFunctionFactory.createSinkFunction(options);
+    }
+
+    private SinkFunction<DefaultStarRocksRowData> buildSinkWithLabelPrefix(
+            String ordersTable, String orderItemsTable, int flushIntervalMs, String labelPrefix) {
+        StarRocksSinkOptions options = StarRocksSinkOptions.builder()
+                .withProperty("jdbc-url", getJdbcUrl())
+                .withProperty("load-url", getHttpUrls())
+                .withProperty("database-name", "*")
+                .withProperty("table-name", "*")
+                .withProperty("username", USERNAME)
+                .withProperty("password", PASSWORD)
+                .withProperty("sink.version", "V2")
+                .withProperty("sink.semantic", "at-least-once")
+                .withProperty("sink.transaction.multi-table.enabled", "true")
+                .withProperty("sink.buffer-flush.interval-ms", String.valueOf(flushIntervalMs))
+                .withProperty("sink.label-prefix", labelPrefix)
+                .withProperty("sink.properties.format", "json")
+                .withProperty("sink.properties.strip_outer_array", "true")
+                .build();
+
+        options.addTableProperties(StreamLoadTableProperties.builder()
+                .database(DB_NAME)
+                .table(ordersTable)
+                .addProperty("format", "json")
+                .addProperty("strip_outer_array", "true")
+                .addProperty("ignore_json_size", "true")
+                .build());
+
+        options.addTableProperties(StreamLoadTableProperties.builder()
+                .database(DB_NAME)
+                .table(orderItemsTable)
+                .addProperty("format", "json")
+                .addProperty("strip_outer_array", "true")
+                .addProperty("ignore_json_size", "true")
+                .build());
+
+        return SinkFunctionFactory.createSinkFunction(options);
+    }
+
+    /** Builds a {@link DefaultStarRocksRowData}. {@code json} may be {@code null} for txnEnd-only rows. */
+    private static DefaultStarRocksRowData row(String db, String table, String json,
+                                               int partition, boolean txnEnd) {
+        DefaultStarRocksRowData r = new DefaultStarRocksRowData(null, db, table, json);
+        r.setSourcePartition(partition);
+        r.setTransactionEnd(txnEnd);
+        return r;
+    }
+
+    // -------------------------------------------------------------------------
+    // SinkV2 API helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Builds a {@link StarRocksSink} (new Flink Sink V2 API) for multi-table
+     * transaction mode, using a pass-through {@link RecordSerializationSchema}.
+     */
+    private StarRocksSink<DefaultStarRocksRowData> buildSinkV2(
+            String ordersTable, String orderItemsTable, int flushIntervalMs) {
+        StarRocksSinkOptions options = StarRocksSinkOptions.builder()
+                .withProperty("jdbc-url", getJdbcUrl())
+                .withProperty("load-url", getHttpUrls())
+                .withProperty("database-name", "*")
+                .withProperty("table-name", "*")
+                .withProperty("username", USERNAME)
+                .withProperty("password", PASSWORD)
+                .withProperty("sink.version", "V2")
+                .withProperty("sink.semantic", "at-least-once")
+                .withProperty("sink.transaction.multi-table.enabled", "true")
+                .withProperty("sink.buffer-flush.interval-ms", String.valueOf(flushIntervalMs))
+                .withProperty("sink.properties.format", "json")
+                .withProperty("sink.properties.strip_outer_array", "true")
+                .build();
+
+        options.addTableProperties(StreamLoadTableProperties.builder()
+                .database(DB_NAME)
+                .table(ordersTable)
+                .addProperty("format", "json")
+                .addProperty("strip_outer_array", "true")
+                .addProperty("ignore_json_size", "true")
+                .build());
+
+        options.addTableProperties(StreamLoadTableProperties.builder()
+                .database(DB_NAME)
+                .table(orderItemsTable)
+                .addProperty("format", "json")
+                .addProperty("strip_outer_array", "true")
+                .addProperty("ignore_json_size", "true")
+                .build());
+
+        return SinkFunctionFactory.createSink(options, new PassThroughSerializationSchema());
+    }
+
+    /**
+     * A pass-through {@link RecordSerializationSchema} that returns the input
+     * {@link DefaultStarRocksRowData} directly as the output {@link StarRocksRowData}.
+     * Used in SinkV2 API tests where the input already contains database, table,
+     * partition, and transaction boundary information.
+     */
+    private static class PassThroughSerializationSchema
+            implements RecordSerializationSchema<DefaultStarRocksRowData> {
+
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public void open(SerializationSchema.InitializationContext context,
+                         StarRocksSinkContext sinkContext) {
+            // no-op
+        }
+
+        @Override
+        public StarRocksRowData serialize(DefaultStarRocksRowData record) {
+            return record;
+        }
+
+        @Override
+        public void close() {
+            // no-op
+        }
+    }
+}

--- a/src/test/java/com/starrocks/connector/flink/it/sink/MultiTableTransactionITTest.java
+++ b/src/test/java/com/starrocks/connector/flink/it/sink/MultiTableTransactionITTest.java
@@ -66,6 +66,7 @@ import static org.junit.Assert.assertTrue;
  *   mvn test -Dtest=MultiTableTransactionITTest \
  *     -Dit.starrocks.fe.http=172.26.95.228:8030 \
  *     -Dit.starrocks.fe.jdbc=jdbc:mysql://172.26.95.228:9030
+ *   (or export SR_HTTP_URLS / SR_JDBC_URLS with the same host:port values)
  * </pre>
  *
  * <h2>Test coverage</h2>

--- a/src/test/java/com/starrocks/connector/flink/it/sink/MultiTableTransactionITTest.java
+++ b/src/test/java/com/starrocks/connector/flink/it/sink/MultiTableTransactionITTest.java
@@ -244,10 +244,12 @@ public class MultiTableTransactionITTest extends StarRocksITTestBase {
      *   t=2×interval+Δ   assert tables have data (Δ ≈ network round-trip)
      * </pre>
      *
-     * <p>This test validates the event-driven {@code setCommitAllowed} path in
-     * {@code DefaultStreamLoadManager}: on txnEnd the task thread immediately calls
-     * {@code switchChunkForCommit()} on all regions and signals the manager thread,
-     * which then drives flush → prepare → commit without waiting for the age timer.
+     * <p>This test validates the {@code setCommitAllowed} path in
+     * {@code DefaultStreamLoadManager}: on txnEnd the task thread calls
+     * {@code tryMiniIntervalSwitch()} on the partition's regions (freezing
+     * activeChunk into inactiveChunks if miniInterval has elapsed), and the
+     * manager thread subsequently runs autonomous flush → prepare → commit
+     * when the commit interval elapses.
      */
     @Test
     public void testNoFlushBeforeTxnEnd() throws Exception {
@@ -522,22 +524,33 @@ public class MultiTableTransactionITTest extends StarRocksITTestBase {
     }
 
     /**
-     * Partial partition blocking test: when two partitions are active but only
-     * one has sent txnEnd, data must NOT be committed.
+     * Per-partition independence test: completed source transactions on one
+     * partition are committed independently of in-progress transactions on
+     * another partition.
      *
-     * <p>This validates that {@code PartitionCommitTracker.allSwitched()} correctly
-     * blocks the commit until ALL active partitions have reached txnEnd.
+     * <p>In the current design, each {@code sourcePartition} represents an
+     * independent source transaction stream. When P0's transaction completes
+     * (txnEnd) but P1's is still in progress, P0's data is committed on the
+     * next commit interval — it is NOT held hostage by P1's incomplete
+     * transaction. P1's data stays in its activeChunk (not yet frozen into
+     * inactiveChunks) and becomes committable only after P1's own txnEnd
+     * arrives.
+     *
+     * <p>This per-partition independence preserves cross-TABLE atomicity
+     * within a single source transaction (all tables written by one partition
+     * within one txnEnd commit together) while avoiding unnecessary commit
+     * latency caused by unrelated laggard partitions.
      *
      * <p>Timeline:
      * <pre>
      *   t=0              P0 emits data + txnEnd; P1 emits data only (no txnEnd)
-     *   t=3×interval     assert BOTH tables EMPTY (P1 blocks the commit)
-     *   t=3×interval     P1 sends txnEnd
-     *   t=3×interval+Δ   assert both tables have data
+     *   t=2×interval+Δ   assert orders has P0's row, order_items is EMPTY
+     *   t=2×interval+Δ   P1 sends txnEnd
+     *   t=3×interval+Δ   assert order_items has P1's row
      * </pre>
      */
     @Test
-    public void testPartialPartitionTxnEndBlocking() throws Exception {
+    public void testPerPartitionIndependentCommit() throws Exception {
         String ordersTable = createOrdersTable();
         String orderItemsTable = createOrderItemsTable();
 
@@ -553,7 +566,7 @@ public class MultiTableTransactionITTest extends StarRocksITTestBase {
 
         Thread jobThread = new Thread(() -> {
             try {
-                env.execute("testPartialPartitionTxnEndBlocking");
+                env.execute("testPerPartitionIndependentCommit");
             } catch (Exception e) {
                 LOG.warn("Job thread finished (may be expected on cancel)", e);
             }
@@ -565,31 +578,33 @@ public class MultiTableTransactionITTest extends StarRocksITTestBase {
             assertTrue("Phase 1 should complete within 10 s",
                     PartialPartitionSource.PHASE1_DONE_LATCH.await(10, TimeUnit.SECONDS));
 
-            // Wait extra flush intervals to ensure the timer fires multiple times
-            Thread.sleep(3L * FLUSH_INTERVAL_MS);
+            // Wait enough flush intervals for the commit interval to elapse and
+            // the manager thread to trigger a time-driven commit of P0's data.
+            Thread.sleep(2L * FLUSH_INTERVAL_MS + COMMIT_PROPAGATION_MS);
 
-            // P1 has NOT sent txnEnd → allSwitched() is false → no commit
-            assertEquals("orders must be empty (P1 blocks commit)",
-                    0, scanTable(DB_CONNECTION, DB_NAME, ordersTable).size());
-            assertEquals("order_items must be empty (P1 blocks commit)",
+            // P0's orders row must be committed (P0 sent txnEnd, its source
+            // transaction is complete). P1's order_items row must NOT yet be
+            // committed because P1's activeChunk is still dirty (no txnEnd).
+            assertEquals("orders must have P0's row committed independently",
+                    1, scanTable(DB_CONNECTION, DB_NAME, ordersTable).size());
+            assertEquals("order_items must be empty (P1 still in-progress)",
                     0, scanTable(DB_CONNECTION, DB_NAME, orderItemsTable).size());
 
-            LOG.info("Confirmed: partial partition txnEnd correctly blocks commit.");
+            LOG.info("Confirmed: P0's completed transaction committed without waiting for P1.");
 
-            // Now let P1 send txnEnd
+            // Now let P1 send txnEnd; its data should become committable.
             PartialPartitionSource.P1_TXN_END_LATCH.countDown();
             assertTrue("P1 txnEnd should be emitted within 10 s",
                     PartialPartitionSource.P1_TXN_END_EMITTED_LATCH.await(10, TimeUnit.SECONDS));
 
-            Thread.sleep(COMMIT_PROPAGATION_MS);
+            Thread.sleep(FLUSH_INTERVAL_MS + COMMIT_PROPAGATION_MS);
 
-            // Now both partitions have txnEnd → data should be committed
+            // P1's order_items row should now be visible
             List<List<Object>> ordersAfter = scanTable(DB_CONNECTION, DB_NAME, ordersTable);
             List<List<Object>> itemsAfter = scanTable(DB_CONNECTION, DB_NAME, orderItemsTable);
 
-            assertEquals("orders must have 1 row after both partitions txnEnd",
-                    1, ordersAfter.size());
-            assertEquals("order_items must have 1 row after both partitions txnEnd",
+            assertEquals("orders must still have 1 row", 1, ordersAfter.size());
+            assertEquals("order_items must have 1 row after P1 txnEnd",
                     1, itemsAfter.size());
 
             verifyResult(
@@ -599,7 +614,7 @@ public class MultiTableTransactionITTest extends StarRocksITTestBase {
                     Arrays.asList(Arrays.asList(1L, 1L, "widget", 2, new BigDecimal("25.00"))),
                     itemsAfter);
 
-            LOG.info("Confirmed: data visible after all partitions sent txnEnd.");
+            LOG.info("Confirmed: P1's data visible after P1 sent txnEnd.");
         } finally {
             jobThread.interrupt();
             jobThread.join(5_000);
@@ -679,8 +694,9 @@ public class MultiTableTransactionITTest extends StarRocksITTestBase {
      *
      * <p>This exercises the happy path of the checkpoint + multi-table transaction
      * interaction: by the time {@code flush()} is called during {@code snapshotState()},
-     * all partitions have already received txnEnd, so {@code getActivePartitions()}
-     * returns an empty list and the shared transaction commits successfully.
+     * all partitions have already received txnEnd, so
+     * {@code getPartitionsWithoutTxnEnd()} returns an empty list and the shared
+     * transaction commits successfully.
      *
      * <p>Timeline:
      * <pre>

--- a/src/test/java/com/starrocks/connector/flink/it/sink/MultiTableTransactionITTest.java
+++ b/src/test/java/com/starrocks/connector/flink/it/sink/MultiTableTransactionITTest.java
@@ -756,8 +756,9 @@ public class MultiTableTransactionITTest extends StarRocksITTestBase {
      * checkpoint to fire. The checkpoint's {@code snapshotState()} calls
      * {@code flush()}, which detects active partitions and throws:
      * <pre>
-     *   [MultiTxn] Partitions [...] still have uncommitted transaction data
-     *   at checkpoint.
+     *   [MultiTxn] Partitions [...] have written data but never received
+     *   txnEnd at checkpoint. Upstream must ensure all transactions are
+     *   complete before checkpoint barrier.
      * </pre>
      *
      * <p>Timeline:
@@ -805,20 +806,26 @@ public class MultiTableTransactionITTest extends StarRocksITTestBase {
         assertTrue("Job should fail when transaction spans checkpoint, but completed successfully",
                 error != null);
 
-        // Unwrap to find the IllegalStateException about active partitions
+        // Unwrap to find the IllegalStateException about active partitions.
+        // The manager thread reports the violation via one of two messages
+        // (partition-level "never received txnEnd" or region-level "in-progress
+        // transaction data"); either satisfies the contract.
         Throwable cause = error;
         boolean foundExpectedError = false;
         while (cause != null) {
-            if (cause instanceof IllegalStateException
-                    && cause.getMessage() != null
-                    && cause.getMessage().contains("uncommitted transaction data at checkpoint")) {
-                foundExpectedError = true;
-                break;
+            if (cause instanceof IllegalStateException && cause.getMessage() != null) {
+                String msg = cause.getMessage();
+                if (msg.contains("[MultiTxn]") && msg.contains("at checkpoint")
+                        && (msg.contains("never received txnEnd")
+                                || msg.contains("in-progress transaction data"))) {
+                    foundExpectedError = true;
+                    break;
+                }
             }
             cause = cause.getCause();
         }
 
-        assertTrue("Expected IllegalStateException about uncommitted transaction data at checkpoint, "
+        assertTrue("Expected IllegalStateException about [MultiTxn] transaction state at checkpoint, "
                         + "but got: " + error.getMessage(),
                 foundExpectedError);
 

--- a/src/test/java/com/starrocks/connector/flink/it/sink/MultiTableTransactionITTest.java
+++ b/src/test/java/com/starrocks/connector/flink/it/sink/MultiTableTransactionITTest.java
@@ -35,9 +35,12 @@ import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
+import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.Assume.assumeTrue;
 
 import java.io.File;
 
@@ -92,6 +95,12 @@ import static org.junit.Assert.assertTrue;
 public class MultiTableTransactionITTest extends StarRocksITTestBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(MultiTableTransactionITTest.class);
+
+    @Before
+    public void checkVersion() {
+        assumeTrue("Multi-table transaction requires StarRocks >= 4.0",
+                isStarRocksVersionAtLeast(4, 0));
+    }
 
     /**
      * Flush interval used in timing-sensitive tests (ms).

--- a/src/test/java/com/starrocks/connector/flink/it/sink/MultiTableTransactionITTest.java
+++ b/src/test/java/com/starrocks/connector/flink/it/sink/MultiTableTransactionITTest.java
@@ -59,7 +59,8 @@ import static org.junit.Assert.assertTrue;
 /**
  * Integration tests for multi-table atomic transaction stream load.
  *
- * <p>Requires StarRocks >= 4.0 for multi-table transaction support.
+ * <p>Requires StarRocks &gt;= 4.0 for multi-table transaction support, or a main-branch build
+ * whose {@code current_version()} string contains {@code main}.
  *
  * <p>Run against an external cluster:
  * <pre>
@@ -99,8 +100,9 @@ public class MultiTableTransactionITTest extends StarRocksITTestBase {
 
     @Before
     public void checkVersion() {
-        assumeTrue("Multi-table transaction requires StarRocks >= 4.0",
-                isStarRocksVersionAtLeast(4, 0));
+        assumeTrue(
+                "Multi-table transaction requires StarRocks >= 4.0 or a main-branch build (current_version contains 'main')",
+                isMultiTableTransactionClusterSupported());
     }
 
     /**

--- a/src/test/java/com/starrocks/connector/flink/table/sink/MultiTableTxnPartitionFailFastTest.java
+++ b/src/test/java/com/starrocks/connector/flink/table/sink/MultiTableTxnPartitionFailFastTest.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright 2021-present StarRocks, Inc. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.starrocks.connector.flink.table.sink;
+
+import com.starrocks.connector.flink.table.data.DefaultStarRocksRowData;
+import com.starrocks.connector.flink.table.sink.v2.StarRocksWriter;
+import org.apache.flink.configuration.Configuration;
+import org.junit.Test;
+import sun.misc.Unsafe;
+
+import java.lang.reflect.Field;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Verifies the fail-fast path in {@link StarRocksDynamicSinkFunctionV2} and
+ * {@link StarRocksWriter} when multi-table transaction mode is enabled but a
+ * {@link DefaultStarRocksRowData} with a negative {@code sourcePartition} (the
+ * default) is emitted.
+ *
+ * <p>Without the fail-fast, such a row would silently route to the legacy
+ * {@code write(uniqueKey, ...)} path on the SDK side; that path does not
+ * participate in partition-scoped {@code setCommitAllowed} tracking and, in
+ * multi-table mode, would eventually stall the task thread on
+ * {@code blockIfCacheFull} because the region's activeChunk can never be
+ * switched (see {@code TransactionTableRegion.write0}). The fail-fast throws
+ * {@link IllegalStateException} at the entry point instead.
+ *
+ * <p>The sink function / writer constructors are heavy (they create a
+ * {@code StreamLoadManagerV2} which requires a real JDBC connection to look
+ * up the StarRocks version during construction). Because the fail-fast check
+ * happens BEFORE any sinkManager interaction, we side-step construction via
+ * {@link Unsafe#allocateInstance(Class)} and only populate the single field
+ * the check reads ({@code sinkOptions}). The other fields are left at their
+ * Java-default values, which is fine because the test exercises only the
+ * partition &lt; 0 branch of {@code invoke} / {@code write} where
+ * {@code serializer == null} (sink v1) or the row is a direct
+ * {@code StarRocksRowData} (sink v2) — neither accesses {@code sinkManager}
+ * on the fail-fast path.
+ */
+public class MultiTableTxnPartitionFailFastTest {
+
+    private static final Unsafe UNSAFE;
+    static {
+        try {
+            Field f = Unsafe.class.getDeclaredField("theUnsafe");
+            f.setAccessible(true);
+            UNSAFE = (Unsafe) f.get(null);
+        } catch (Exception e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    /**
+     * Builds a minimal, validation-passing {@link StarRocksSinkOptions} with
+     * multi-table transaction mode enabled.
+     */
+    private static StarRocksSinkOptions buildMultiTableEnabledSinkOptions() {
+        Configuration conf = new Configuration();
+        conf.setString(StarRocksSinkOptions.TABLE_NAME, "test_table");
+        conf.setString(StarRocksSinkOptions.DATABASE_NAME, "test_db");
+        conf.setString(StarRocksSinkOptions.LOAD_URL.key(), "127.0.0.1:8030");
+        conf.setString(StarRocksSinkOptions.JDBC_URL, "jdbc:mysql://127.0.0.1:9030");
+        conf.setString(StarRocksSinkOptions.USERNAME, "root");
+        conf.setString(StarRocksSinkOptions.PASSWORD, "");
+        conf.setBoolean(StarRocksSinkOptions.SINK_MULTI_TABLE_TXN_ENABLED, true);
+        // Validation requires at-least-once semantic with multi-table mode,
+        // which is the default, but set it explicitly for clarity.
+        conf.setString(StarRocksSinkOptions.SINK_SEMANTIC,
+                StarRocksSinkSemantic.AT_LEAST_ONCE.getName());
+        return new StarRocksSinkOptions(conf, conf.toMap());
+    }
+
+    /**
+     * Builds a non-multi-table-enabled variant for the negative-case test
+     * (partition &lt; 0 should be silently accepted in normal mode).
+     */
+    private static StarRocksSinkOptions buildNonMultiTableSinkOptions() {
+        Configuration conf = new Configuration();
+        conf.setString(StarRocksSinkOptions.TABLE_NAME, "test_table");
+        conf.setString(StarRocksSinkOptions.DATABASE_NAME, "test_db");
+        conf.setString(StarRocksSinkOptions.LOAD_URL.key(), "127.0.0.1:8030");
+        conf.setString(StarRocksSinkOptions.JDBC_URL, "jdbc:mysql://127.0.0.1:9030");
+        conf.setString(StarRocksSinkOptions.USERNAME, "root");
+        conf.setString(StarRocksSinkOptions.PASSWORD, "");
+        // Multi-table NOT enabled.
+        return new StarRocksSinkOptions(conf, conf.toMap());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T allocateWithoutConstructor(Class<T> cls) throws Exception {
+        return (T) UNSAFE.allocateInstance(cls);
+    }
+
+    private static void setField(Object target, Class<?> declaringClass, String name, Object value)
+            throws Exception {
+        Field f = declaringClass.getDeclaredField(name);
+        f.setAccessible(true);
+        f.set(target, value);
+    }
+
+    private static DefaultStarRocksRowData rowWithPartition(int partition) {
+        DefaultStarRocksRowData row = new DefaultStarRocksRowData("uk", "test_db", "test_table",
+                "{\"order_id\":1}");
+        row.setSourcePartition(partition);
+        return row;
+    }
+
+    // -------------------------------------------------------------------------
+    // Sink v1 (StarRocksDynamicSinkFunctionV2) tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testSinkV1ThrowsWhenMultiTableEnabledAndPartitionNegative() throws Exception {
+        StarRocksSinkOptions sinkOptions = buildMultiTableEnabledSinkOptions();
+        assertTrue("Test setup: multi-table should be enabled",
+                sinkOptions.isMultiTableTransactionEnabled());
+
+        // Bypass the heavy constructor (which would try to fetch the StarRocks
+        // version via JDBC) and only inject sinkOptions — the fail-fast path
+        // never touches sinkManager/serializer.
+        StarRocksDynamicSinkFunctionV2<Object> sink =
+                allocateWithoutConstructor(StarRocksDynamicSinkFunctionV2.class);
+        setField(sink, StarRocksDynamicSinkFunctionV2.class, "sinkOptions", sinkOptions);
+
+        IllegalStateException caught = null;
+        try {
+            sink.invoke(rowWithPartition(-1), null);
+            fail("Expected IllegalStateException for partition<0 in multi-table mode");
+        } catch (IllegalStateException e) {
+            caught = e;
+        }
+
+        assertNotNull(caught);
+        assertTrue("Error should mention multi-table transaction: " + caught.getMessage(),
+                caught.getMessage().contains("Multi-table transaction mode"));
+        assertTrue("Error should mention partition: " + caught.getMessage(),
+                caught.getMessage().contains("partition=-1"));
+        assertTrue("Error should identify the target table: " + caught.getMessage(),
+                caught.getMessage().contains("test_db") && caught.getMessage().contains("test_table"));
+    }
+
+    @Test
+    public void testSinkV1DoesNotThrowWhenMultiTableDisabledAndPartitionNegative() throws Exception {
+        // In non-multi-table mode, partition<0 rows must silently route to the
+        // legacy write(uniqueKey, ...) path (original behavior). The fail-fast
+        // must not regress that. Because we only populate sinkOptions here and
+        // leave sinkManager null, the expected outcome is a NullPointerException
+        // when invoke reaches sinkManager.write(...) — which proves the
+        // fail-fast was NOT triggered (i.e. execution proceeded past the
+        // guard).
+        StarRocksSinkOptions sinkOptions = buildNonMultiTableSinkOptions();
+        assertTrue("Test setup: multi-table should be disabled",
+                !sinkOptions.isMultiTableTransactionEnabled());
+
+        StarRocksDynamicSinkFunctionV2<Object> sink =
+                allocateWithoutConstructor(StarRocksDynamicSinkFunctionV2.class);
+        setField(sink, StarRocksDynamicSinkFunctionV2.class, "sinkOptions", sinkOptions);
+
+        try {
+            sink.invoke(rowWithPartition(-1), null);
+            fail("Expected NullPointerException from the legacy write path "
+                    + "(sinkManager is null in this bypassed-construction test)");
+        } catch (IllegalStateException e) {
+            fail("Fail-fast must NOT trigger in non-multi-table mode: " + e.getMessage());
+        } catch (NullPointerException expected) {
+            // Expected: execution proceeded past the fail-fast guard into
+            // sinkManager.write(...) which is null.
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Sink v2 (StarRocksWriter) tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testSinkV2ThrowsWhenMultiTableEnabledAndPartitionNegative() throws Exception {
+        StarRocksSinkOptions sinkOptions = buildMultiTableEnabledSinkOptions();
+        assertTrue("Test setup: multi-table should be enabled",
+                sinkOptions.isMultiTableTransactionEnabled());
+
+        // Allocate a StarRocksWriter without running its constructor, and
+        // inject sinkOptions via reflection. The write() fail-fast check
+        // consults sinkOptions before touching sinkManager, so the other
+        // fields being null is fine for this code path.
+        StarRocksWriter<Object> writer = allocateWithoutConstructor(StarRocksWriter.class);
+        setField(writer, StarRocksWriter.class, "sinkOptions", sinkOptions);
+        // StarRocksWriter.write calls serializationSchema.serialize(element)
+        // first. We bypass that by injecting a StarRocksRowData as the
+        // "serialized" result via a minimal schema subclass.
+        setField(writer, StarRocksWriter.class, "serializationSchema",
+                new TestRecordSerializationSchema(rowWithPartition(-1)));
+
+        IllegalStateException caught = null;
+        try {
+            writer.write(new Object(), null);
+            fail("Expected IllegalStateException for partition<0 in multi-table mode");
+        } catch (IllegalStateException e) {
+            caught = e;
+        }
+
+        assertNotNull(caught);
+        assertTrue("Error should mention multi-table transaction: " + caught.getMessage(),
+                caught.getMessage().contains("Multi-table transaction mode"));
+        assertTrue("Error should mention partition: " + caught.getMessage(),
+                caught.getMessage().contains("partition=-1"));
+    }
+
+    @Test
+    public void testSinkV2DoesNotThrowWhenMultiTableDisabledAndPartitionNegative() throws Exception {
+        // Same rationale as testSinkV1DoesNotThrowWhenMultiTableDisabledAndPartitionNegative:
+        // in non-multi-table mode, partition<0 must fall through to the legacy
+        // write path without the fail-fast. Because sinkManager is null here
+        // the fall-through manifests as an NPE, which is sufficient to prove
+        // the guard was not tripped.
+        StarRocksSinkOptions sinkOptions = buildNonMultiTableSinkOptions();
+        assertTrue("Test setup: multi-table should be disabled",
+                !sinkOptions.isMultiTableTransactionEnabled());
+
+        StarRocksWriter<Object> writer = allocateWithoutConstructor(StarRocksWriter.class);
+        setField(writer, StarRocksWriter.class, "sinkOptions", sinkOptions);
+        setField(writer, StarRocksWriter.class, "serializationSchema",
+                new TestRecordSerializationSchema(rowWithPartition(-1)));
+
+        try {
+            writer.write(new Object(), null);
+            fail("Expected NullPointerException from the legacy write path "
+                    + "(sinkManager is null in this bypassed-construction test)");
+        } catch (IllegalStateException e) {
+            fail("Fail-fast must NOT trigger in non-multi-table mode: " + e.getMessage());
+        } catch (NullPointerException expected) {
+            // Expected: execution proceeded past the fail-fast guard into
+            // sinkManager.write(...) which is null.
+        }
+    }
+
+    /**
+     * Minimal test stub for the v2 {@code RecordSerializationSchema}. Returns
+     * the pre-built {@link DefaultStarRocksRowData} regardless of the input
+     * element, so the writer sees a fixed partition value.
+     */
+    private static final class TestRecordSerializationSchema
+            implements com.starrocks.connector.flink.table.sink.v2.RecordSerializationSchema<Object> {
+        private static final long serialVersionUID = 1L;
+        private final DefaultStarRocksRowData row;
+
+        TestRecordSerializationSchema(DefaultStarRocksRowData row) {
+            this.row = row;
+        }
+
+        @Override
+        public void open(
+                org.apache.flink.api.common.serialization.SerializationSchema.InitializationContext context,
+                com.starrocks.connector.flink.table.sink.v2.StarRocksSinkContext sinkContext) {
+            // no-op
+        }
+
+        @Override
+        public DefaultStarRocksRowData serialize(Object element) {
+            return row;
+        }
+
+        @Override
+        public void close() {
+            // no-op
+        }
+    }
+}

--- a/src/test/java/com/starrocks/connector/flink/table/sink/MultiTableTxnPartitionFailFastTest.java
+++ b/src/test/java/com/starrocks/connector/flink/table/sink/MultiTableTxnPartitionFailFastTest.java
@@ -126,6 +126,19 @@ public class MultiTableTxnPartitionFailFastTest {
         return row;
     }
 
+    /**
+     * Builds a control-only txnEnd marker with {@code row==null} and the given
+     * partition. This models the signal a Kafka transaction assembler emits at
+     * the end of a source transaction when there is no data row to attach the
+     * txnEnd flag to.
+     */
+    private static DefaultStarRocksRowData txnEndControlRowWithPartition(int partition) {
+        DefaultStarRocksRowData row = new DefaultStarRocksRowData("test_db", "test_table");
+        row.setTransactionEnd(true);
+        row.setSourcePartition(partition);
+        return row;
+    }
+
     // -------------------------------------------------------------------------
     // Sink v1 (StarRocksDynamicSinkFunctionV2) tests
     // -------------------------------------------------------------------------
@@ -158,6 +171,39 @@ public class MultiTableTxnPartitionFailFastTest {
                 caught.getMessage().contains("partition=-1"));
         assertTrue("Error should identify the target table: " + caught.getMessage(),
                 caught.getMessage().contains("test_db") && caught.getMessage().contains("test_table"));
+    }
+
+    @Test
+    public void testSinkV1ThrowsOnControlRowWhenMultiTableEnabledAndPartitionNegative() throws Exception {
+        // Control-only txnEnd row (row==null, transactionEnd=true, partition=-1)
+        // must also fail fast in multi-table mode. Without the fail-fast,
+        // setCommitAllowed(-1, true) would silently target a non-existent
+        // partition: the real partitions where prior data rows were written
+        // never receive their txnEnd signal, their activeChunks stay open
+        // (mid-transaction switching is disabled in multi-table mode), and
+        // the task thread eventually stalls on blockIfCacheFull.
+        StarRocksSinkOptions sinkOptions = buildMultiTableEnabledSinkOptions();
+        assertTrue("Test setup: multi-table should be enabled",
+                sinkOptions.isMultiTableTransactionEnabled());
+
+        StarRocksDynamicSinkFunctionV2<Object> sink =
+                allocateWithoutConstructor(StarRocksDynamicSinkFunctionV2.class);
+        setField(sink, StarRocksDynamicSinkFunctionV2.class, "sinkOptions", sinkOptions);
+
+        IllegalStateException caught = null;
+        try {
+            sink.invoke(txnEndControlRowWithPartition(-1), null);
+            fail("Expected IllegalStateException for control-only txnEnd row "
+                    + "with partition<0 in multi-table mode");
+        } catch (IllegalStateException e) {
+            caught = e;
+        }
+
+        assertNotNull(caught);
+        assertTrue("Error should mention multi-table transaction: " + caught.getMessage(),
+                caught.getMessage().contains("Multi-table transaction mode"));
+        assertTrue("Error should mention partition: " + caught.getMessage(),
+                caught.getMessage().contains("partition=-1"));
     }
 
     @Test
@@ -215,6 +261,36 @@ public class MultiTableTxnPartitionFailFastTest {
         try {
             writer.write(new Object(), null);
             fail("Expected IllegalStateException for partition<0 in multi-table mode");
+        } catch (IllegalStateException e) {
+            caught = e;
+        }
+
+        assertNotNull(caught);
+        assertTrue("Error should mention multi-table transaction: " + caught.getMessage(),
+                caught.getMessage().contains("Multi-table transaction mode"));
+        assertTrue("Error should mention partition: " + caught.getMessage(),
+                caught.getMessage().contains("partition=-1"));
+    }
+
+    @Test
+    public void testSinkV2ThrowsOnControlRowWhenMultiTableEnabledAndPartitionNegative() throws Exception {
+        // Same rationale as the sink-v1 control-row test above: partition<0
+        // on a control-only txnEnd row must trip the fail-fast in multi-table
+        // mode, not slip past into setCommitAllowed(-1, true).
+        StarRocksSinkOptions sinkOptions = buildMultiTableEnabledSinkOptions();
+        assertTrue("Test setup: multi-table should be enabled",
+                sinkOptions.isMultiTableTransactionEnabled());
+
+        StarRocksWriter<Object> writer = allocateWithoutConstructor(StarRocksWriter.class);
+        setField(writer, StarRocksWriter.class, "sinkOptions", sinkOptions);
+        setField(writer, StarRocksWriter.class, "serializationSchema",
+                new TestRecordSerializationSchema(txnEndControlRowWithPartition(-1)));
+
+        IllegalStateException caught = null;
+        try {
+            writer.write(new Object(), null);
+            fail("Expected IllegalStateException for control-only txnEnd row "
+                    + "with partition<0 in multi-table mode");
         } catch (IllegalStateException e) {
             caught = e;
         }

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/StreamLoadManager.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/StreamLoadManager.java
@@ -50,4 +50,27 @@ public interface StreamLoadManager {
     }
 
     default void setMetricListener(MetricListener metricListener) {}
+
+    default void setCommitAllowed(boolean allowed) {}
+
+    /**
+     * Partition-aware variant for multi-table transaction mode.
+     * Signals that partition {@code partition} has reached a transaction boundary.
+     */
+    default void setCommitAllowed(int partition, boolean allowed) {
+        setCommitAllowed(allowed);
+    }
+
+    /**
+     * Partition-aware write for multi-table transaction mode.
+     * Routes data to a per-partition region so that switchChunk can be
+     * scoped to a single partition without affecting other partitions' data.
+     */
+    default void write(int partition, String database, String table, String... rows) {
+        write(null, database, table, rows);
+    }
+
+    default Throwable getException() {
+        return null;
+    }
 }

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/StreamLoadSnapshot.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/StreamLoadSnapshot.java
@@ -70,12 +70,18 @@ public class StreamLoadSnapshot implements Serializable {
         private String table;
         private String label;
         private boolean finish;
+        private boolean multiTable;
 
         public Transaction(String database, String table, String label) {
+            this(database, table, label, false);
+        }
+
+        public Transaction(String database, String table, String label, boolean multiTable) {
             this.database = database;
             this.table = table;
             this.label = label;
             this.finish = false;
+            this.multiTable = multiTable;
         }
 
         public String getDatabase() {
@@ -108,6 +114,14 @@ public class StreamLoadSnapshot implements Serializable {
 
         public void setFinish(boolean finish) {
             this.finish = finish;
+        }
+
+        public boolean isMultiTable() {
+            return multiTable;
+        }
+
+        public void setMultiTable(boolean multiTable) {
+            this.multiTable = multiTable;
         }
 
         @Override

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/StreamLoader.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/StreamLoader.java
@@ -31,6 +31,20 @@ public interface StreamLoader {
     void close();
 
     boolean begin(TableRegion region);
+
+    /**
+     * Begin a transaction with an explicit label. Used by multi-table transaction mode
+     * where multiple tables share one transaction label. The transaction is opened at
+     * the database level without binding to a specific table, so subsequent
+     * /api/transaction/load calls can target different tables under this label.
+     *
+     * @return true if the transaction was successfully begun
+     */
+    default boolean beginTransaction(String label, String database) {
+        throw new UnsupportedOperationException(
+                "beginTransaction is not supported by this StreamLoader implementation");
+    }
+
     Future<StreamLoadResponse> send(TableRegion region);
 
     Future<StreamLoadResponse> send(TableRegion region, int delayMs);

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/TransactionStreamLoader.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/TransactionStreamLoader.java
@@ -127,17 +127,29 @@ public class TransactionStreamLoader extends DefaultStreamLoader {
         return true;
     }
 
+    @Override
+    public boolean beginTransaction(String label, String database) {
+        return doBegin(label, database, null);
+    }
+
     protected boolean doBegin(TableRegion region) {
+        return doBegin(region.getLabel(), region.getDatabase(), region.getTable());
+    }
+
+    protected boolean doBegin(String label, String database, String table) {
         String host = getAvailableHost();
         String beginUrl = getBeginUrl(host);
-        String label = region.getLabel();
         log.info("Transaction start, label : {}", label);
 
         HttpPost httpPost = new HttpPost(beginUrl);
         httpPost.setHeaders(beginTxnHeader);
         httpPost.addHeader("label", label);
-        httpPost.addHeader("db", region.getDatabase());
-        httpPost.addHeader("table", region.getTable());
+        httpPost.addHeader("db", database);
+        if (table != null) {
+            httpPost.addHeader("table", table);
+        } else {
+            httpPost.addHeader("transaction_type", "multi");
+        }
 
         httpPost.setConfig(RequestConfig.custom()
                         .setSocketTimeout(properties.getSocketTimeout())
@@ -145,16 +157,14 @@ public class TransactionStreamLoader extends DefaultStreamLoader {
                         .setRedirectsEnabled(true)
                         .build());
 
-        String db = region.getDatabase();
-        String table = region.getTable();
-        log.info("Transaction start, db: {}, table: {}, label: {}, request : {}", db, table, label, httpPost);
+        log.info("Transaction start, db: {}, table: {}, label: {}, request : {}", database, table, label, httpPost);
 
         try (CloseableHttpClient client = clientBuilder.build()) {
             String responseBody;
             try (CloseableHttpResponse response = client.execute(httpPost)) {
-                responseBody = parseHttpResponse("begin transaction", region.getDatabase(), region.getTable(), label, response);
+                responseBody = parseHttpResponse("begin transaction", database, table, label, response);
             }
-            log.info("Transaction started, db: {}, table: {}, label: {}, body : {}", db, table, label, responseBody);
+            log.info("Transaction started, db: {}, table: {}, label: {}, body : {}", database, table, label, responseBody);
 
             JsonNode node = objectMapper.readTree(responseBody);
             JsonNode statusNode = node.get("Status");
@@ -164,7 +174,7 @@ public class TransactionStreamLoader extends DefaultStreamLoader {
                 String errMsg = String.format("Can't find 'Status' in the response of transaction begin request. " +
                         "Transaction load is supported since StarRocks 2.4, and please make sure your " +
                         "StarRocks version support transaction load first. db: %s, table: %s, label: %s, response: %s",
-                        db, table, label, responseBody);
+                        database, table, label, responseBody);
                 log.error(errMsg);
                 throw new StreamLoadFailException(errMsg);
             }
@@ -174,12 +184,13 @@ public class TransactionStreamLoader extends DefaultStreamLoader {
             }
 
             String errMsg = String.format("Transaction start failed, db: %s, table: %s, label: %s, responseBody: %s",
-                    region.getDatabase(), region.getTable(), label, responseBody);
+                    database, table, label, responseBody);
             throw new StreamLoadFailException(errMsg);
         } catch (StreamLoadFailException se) {
             throw se;
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException("Failed to begin transaction, label: " + label
+                    + ", db: " + database + ", table: " + table, e);
         }
     }
 
@@ -192,7 +203,11 @@ public class TransactionStreamLoader extends DefaultStreamLoader {
         httpPost.setHeaders(preparedTxnHeader);
         httpPost.addHeader("label", transaction.getLabel());
         httpPost.addHeader("db", transaction.getDatabase());
-        httpPost.addHeader("table", transaction.getTable());
+        if (transaction.isMultiTable()) {
+            httpPost.addHeader("transaction_type", "multi");
+        } else {
+            httpPost.addHeader("table", transaction.getTable());
+        }
 
         httpPost.setConfig(RequestConfig.custom()
                         .setSocketTimeout(properties.getSocketTimeout())
@@ -263,7 +278,11 @@ public class TransactionStreamLoader extends DefaultStreamLoader {
         httpPost.setHeaders(defaultTxnHeaders);
         httpPost.addHeader("label", transaction.getLabel());
         httpPost.addHeader("db", transaction.getDatabase());
-        httpPost.addHeader("table", transaction.getTable());
+        if (transaction.isMultiTable()) {
+            httpPost.addHeader("transaction_type", "multi");
+        } else {
+            httpPost.addHeader("table", transaction.getTable());
+        }
         if (properties.getPublishTimeoutMs() > 0) {
             int timeoutSeconds = Math.max(1, properties.getPublishTimeoutMs() / 1000);
             httpPost.addHeader("timeout", String.valueOf(timeoutSeconds));
@@ -283,7 +302,7 @@ public class TransactionStreamLoader extends DefaultStreamLoader {
                 responseBody = parseHttpResponse("commit transaction", transaction.getDatabase(), transaction.getTable(),
                         transaction.getLabel(), response);
             }
-            log.info("Transaction committed, lable: {}, body : {}", transaction.getLabel(), responseBody);
+            log.info("Transaction committed, label: {}, body : {}", transaction.getLabel(), responseBody);
 
             StreamLoadResponse streamLoadResponse = new StreamLoadResponse();
             StreamLoadResponse.StreamLoadResponseBody streamLoadBody =
@@ -342,7 +361,11 @@ public class TransactionStreamLoader extends DefaultStreamLoader {
         httpPost.setHeaders(defaultTxnHeaders);
         httpPost.addHeader("label", transaction.getLabel());
         httpPost.addHeader("db", transaction.getDatabase());
-        httpPost.addHeader("table", transaction.getTable());
+        if (transaction.isMultiTable()) {
+            httpPost.addHeader("transaction_type", "multi");
+        } else {
+            httpPost.addHeader("table", transaction.getTable());
+        }
 
         try (CloseableHttpClient client = clientBuilder.build()) {
             String responseBody;

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/properties/StreamLoadProperties.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/properties/StreamLoadProperties.java
@@ -23,6 +23,9 @@ package com.starrocks.data.load.stream.properties;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.starrocks.data.load.stream.StarRocksVersion;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collections;
@@ -33,6 +36,9 @@ import java.util.Objects;
 import static org.apache.http.protocol.HttpRequestExecutor.DEFAULT_WAIT_FOR_CONTINUE;
 
 public class StreamLoadProperties implements Serializable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(StreamLoadProperties.class);
+
     private final String jdbcUrl;
     private final String[] loadUrls;
     private final String username;
@@ -48,6 +54,8 @@ public class StreamLoadProperties implements Serializable {
     private final Map<String, StreamLoadTableProperties> tablePropertiesMap;
 
     private final boolean enableTransaction;
+    private final boolean enableMultiTableTransaction;
+    private final long multiTableTransactionBufferSize;
 
     // manager settings
     /**
@@ -116,6 +124,8 @@ public class StreamLoadProperties implements Serializable {
         this.starRocksVersion = StarRocksVersion.parse(version);
 
         this.enableTransaction = builder.enableTransaction;
+        this.enableMultiTableTransaction = builder.enableMultiTableTransaction;
+        this.multiTableTransactionBufferSize = builder.multiTableTransactionBufferSize;
 
         this.labelPrefix = builder.labelPrefix;
 
@@ -157,6 +167,14 @@ public class StreamLoadProperties implements Serializable {
 
     public boolean isEnableTransaction() {
         return enableTransaction;
+    }
+
+    public boolean isEnableMultiTableTransaction() {
+        return enableMultiTableTransaction;
+    }
+
+    public long getMultiTableTransactionBufferSize() {
+        return multiTableTransactionBufferSize;
     }
 
     public String getJdbcUrl() {
@@ -330,6 +348,8 @@ public class StreamLoadProperties implements Serializable {
         private String version;
 
         private boolean enableTransaction;
+        private boolean enableMultiTableTransaction;
+        private long multiTableTransactionBufferSize = 128 * 1024 * 1024; // 128MB default
 
         private String labelPrefix = "";
 
@@ -405,6 +425,20 @@ public class StreamLoadProperties implements Serializable {
 
         public Builder enableTransaction() {
             this.enableTransaction = true;
+            return this;
+        }
+
+        public Builder enableMultiTableTransaction() {
+            this.enableMultiTableTransaction = true;
+            this.enableTransaction = true;
+            return this;
+        }
+
+        public Builder multiTableTransactionBufferSize(long bufferSize) {
+            if (bufferSize <= 0) {
+                throw new IllegalArgumentException("multiTableTransactionBufferSize must be greater than 0, got: " + bufferSize);
+            }
+            this.multiTableTransactionBufferSize = bufferSize;
             return this;
         }
 
@@ -506,7 +540,7 @@ public class StreamLoadProperties implements Serializable {
 
         public Builder oldThreshold(float oldThreshold) {
             if (oldThreshold <= 0 || oldThreshold > 1) {
-                throw new IllegalArgumentException("youngThreshold `" + oldThreshold + "` set failed, must range in (0, 1]");
+                throw new IllegalArgumentException("oldThreshold `" + oldThreshold + "` set failed, must range in (0, 1]");
             }
             this.oldThreshold = oldThreshold;
             return this;
@@ -598,7 +632,23 @@ public class StreamLoadProperties implements Serializable {
         }
 
         public StreamLoadProperties build() {
+            if (enableMultiTableTransaction && !enableTransaction) {
+                throw new IllegalArgumentException(
+                        "Multi-table transaction mode requires transaction stream load to be enabled");
+            }
             StreamLoadProperties streamLoadProperties = new StreamLoadProperties(this);
+
+            if (enableMultiTableTransaction) {
+                StarRocksVersion v = streamLoadProperties.getStarRocksVersion();
+                if (v != null && v.getMajor() < 4) {
+                    throw new IllegalArgumentException(String.format(
+                            "Multi-table transaction mode requires StarRocks >= 4.0, but current version is %d.%d.%d",
+                            v.getMajor(), v.getMinor(), v.getPatch()));
+                }
+                if (v == null) {
+                    LOG.warn("StarRocks version is unknown; multi-table transaction mode requires >= 4.0");
+                }
+            }
 
             if (streamLoadProperties.getYoungThreshold() >= streamLoadProperties.getOldThreshold()) {
                 throw new IllegalArgumentException(String.format("oldThreshold(`%s`) must greater to youngThreshold(`%s`)",

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/DefaultStreamLoadManager.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/DefaultStreamLoadManager.java
@@ -37,10 +37,14 @@ import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -100,6 +104,13 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
     private volatile boolean savepoint = false;
     private volatile boolean allRegionsCommitted;
     private long flushTimeoutMs = 660000L; // default stream load timeout is 600s, 1.1x for flush
+    /**
+     * Maximum time (ms) a shared transaction can stay open before being proactively
+     * recycled to avoid StarRocks server-side timeout. Defaults to 80% of 600s = 480s.
+     */
+    private long sharedTxnMaxIdleMs = 480_000L;
+
+    private final AtomicBoolean commitInFlight = new AtomicBoolean(false);
 
     private final Lock lock = new ReentrantLock();
     private final Condition writable = lock.newCondition();
@@ -109,6 +120,17 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
     private volatile Throwable e;
 
     private final Queue<TransactionTableRegion> flushQ = new ConcurrentLinkedQueue<>();
+
+    /** Per-partition region index for multi-table transaction mode. */
+    private final Map<Integer, List<TransactionTableRegion>> partitionRegions = new ConcurrentHashMap<>();
+
+    private final boolean multiTableTransactionEnabled;
+
+    /** Tracks per-partition transaction boundaries (multi-table mode only). */
+    private transient PartitionCommitTracker partitionTracker;
+
+    /** Coordinates shared label begin/prepare/commit (multi-table mode only). */
+    private transient SharedTransactionCoordinator txnCoordinator;
 
     /**
      * Whether write() has triggered a flush after currentCacheBytes > maxCacheBytes.
@@ -138,15 +160,28 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
             maxRetries = properties.getMaxRetries();
             retryIntervalInMs = properties.getRetryIntervalInMs();
         }
-        this.maxCacheBytes = properties.getMaxCacheBytes();
+        if (properties.isEnableMultiTableTransaction() && !(streamLoader instanceof TransactionStreamLoader)) {
+            throw new IllegalArgumentException(
+                    "Multi-table transaction mode requires TransactionStreamLoader. " +
+                    "Retry (maxRetries > 0) is not supported with multi-table transactions.");
+        }
+        if (properties.isEnableMultiTableTransaction() && properties.getMultiTableTransactionBufferSize() > 0) {
+            this.maxCacheBytes = properties.getMultiTableTransactionBufferSize();
+        } else {
+            this.maxCacheBytes = properties.getMaxCacheBytes();
+        }
         this.maxWriteBlockCacheBytes = 2 * maxCacheBytes;
         this.scanningFrequency = properties.getScanningFrequency();
+        this.multiTableTransactionEnabled = properties.isEnableMultiTableTransaction();
         this.flushAndCommitStrategy = new FlushAndCommitStrategy(properties, enableAutoCommit);
         // get timeout from properties's header
         String timeoutStr = properties.getHeaders().get("timeout");
         if (timeoutStr != null) {
             try {
-                this.flushTimeoutMs = Long.parseLong(timeoutStr) * 1100; // 1.1x for flush
+                long timeoutSec = Long.parseLong(timeoutStr);
+                this.flushTimeoutMs = timeoutSec * 1100; // 1.1x for flush
+                // 80% of server-side timeout as safety margin for shared transaction recycling
+                this.sharedTxnMaxIdleMs = timeoutSec * 800;
             } catch (NumberFormatException ex) {
                 LOG.warn("Invalid timeout value in properties header: {}, using default", timeoutStr);
             }
@@ -161,6 +196,9 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
         }
         this.writeTriggerFlush = new AtomicBoolean(false);
         this.loadMetrics = new LoadMetrics();
+        if (multiTableTransactionEnabled) {
+            this.partitionTracker = new PartitionCommitTracker(properties.getExpectDelayTime());
+        }
         if (state.compareAndSet(State.INACTIVE, State.ACTIVE)) {
             this.manager = new Thread(() -> {
                 long lastPrintTimestamp = -1;
@@ -185,36 +223,190 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
                     }
 
                     if (savepoint) {
-                        for (TransactionTableRegion region : flushQ) {
-                            boolean flush = region.flush(FlushReason.FORCE);
-                            LOG.debug("Trigger flush table region {} because of savepoint, region cache bytes: {}, flush: {}",
-                                    region.getUniqueKey(), region.getCacheBytes(), flush);
-                        }
+                        if (multiTableTransactionEnabled && txnCoordinator != null) {
+                          try {
+                            LOG.info("[MultiTxn] Savepoint: completing shared transaction");
 
-                        // should ensure all data is committed for auto-commit mode
-                        if (enableAutoCommit) {
-                            int committedRegions = 0;
-                            for (TransactionTableRegion region : flushQ) {
-                                // savepoint makes sure no more data is written, so these conditions
-                                // can guarantee commit after all data has been written to StarRocks
-                                boolean success = region.commit();
-                                if (success && region.getCacheBytes() == 0) {
-                                    committedRegions += 1;
-                                    region.resetAge();
-                                }
-                                LOG.debug("Commit region {} for savepoint, success: {}", region.getUniqueKey(), success);
+                            // Upstream must ensure all source transactions are complete
+                            // before the checkpoint barrier arrives. If any partition is
+                            // still ACTIVE (no txnEnd received), it means upstream violated
+                            // this contract — fail fast rather than silently committing
+                            // partial transaction data.
+                            List<Integer> activePartitions = partitionTracker.getActivePartitions();
+                            if (!activePartitions.isEmpty()) {
+                                throw new IllegalStateException(
+                                        "[MultiTxn] Partitions " + activePartitions + " still have " +
+                                        "uncommitted transaction data at checkpoint. Upstream must " +
+                                        "ensure all transactions are complete before checkpoint barrier.");
                             }
 
-                            if (committedRegions == flushQ.size()) {
+                            // Ensure a shared transaction is open (may not be if no data
+                            // was written yet, or if we just finished a commit cycle).
+                            if (!txnCoordinator.isActive() && !flushQ.isEmpty()) {
+                                ensureSharedTransaction();
+                            }
+
+                            // Wait for any in-flight loads to complete
+                            for (TransactionTableRegion region : flushQ) {
+                                Future<?> result = region.getResult();
+                                if (result != null) {
+                                    try {
+                                        result.get();
+                                    } catch (Exception ignored) {
+                                        // errors will be handled by the callback
+                                    }
+                                }
+                            }
+
+                            // Switch and trigger loads for regions that have been through
+                            // trySwitchAndCommit() (TXN_END_RECEIVED or SWITCHED) but
+                            // may still have inactive chunks not yet sent.
+                            for (TransactionTableRegion region : flushQ) {
+                                region.switchChunkForCommit();
+                            }
+                            // Trigger loads for regions with pending data
+                            for (TransactionTableRegion region : flushQ) {
+                                if (region.triggerLoadIfNeeded()) {
+                                    txnCoordinator.markDataLoaded();
+                                }
+                            }
+                            // Wait for triggered loads to complete.
+                            boolean allLoadsDone = false;
+                            while (!allLoadsDone && this.e == null) {
+                                allLoadsDone = true;
+                                for (TransactionTableRegion region : flushQ) {
+                                    if (region.isFlushing()) {
+                                        allLoadsDone = false;
+                                        break;
+                                    }
+                                }
+                                if (!allLoadsDone && this.e == null) {
+                                    LockSupport.parkNanos(1_000_000L);
+                                }
+                            }
+                            // Commit or rollback
+                            String anyTable = null;
+                            for (TransactionTableRegion region : flushQ) {
+                                if (anyTable == null) {
+                                    anyTable = region.getTable();
+                                }
+                            }
+                            if (allLoadsDone && anyTable != null && txnCoordinator.isActive()) {
+                                try {
+                                    if (txnCoordinator.hasDataLoaded()) {
+                                        txnCoordinator.prepareAndCommit(anyTable);
+                                        LOG.info("[MultiTxn] Shared transaction committed during savepoint");
+                                    } else {
+                                        LOG.info("[MultiTxn] No data loaded; rolling back empty txn during savepoint");
+                                        txnCoordinator.reset();
+                                    }
+                                    allRegionsCommitted = true;
+                                } catch (Exception ex) {
+                                    LOG.error("[MultiTxn] Failed to commit shared transaction during savepoint", ex);
+                                    this.e = ex;
+                                }
+                            } else if (anyTable == null) {
+                                // No regions at all — nothing to commit
                                 allRegionsCommitted = true;
-                                LOG.info("All regions committed for savepoint, number of regions: {}", committedRegions);
-                            } else {
-                                LOG.debug("Some regions not committed for savepoint, expected num: {}, actual num: {}",
-                                        flushQ.size(), committedRegions);
+                            }
+                          } catch (Exception ex) {
+                            LOG.error("[MultiTxn] Savepoint shared transaction failed", ex);
+                            this.e = ex;
+                          } finally {
+                            if (txnCoordinator.isActive()) {
+                                txnCoordinator.reset();
+                            }
+                            commitInFlight.set(false);
+                            if (partitionTracker != null) {
+                                partitionTracker.reset();
+                            }
+                            for (TransactionTableRegion region : flushQ) {
+                                if (!region.isRetrying()) {
+                                    region.setLabel(null);
+                                }
+                            }
+                          }
+                        } else {
+                            // Non-multi-table path: flush and commit each region independently.
+                            // This block must NOT run after a multi-table savepoint commit,
+                            // because it would open new independent transactions for any
+                            // residual data, breaking the atomicity guarantee.
+                            for (TransactionTableRegion region : flushQ) {
+                                boolean flush = region.flush(FlushReason.FORCE);
+                                LOG.debug("Trigger flush table region {} because of savepoint, region cache bytes: {}, flush: {}",
+                                        region.getUniqueKey(), region.getCacheBytes(), flush);
+                            }
+
+                            // should ensure all data is committed for auto-commit mode
+                            if (enableAutoCommit) {
+                                int committedRegions = 0;
+                                for (TransactionTableRegion region : flushQ) {
+                                    // savepoint makes sure no more data is written, so these conditions
+                                    // can guarantee commit after all data has been written to StarRocks
+                                    boolean success = region.commit();
+                                    if (success && region.getCacheBytes() == 0) {
+                                        committedRegions += 1;
+                                        region.resetAge();
+                                    }
+                                    LOG.debug("Commit region {} for savepoint, success: {}", region.getUniqueKey(), success);
+                                }
+
+                                if (committedRegions == flushQ.size()) {
+                                    allRegionsCommitted = true;
+                                    LOG.info("All regions committed for savepoint, number of regions: {}", committedRegions);
+                                } else {
+                                    LOG.debug("Some regions not committed for savepoint, expected num: {}, actual num: {}",
+                                            flushQ.size(), committedRegions);
+                                }
                             }
                         }
                         LockSupport.unpark(current);
+                    } else if (commitInFlight.get()) {
+                        // Multi-table coordinator-based commit (manager thread)
+                        processMultiTableCommit();
                     } else {
+                        // Normal timer-driven path (non-multi-table, or multi-table between commits)
+
+                        // In multi-table mode, ensure a shared transaction is always open so
+                        // that autonomous flushes use the shared label instead of independent labels.
+                        // This eliminates the data-loss window where an independent-label flush
+                        // could be orphaned when a shared transaction later overwrites the label.
+                        if (multiTableTransactionEnabled && txnCoordinator != null && !flushQ.isEmpty()) {
+                            if (!txnCoordinator.isActive()) {
+                                try {
+                                    ensureSharedTransaction();
+                                } catch (Exception beginEx) {
+                                    LOG.error("[MultiTxn] Failed to eagerly open shared transaction", beginEx);
+                                    this.e = beginEx;
+                                    // Skip flush/commit to avoid creating orphan independent transactions.
+                                    continue;
+                                }
+                            } else if (txnCoordinator.getElapsedMs() >= sharedTxnMaxIdleMs) {
+                                // Recycle the shared transaction before server-side timeout.
+                                try {
+                                    recycleSharedTransaction();
+                                } catch (Exception recycleEx) {
+                                    LOG.error("[MultiTxn] Failed to recycle shared transaction", recycleEx);
+                                    this.e = recycleEx;
+                                    continue;
+                                }
+                            }
+                        }
+
+                        // In multi-table mode, check if partitions are ready to
+                        // switch and commit.  This runs on the manager thread (not
+                        // the task thread) so that the task thread has had time to
+                        // process subsequent records and register all partitions in
+                        // the tracker before allSwitched() is evaluated.
+                        if (multiTableTransactionEnabled && partitionTracker != null) {
+                            trySwitchAndCommit();
+                            if (commitInFlight.get()) {
+                                // All partitions switched; skip autonomous flush and
+                                // enter processMultiTableCommit() on the next iteration.
+                                continue;
+                            }
+                        }
+
                         for (TransactionTableRegion region : flushQ) {
                             region.getAndIncrementAge();
                             if (flushAndCommitStrategy.shouldCommit(region)) {
@@ -229,6 +421,9 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
                         for (FlushAndCommitStrategy.SelectFlushResult result : flushAndCommitStrategy.selectFlushRegions(flushQ, currentCacheBytes.get())) {
                             TransactionTableRegion region = result.getRegion();
                             boolean flush = region.flush(result.getReason());
+                            if (flush && multiTableTransactionEnabled && txnCoordinator != null) {
+                                txnCoordinator.markDataLoaded();
+                            }
                             LOG.debug("Trigger flush table region {} because of selection, region cache bytes: {}," +
                                     " flush: {}", region.getUniqueKey(), region.getCacheBytes(), flush);
                         }
@@ -236,16 +431,304 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
                 }
             }, "StarRocks-Sink-Manager");
             manager.setDaemon(true);
-            manager.start();
             manager.setUncaughtExceptionHandler((t, ee) -> {
                 LOG.error("StarRocks-Sink-Manager error", ee);
                 e = ee;
             });
+            streamLoader.start(properties, this);
+
+            if (multiTableTransactionEnabled) {
+                this.txnCoordinator = new SharedTransactionCoordinator(streamLoader, labelGeneratorFactory);
+                LOG.info("[MultiTxn] Multi-table transaction mode enabled");
+            }
+
+            // Start the manager thread AFTER streamLoader and txnCoordinator
+            // are fully initialized, so the thread has guaranteed visibility
+            // of these fields (Thread.start() provides happens-before).
+            manager.start();
             LOG.info("StarRocks-Sink-Manager start, enableAutoCommit: {}, streamLoader: {}, {}",
                     enableAutoCommit, streamLoader.getClass().getName(), EnvUtils.getGitInformation());
-
-            streamLoader.start(properties, this);
         }
+    }
+
+    @Override
+    public void setCommitAllowed(boolean allowed) {
+        // Legacy no-partition variant: no-op in multi-table mode
+    }
+
+    @Override
+    public void setCommitAllowed(int partition, boolean allowed) {
+        if (!multiTableTransactionEnabled) {
+            return;
+        }
+        if (!allowed) {
+            return;
+        }
+
+        // Record the txnEnd and immediately switch chunks on the task thread.
+        // This must happen synchronously before returning, because the very next
+        // record from the source may belong to a new transaction.  If we deferred
+        // the switch to the manager thread, the new transaction's write() would
+        // call onWrite() and reset the partition back to ACTIVE, causing the
+        // previous transaction's commit to be lost.
+        boolean transitioned = partitionTracker.onTxnEnd(partition);
+        if (transitioned) {
+            List<TransactionTableRegion> pRegions = partitionRegions.get(partition);
+            if (pRegions != null) {
+                for (TransactionTableRegion region : pRegions) {
+                    region.switchChunkForCommit();
+                }
+            }
+            partitionTracker.markSwitched(partition);
+            LOG.debug("[MultiTxn] txnEnd for partition={}, regions immediately switched", partition);
+        } else {
+            LOG.debug("[MultiTxn] txnEnd for partition={}, deferred (already switched)", partition);
+        }
+    }
+
+    /**
+     * Attempts to switch ready partitions and trigger a commit if all are switched.
+     * Called on the manager thread (from the normal timer-driven path) so that the
+     * task thread has had time to process subsequent records and register all
+     * partitions before allSwitched() is evaluated.
+     */
+    private void trySwitchAndCommit() {
+        List<Integer> readyPartitions = partitionTracker.getReadyToSwitch();
+        for (int p : readyPartitions) {
+            List<TransactionTableRegion> pRegions = partitionRegions.get(p);
+            if (pRegions != null) {
+                for (TransactionTableRegion region : pRegions) {
+                    region.switchChunkForCommit();
+                }
+            }
+            partitionTracker.markSwitched(p);
+            LOG.debug("[MultiTxn] partition {} switched, regions={}", p,
+                    pRegions == null ? 0 : pRegions.size());
+        }
+
+        if (partitionTracker.allSwitched() && commitInFlight.compareAndSet(false, true)) {
+            // No flushable.signal() needed — this method already runs on the
+            // manager thread.  The caller will see commitInFlight==true and
+            // `continue` to the next iteration which enters processMultiTableCommit().
+            LOG.info("[MultiTxn] All partitions switched, commitInFlight=true");
+        }
+    }
+
+    /**
+     * Processes a multi-table commit cycle using the SharedTransactionCoordinator.
+     * Called on the manager thread when commitInFlight=true.
+     *
+     * <p>Because the shared transaction is eagerly opened (by {@link #ensureSharedTransaction()})
+     * before any autonomous flush, all in-flight HTTP loads already use the shared label.
+     * This method simply:
+     * <ol>
+     *   <li>Waits for all in-flight loads to complete</li>
+     *   <li>Triggers loads for any remaining inactive chunks (from switchChunkForCommit)</li>
+     *   <li>Waits again for those loads</li>
+     *   <li>Executes unified prepare + commit</li>
+     *   <li>Opens a new shared transaction for the next cycle</li>
+     * </ol>
+     */
+    private void processMultiTableCommit() {
+        // If a prior error occurred (e.g. failed HTTP load), abort the commit
+        // cycle immediately so the error surfaces via checkAndThrowException().
+        if (this.e != null) {
+            LOG.error("[MultiTxn] Aborting commit cycle due to prior error: {}", this.e.getMessage());
+            commitInFlight.set(false);
+            partitionTracker.reset();
+            return;
+        }
+
+        final List<TransactionTableRegion> regionSnapshot =
+                Collections.unmodifiableList(new ArrayList<>(flushQ));
+        try {
+            if (!txnCoordinator.isActive()) {
+                // Edge case: commitInFlight was set but no shared txn is open yet
+                // (e.g. first write + immediate txnEnd before manager thread ran).
+                // Ensure the shared transaction exists before proceeding.
+                ensureSharedTransaction();
+            }
+
+            // Wait for any in-flight autonomous flushes to complete.
+            for (TransactionTableRegion region : regionSnapshot) {
+                if (region.isFlushing() || region.isRetrying()) {
+                    LOG.debug("[MultiTxn] Region {} still flushing/retrying, will retry next scan",
+                            region.getUniqueKey());
+                    return;
+                }
+            }
+
+            // Trigger loads for regions that have inactive chunks from switchChunkForCommit
+            // but haven't been flushed yet (data arrived between the last autonomous flush
+            // and the txnEnd marker).
+            boolean triggeredNew = false;
+            for (TransactionTableRegion region : regionSnapshot) {
+                if (region.triggerLoadIfNeeded()) {
+                    txnCoordinator.markDataLoaded();
+                    triggeredNew = true;
+                    LOG.debug("[MultiTxn] triggered load for region={}", region.getUniqueKey());
+                }
+            }
+            if (triggeredNew) {
+                // New loads were triggered, wait for them to complete on next scan.
+                return;
+            }
+
+            // All loads are done. Commit.
+            String anyTable = null;
+            for (TransactionTableRegion region : regionSnapshot) {
+                if (anyTable == null) {
+                    anyTable = region.getTable();
+                }
+            }
+
+            if (anyTable != null) {
+                if (txnCoordinator.hasDataLoaded()) {
+                    txnCoordinator.prepareAndCommit(anyTable);
+                } else {
+                    // No data was loaded — rollback the empty transaction.
+                    LOG.info("[MultiTxn] No data loaded in shared transaction; rolling back empty txn");
+                    txnCoordinator.reset();
+                }
+            } else {
+                txnCoordinator.reset();
+            }
+
+            // Clear labels and reset state
+            for (TransactionTableRegion region : regionSnapshot) {
+                region.setLabel(null);
+                region.resetAge();
+            }
+            commitInFlight.set(false);
+            partitionTracker.reset();
+            LOG.info("[MultiTxn] Shared transaction cycle completed; commitInFlight=false");
+
+            // Immediately open a new shared transaction for the next cycle,
+            // so any subsequent autonomous flushes are under the new shared label.
+            // This is best-effort: if it fails, the normal path will retry on the next scan.
+            if (!flushQ.isEmpty()) {
+                try {
+                    ensureSharedTransaction();
+                } catch (Exception beginEx) {
+                    LOG.warn("[MultiTxn] Failed to eagerly open next shared transaction after commit; " +
+                            "will retry on next scan: {}", beginEx.getMessage());
+                    txnCoordinator.reset();
+                    for (TransactionTableRegion region : regionSnapshot) {
+                        if (!region.isRetrying()) {
+                            region.setLabel(null);
+                        }
+                    }
+                }
+            }
+        } catch (Exception ex) {
+            LOG.error("[MultiTxn] Shared transaction commit failed", ex);
+            txnCoordinator.reset();
+            commitInFlight.set(false);
+            partitionTracker.reset();
+            for (TransactionTableRegion region : regionSnapshot) {
+                if (!region.isRetrying()) {
+                    region.setLabel(null);
+                }
+            }
+            this.e = ex;
+        }
+    }
+
+    /**
+     * Opens a new shared transaction and injects its label into all current regions.
+     * Called on the manager thread to ensure autonomous flushes always use the shared label.
+     *
+     * <p>This must only be called when no shared transaction is currently active.
+     */
+    private void ensureSharedTransaction() {
+        String anyDb = null;
+        String anyTable = null;
+        for (TransactionTableRegion region : flushQ) {
+            if (anyDb == null) {
+                anyDb = region.getDatabase();
+                anyTable = region.getTable();
+            } else if (!anyDb.equals(region.getDatabase())) {
+                throw new IllegalStateException(
+                        "All regions in a multi-table commit must share the same database. " +
+                        "Found databases: '" + anyDb + "' and '" + region.getDatabase() + "'");
+            }
+        }
+        if (anyDb == null) {
+            return;
+        }
+
+        // Ensure no region is retrying — setLabel() throws if numRetries > 0.
+        for (TransactionTableRegion region : flushQ) {
+            if (region.isFlushing() || region.isRetrying()) {
+                LOG.debug("[MultiTxn] Cannot open shared txn: region {} is flushing/retrying",
+                        region.getUniqueKey());
+                return;
+            }
+        }
+
+        txnCoordinator.begin(anyDb, anyTable);
+
+        for (TransactionTableRegion region : flushQ) {
+            try {
+                region.setLabel(txnCoordinator.getSharedLabel());
+            } catch (IllegalStateException ex) {
+                // Region started retrying between the check and setLabel (narrow race).
+                // Roll back and let the next scan retry.
+                LOG.warn("[MultiTxn] Region {} started retrying during ensureSharedTransaction; " +
+                        "rolling back: {}", region.getUniqueKey(), ex.getMessage());
+                txnCoordinator.reset();
+                return;
+            }
+        }
+        LOG.info("[MultiTxn] Eagerly opened shared transaction: label={}",
+                txnCoordinator.getSharedLabel());
+    }
+
+    /**
+     * Recycles (commit-or-rollback + reopen) the current shared transaction to prevent
+     * it from hitting the StarRocks server-side timeout. Must only be called from the
+     * manager thread when no region is actively flushing.
+     */
+    private void recycleSharedTransaction() {
+        // Do not recycle if a commit cycle is pending — the switched chunks
+        // must be committed under the current shared transaction to preserve atomicity.
+        if (commitInFlight.get()) {
+            LOG.debug("[MultiTxn] Cannot recycle shared txn: commitInFlight=true");
+            return;
+        }
+
+        // Wait for any in-flight loads before recycling.
+        for (TransactionTableRegion region : flushQ) {
+            if (region.isFlushing() || region.isRetrying()) {
+                LOG.debug("[MultiTxn] Cannot recycle shared txn: region {} still flushing/retrying",
+                        region.getUniqueKey());
+                return;
+            }
+        }
+
+        LOG.info("[MultiTxn] Recycling shared transaction approaching timeout: label={}, elapsed={}ms",
+                txnCoordinator.getSharedLabel(), txnCoordinator.getElapsedMs());
+
+        String anyTable = null;
+        for (TransactionTableRegion region : flushQ) {
+            if (anyTable == null) {
+                anyTable = region.getTable();
+            }
+        }
+
+        if (anyTable != null && txnCoordinator.hasDataLoaded()) {
+            txnCoordinator.prepareAndCommit(anyTable);
+            LOG.info("[MultiTxn] Recycled shared transaction committed");
+        } else {
+            txnCoordinator.reset();
+            LOG.info("[MultiTxn] Recycled empty shared transaction (rolled back)");
+        }
+
+        // Clear labels and open a fresh shared transaction.
+        for (TransactionTableRegion region : flushQ) {
+            region.setLabel(null);
+        }
+        ensureSharedTransaction();
     }
 
     public void setStreamLoadListener(StreamLoadListener streamLoadListener) {
@@ -260,42 +743,51 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
     public void write(String uniqueKey, String database, String table, String... rows) {
         TableRegion region = getCacheRegion(uniqueKey, database, table);
         for (String row : rows) {
-            AssertNotException();
+            checkAndThrowException();
             if (LOG.isTraceEnabled()) {
                 LOG.trace("Write uniqueKey {}, database {}, table {}, row {}",
                         uniqueKey == null ? "null" : uniqueKey, database, table, row);
             }
             int bytes = region.write(row.getBytes(StandardCharsets.UTF_8));
-            long cachedBytes = currentCacheBytes.addAndGet(bytes);
-            if (cachedBytes >= maxWriteBlockCacheBytes) {
-                long startTime = System.nanoTime();
-                lock.lock();
-                try {
-                    int idx = 0;
-                    while (currentCacheBytes.get() >= maxWriteBlockCacheBytes) {
-                        AssertNotException();
-                        LOG.info("Cache full, wait flush, currentBytes: {}, maxWriteBlockCacheBytes: {}",
-                                currentCacheBytes.get(), maxWriteBlockCacheBytes);
-                        flushable.signal();
-                        writable.await(Math.min(++idx, 5), TimeUnit.SECONDS);
-                    }
-                } catch (InterruptedException ex) {
-                    this.e = ex;
-                    throw new RuntimeException(ex);
-                } finally {
-                    lock.unlock();
-                }
-                loadMetrics.updateWriteBlock(1, System.nanoTime() - startTime);
-            } else if (cachedBytes >= maxCacheBytes && writeTriggerFlush.compareAndSet(false, true)) {
-                lock.lock();
-                try {
+            blockIfCacheFull(currentCacheBytes.addAndGet(bytes));
+        }
+    }
+
+    /**
+     * Blocks the calling (task) thread if the write-side cache is full, and signals
+     * the manager thread to flush when the soft threshold is reached.
+     *
+     * <p>Extracted to avoid duplication between the two {@code write()} overloads.
+     */
+    private void blockIfCacheFull(long cachedBytes) {
+        if (cachedBytes >= maxWriteBlockCacheBytes) {
+            long startTime = System.nanoTime();
+            lock.lock();
+            try {
+                int idx = 0;
+                while (currentCacheBytes.get() >= maxWriteBlockCacheBytes) {
+                    checkAndThrowException();
+                    LOG.info("Cache full, wait flush, currentBytes: {}, maxWriteBlockCacheBytes: {}",
+                            currentCacheBytes.get(), maxWriteBlockCacheBytes);
                     flushable.signal();
-                } finally {
-                    lock.unlock();
+                    writable.await(Math.min(++idx, 5), TimeUnit.SECONDS);
                 }
-                loadMetrics.updateWriteTriggerFlush(1);
-                LOG.info("Trigger flush, currentBytes: {}, maxCacheBytes: {}", cachedBytes, maxCacheBytes);
+            } catch (InterruptedException ex) {
+                this.e = ex;
+                throw new RuntimeException(ex);
+            } finally {
+                lock.unlock();
             }
+            loadMetrics.updateWriteBlock(1, System.nanoTime() - startTime);
+        } else if (cachedBytes >= maxCacheBytes && writeTriggerFlush.compareAndSet(false, true)) {
+            lock.lock();
+            try {
+                flushable.signal();
+            } finally {
+                lock.unlock();
+            }
+            loadMetrics.updateWriteTriggerFlush(1);
+            LOG.info("Trigger flush, currentBytes: {}, maxCacheBytes: {}", cachedBytes, maxCacheBytes);
         }
     }
 
@@ -307,7 +799,7 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
         }
         writeTriggerFlush.set(false);
 
-        LOG.info("Receive load response, cacheByteBeforeFlush: {}, currentCacheBytes: {}, totalFlushRows : {}",
+        LOG.debug("Receive load response, cacheByteBeforeFlush: {}, currentCacheBytes: {}, totalFlushRows : {}",
                 cacheByteBeforeFlush, currentCacheBytes.get(), totalFlushRows.get());
 
         lock.lock();
@@ -366,21 +858,28 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
         long startTime = System.currentTimeMillis();
         long waitTime = 100; // Initial wait time: 100ms
 
-        while (!isSavepointFinished()) {
-            checkFlushTimeout(startTime);
+        try {
+            while (!isSavepointFinished()) {
+                checkFlushTimeout(startTime);
 
-            triggerFlushSignal();
-            LockSupport.park(current);
+                triggerFlushSignal();
+                LockSupport.park(current);
 
-            if (!savepoint) {
-                break;
+                if (!savepoint) {
+                    break;
+                }
+
+                waitForRegionResults(waitTime);
+                waitTime = calculateNextWaitTime(waitTime);
             }
 
-            waitForRegionResults(waitTime);
-            waitTime = calculateNextWaitTime(waitTime);
+            finishFlush();
+        } finally {
+            // Ensure the savepoint flag is always cleared even if checkFlushTimeout()
+            // or finishFlush() throw, so the manager thread does not keep acting on
+            // a stale savepoint signal after flush() has already returned.
+            savepoint = false;
         }
-
-        finishFlush();
     }
 
     private void initializeFlushState() {
@@ -438,7 +937,7 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
     private void finishFlush() {
         LOG.info("Stream load manager flush finished - currentCacheBytes: {}, maxCacheBytes: {}, allRegionsCommitted: {}",
                 currentCacheBytes.get(), maxCacheBytes, allRegionsCommitted);
-        AssertNotException();
+        checkAndThrowException();
         savepoint = false;
     }
 
@@ -475,6 +974,14 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
         if (state.compareAndSet(State.ACTIVE, State.INACTIVE)) {
             LOG.info("StreamLoadManagerV2 close, loadMetrics: {}, flushAndCommit: {}",
                     loadMetrics, flushAndCommitStrategy);
+            // Clean up the shared transaction to avoid server-side timeout warnings.
+            if (txnCoordinator != null && txnCoordinator.isActive()) {
+                try {
+                    txnCoordinator.reset();
+                } catch (Exception ex) {
+                    LOG.warn("Failed to rollback shared transaction during close", ex);
+                }
+            }
             manager.interrupt();
             streamLoader.close();
         }
@@ -484,10 +991,10 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
         if (e != null) {
             return true;
         }
-        return currentCacheBytes.compareAndSet(0L, 0L) && (!enableAutoCommit || allRegionsCommitted);
+        return currentCacheBytes.get() == 0L && (!enableAutoCommit || allRegionsCommitted);
     }
 
-    private void AssertNotException() {
+    private void checkAndThrowException() {
         if (e != null) {
             LOG.error("catch exception, wait rollback ", e);
             streamLoader.rollback(snapshot());
@@ -496,24 +1003,57 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
         }
     }
 
+    @Override
+    public void write(int partition, String database, String table, String... rows) {
+        if (!multiTableTransactionEnabled) {
+            write(null, database, table, rows);
+            return;
+        }
+        String uniqueKey = "P" + partition + "-" + StreamLoadUtils.getTableUniqueKey(database, table);
+        partitionTracker.onWrite(partition);
+        TableRegion region = getCacheRegion(uniqueKey, database, table, partition);
+        for (String row : rows) {
+            checkAndThrowException();
+            int bytes = region.write(row.getBytes(StandardCharsets.UTF_8));
+            blockIfCacheFull(currentCacheBytes.addAndGet(bytes));
+        }
+    }
+
     protected TableRegion getCacheRegion(String uniqueKey, String database, String table) {
+        return getCacheRegion(uniqueKey, database, table, -1);
+    }
+
+    protected TableRegion getCacheRegion(String uniqueKey, String database, String table, int partition) {
         if (uniqueKey == null) {
             uniqueKey = StreamLoadUtils.getTableUniqueKey(database, table);
         }
 
         TableRegion region = regions.get(uniqueKey);
         if (region == null) {
-            // currently write() will not be called concurrently, so regions will also not be
-            // created concurrently, but for future extension, protect it with synchronized
             synchronized (regions) {
                 region = regions.get(uniqueKey);
                 if (region == null) {
-                    StreamLoadTableProperties tableProperties = properties.getTableProperties(uniqueKey, database, table);
+                    // For per-partition regions, look up table properties by the real table key
+                    String tableKey = StreamLoadUtils.getTableUniqueKey(database, table);
+                    StreamLoadTableProperties tableProperties = properties.getTableProperties(tableKey, database, table);
                     LabelGenerator labelGenerator = labelGeneratorFactory.create(database, table);
-                    region = new TransactionTableRegion(uniqueKey, database, table, this,
+                    TransactionTableRegion newRegion = new TransactionTableRegion(
+                            uniqueKey, database, table, this,
                             tableProperties, streamLoader, labelGenerator, maxRetries, retryIntervalInMs);
-                    regions.put(uniqueKey, region);
-                    flushQ.offer((TransactionTableRegion) region);
+                    if (multiTableTransactionEnabled) {
+                        newRegion.getHeaders().put("transaction_type", "multi");
+                        // If a shared transaction is already open, inject its label so that
+                        // the first flush of this region uses the shared label.
+                        if (txnCoordinator != null && txnCoordinator.isActive()) {
+                            newRegion.setLabel(txnCoordinator.getSharedLabel());
+                        }
+                    }
+                    regions.put(uniqueKey, newRegion);
+                    flushQ.offer(newRegion);
+                    if (partition >= 0) {
+                        partitionRegions.computeIfAbsent(partition, k -> new CopyOnWriteArrayList<>()).add(newRegion);
+                    }
+                    region = newRegion;
                 }
             }
         }

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/DefaultStreamLoadManager.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/DefaultStreamLoadManager.java
@@ -1531,7 +1531,25 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
                         newRegion.getHeaders().put("transaction_type", "multi");
                         // If a shared transaction is already open, inject its label so that
                         // the first flush of this region uses the shared label.
+                        //
+                        // Shared transactions are single-database by construction
+                        // (see ensureSharedTransaction()), so a region whose database
+                        // does not match the active shared txn must never receive that
+                        // label — otherwise its first flush would POST to its own
+                        // database with a label that belongs to a different one, which
+                        // StarRocks rejects and which would abort the sink task with
+                        // an opaque HTTP error. Fail fast at routing time instead, so
+                        // the exception points directly at the mixed-database write.
                         if (txnCoordinator != null && txnCoordinator.isActive()) {
+                            String txnDb = txnCoordinator.getDatabase();
+                            if (txnDb != null && !txnDb.equals(database)) {
+                                throw new IllegalStateException(
+                                        "[MultiTxn] Cannot route write for database '" + database
+                                        + "' while a shared transaction is active for database '"
+                                        + txnDb + "'. Multi-table shared transactions require all "
+                                        + "regions to share the same database; configure a separate "
+                                        + "sink for each database.");
+                            }
                             newRegion.setLabel(txnCoordinator.getSharedLabel());
                         }
                     }

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/DefaultStreamLoadManager.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/DefaultStreamLoadManager.java
@@ -95,6 +95,24 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
     private final AtomicLong currentCacheBytes = new AtomicLong(0L);
     private final AtomicLong totalFlushRows = new AtomicLong(0L);
 
+    // Multi-table mode only. Aggregate bytes currently held in activeChunks that
+    // belong to in-progress (not-yet-ended) source transactions across all
+    // regions. A single source transaction can span several tables; the task
+    // thread accumulates rows into each region's activeChunk until the per-table
+    // txnEnd arrives, at which point the corresponding region transitions to a
+    // clean boundary and its in-progress contribution is subtracted from this
+    // counter.
+    //
+    // The per-region fail-fast in TransactionTableRegion only catches the case
+    // where a single region's in-progress chunk exceeds maxWriteBlockCacheBytes.
+    // When a single source transaction splits its payload across many regions,
+    // each region can stay under the per-region cap while the aggregate pushes
+    // currentCacheBytes past the write-block threshold — blockIfCacheFull then
+    // parks the task thread, which in turn cannot deliver the txnEnd marker,
+    // resulting in a silent deadlock. This aggregate counter lets us fail fast
+    // in write() before the deadlock window opens.
+    private final AtomicLong aggregateInProgressTxnBytes = new AtomicLong(0L);
+
     private final AtomicLong numberTotalRows = new AtomicLong(0L);
     private final AtomicLong numberLoadRows = new AtomicLong(0L);
 
@@ -1093,6 +1111,39 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
     }
 
     /**
+     * Applies {@code delta} to the multi-table aggregate in-progress txn byte
+     * counter and returns the resulting value.
+     *
+     * <p>Called from {@link TransactionTableRegion} when:
+     * <ul>
+     *   <li>a write extends an in-progress source transaction ({@code delta > 0});</li>
+     *   <li>a region transitions back to a clean transaction boundary,
+     *       freezing previously in-progress bytes as committed ({@code delta < 0}).</li>
+     * </ul>
+     *
+     * <p>Meaningful only when multi-table transaction mode is enabled.
+     */
+    long addAggregateInProgressTxnBytes(long delta) {
+        return aggregateInProgressTxnBytes.addAndGet(delta);
+    }
+
+    /** Returns the current value of the aggregate in-progress txn byte counter. */
+    long getAggregateInProgressTxnBytes() {
+        return aggregateInProgressTxnBytes.get();
+    }
+
+    /**
+     * Returns the effective write-block threshold. When the multi-table aggregate
+     * in-progress bytes plus an incoming row would exceed this threshold, the
+     * task thread would be blocked by {@link #blockIfCacheFull} with no way for
+     * any region to flush (no region has reached a clean boundary yet) — a
+     * silent deadlock. Regions call this to know when to fail fast.
+     */
+    long getMaxWriteBlockCacheBytes() {
+        return maxWriteBlockCacheBytes;
+    }
+
+    /**
      * Blocks the calling (task) thread if the write-side cache is full, and signals
      * the manager thread to flush when the soft threshold is reached.
      *
@@ -1321,8 +1372,19 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
                     LOG.warn("Failed to rollback shared transaction during close", ex);
                 }
             }
-            manager.interrupt();
-            streamLoader.close();
+            try {
+                manager.interrupt();
+                streamLoader.close();
+            } finally {
+                // Defensive: drop any residual in-progress byte accounting so a
+                // later reuse of this instance (or a snapshot taken post-close)
+                // cannot observe a stale non-zero aggregate that would produce
+                // false-positive fail-fasts in write0's aggregate guard. The
+                // reset must run even if streamLoader.close() throws — otherwise
+                // the "defensive" framing in the comment above would only hold
+                // on the happy path.
+                aggregateInProgressTxnBytes.set(0L);
+            }
         }
     }
 

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/DefaultStreamLoadManager.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/DefaultStreamLoadManager.java
@@ -193,6 +193,17 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
                     "Multi-table transaction mode requires TransactionStreamLoader. " +
                     "Retry (maxRetries > 0) is not supported with multi-table transactions.");
         }
+        // Multi-table mode is incompatible with SDK manual-commit mode. The manager's
+        // timer-driven path (tryStartTimerDrivenCommit -> processMultiTableCommit) autonomously
+        // commits the shared transaction once commitIntervalMs has elapsed and data is present,
+        // so an external 2PC caller would see data published before its explicit snapshot/commit
+        // step. Reject the combination at construction time rather than silently auto-publishing.
+        if (properties.isEnableMultiTableTransaction() && !enableAutoCommit) {
+            throw new IllegalArgumentException(
+                    "Multi-table transaction mode requires enableAutoCommit=true. " +
+                    "The manager autonomously drives shared-transaction commits on a timer, " +
+                    "which is incompatible with external manual-commit (2PC) control.");
+        }
         if (properties.isEnableMultiTableTransaction() && properties.getMultiTableTransactionBufferSize() > 0) {
             this.maxCacheBytes = properties.getMultiTableTransactionBufferSize();
         } else {

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/DefaultStreamLoadManager.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/DefaultStreamLoadManager.java
@@ -111,6 +111,8 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
     private long sharedTxnMaxIdleMs = 480_000L;
 
     private final AtomicBoolean commitInFlight = new AtomicBoolean(false);
+    /** Timestamp (ms) when commitInFlight was set to true, for timeout detection. */
+    private volatile long commitInFlightStartMs;
 
     private final Lock lock = new ReentrantLock();
     private final Condition writable = lock.newCondition();
@@ -388,8 +390,13 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
                                 } catch (Exception recycleEx) {
                                     LOG.error("[MultiTxn] Failed to recycle shared transaction", recycleEx);
                                     this.e = recycleEx;
-                                    continue;
                                 }
+                                // Must skip the flush-selection loop below: recycleSharedTransaction()
+                                // clears region labels then re-opens via ensureSharedTransaction().
+                                // If the re-open silently returned (e.g. a region started retrying),
+                                // regions have null labels; falling through would create orphan
+                                // independent-label loads that break atomicity.
+                                continue;
                             }
                         }
 
@@ -507,6 +514,7 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
         }
 
         if (partitionTracker.allSwitched() && commitInFlight.compareAndSet(false, true)) {
+            commitInFlightStartMs = System.currentTimeMillis();
             // No flushable.signal() needed — this method already runs on the
             // manager thread.  The caller will see commitInFlight==true and
             // `continue` to the next iteration which enters processMultiTableCommit().
@@ -536,6 +544,26 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
             LOG.error("[MultiTxn] Aborting commit cycle due to prior error: {}", this.e.getMessage());
             commitInFlight.set(false);
             partitionTracker.reset();
+            return;
+        }
+
+        // Timeout detection: if the commit cycle is stuck (e.g. a region's HTTP load
+        // keeps failing and retrying), abort to avoid stalling the pipeline indefinitely.
+        long commitElapsedMs = System.currentTimeMillis() - commitInFlightStartMs;
+        if (commitElapsedMs > flushTimeoutMs) {
+            LOG.error("[MultiTxn] Commit-in-flight timeout: elapsed {}ms, timeout {}ms",
+                    commitElapsedMs, flushTimeoutMs);
+            txnCoordinator.reset();
+            for (TransactionTableRegion region : flushQ) {
+                if (!region.isRetrying()) {
+                    region.setLabel(null);
+                }
+            }
+            commitInFlight.set(false);
+            partitionTracker.reset();
+            this.e = new RuntimeException(String.format(
+                    "[MultiTxn] Commit-in-flight timeout: elapsed %dms, timeout %dms",
+                    commitElapsedMs, flushTimeoutMs));
             return;
         }
 
@@ -657,7 +685,8 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
             return;
         }
 
-        // Ensure no region is retrying — setLabel() throws if numRetries > 0.
+        // Ensure no region is retrying — setLabel() silently skips when numRetries > 0,
+        // which would leave the region with a stale label, breaking atomicity.
         for (TransactionTableRegion region : flushQ) {
             if (region.isFlushing() || region.isRetrying()) {
                 LOG.debug("[MultiTxn] Cannot open shared txn: region {} is flushing/retrying",
@@ -669,16 +698,15 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
         txnCoordinator.begin(anyDb, anyTable);
 
         for (TransactionTableRegion region : flushQ) {
-            try {
-                region.setLabel(txnCoordinator.getSharedLabel());
-            } catch (IllegalStateException ex) {
-                // Region started retrying between the check and setLabel (narrow race).
-                // Roll back and let the next scan retry.
-                LOG.warn("[MultiTxn] Region {} started retrying during ensureSharedTransaction; " +
-                        "rolling back: {}", region.getUniqueKey(), ex.getMessage());
+            // Re-check retrying: a region may have entered retry (via fail() on the
+            // executor thread) between the bulk check above and this point.
+            if (region.isRetrying()) {
+                LOG.warn("[MultiTxn] Region {} started retrying during ensureSharedTransaction; "
+                        + "rolling back", region.getUniqueKey());
                 txnCoordinator.reset();
                 return;
             }
+            region.setLabel(txnCoordinator.getSharedLabel());
         }
         LOG.info("[MultiTxn] Eagerly opened shared transaction: label={}",
                 txnCoordinator.getSharedLabel());
@@ -688,6 +716,11 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
      * Recycles (commit-or-rollback + reopen) the current shared transaction to prevent
      * it from hitting the StarRocks server-side timeout. Must only be called from the
      * manager thread when no region is actively flushing.
+     *
+     * <p><b>IMPORTANT:</b> The caller must {@code continue} to the next loop iteration
+     * after calling this method, skipping the flush-selection loop. Between clearing
+     * region labels and re-opening the shared transaction, any autonomous flush would
+     * use a null/stale label and break atomicity.
      */
     private void recycleSharedTransaction() {
         // Do not recycle if a commit cycle is pending — the switched chunks
@@ -938,7 +971,7 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
         LOG.info("Stream load manager flush finished - currentCacheBytes: {}, maxCacheBytes: {}, allRegionsCommitted: {}",
                 currentCacheBytes.get(), maxCacheBytes, allRegionsCommitted);
         checkAndThrowException();
-        savepoint = false;
+        // savepoint is cleared by the finally block in flush(), not here.
     }
 
     @Override

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/DefaultStreamLoadManager.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/DefaultStreamLoadManager.java
@@ -325,21 +325,58 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
                                 }
                             }
 
-                            // Ensure a shared transaction is open (may not be if no data
-                            // was written yet, or if we just finished a commit cycle).
-                            if (!txnCoordinator.isActive() && !flushQ.isEmpty()) {
-                                ensureSharedTransaction();
+                            // Wait for all regions to quiesce (neither flushing nor
+                            // retrying) before opening the shared transaction. Without
+                            // this wait, ensureSharedTransaction() would return false on
+                            // any transient in-flight load and force the checkpoint to
+                            // fail — a common race under load. The check mirrors the
+                            // allLoadsDone loop below, extended with isRetrying() (so
+                            // we don't race trySetLabel() against a region currently
+                            // between retry attempts), and capped by flushTimeoutMs so
+                            // a non-converging retry cannot block the savepoint forever.
+                            long waitDeadline = System.currentTimeMillis() + flushTimeoutMs;
+                            while (true) {
+                                if (this.e != null) {
+                                    // Some callback failed the manager while we were
+                                    // waiting. Preserve the original root cause rather
+                                    // than letting ensureSharedTransaction() below throw
+                                    // a secondary exception that the outer catch would
+                                    // assign to this.e, masking the real error.
+                                    throw new IllegalStateException(
+                                            "[MultiTxn] Manager errored while waiting for "
+                                            + "regions to quiesce during savepoint", this.e);
+                                }
+                                boolean anyBusy = false;
+                                for (TransactionTableRegion region : flushQ) {
+                                    if (region.isFlushing() || region.isRetrying()) {
+                                        anyBusy = true;
+                                        break;
+                                    }
+                                }
+                                if (!anyBusy) {
+                                    break;
+                                }
+                                if (System.currentTimeMillis() > waitDeadline) {
+                                    throw new IllegalStateException(
+                                            "[MultiTxn] Savepoint timed out after " + flushTimeoutMs
+                                            + "ms waiting for regions to quiesce before opening "
+                                            + "shared transaction");
+                                }
+                                LockSupport.parkNanos(1_000_000L);
                             }
 
-                            // Wait for any in-flight loads to complete
-                            for (TransactionTableRegion region : flushQ) {
-                                Future<?> result = region.getResult();
-                                if (result != null) {
-                                    try {
-                                        result.get();
-                                    } catch (Exception ignored) {
-                                        // errors will be handled by the callback
-                                    }
+                            // Ensure a shared transaction is open (may not be if no data
+                            // was written yet, or if we just finished a commit cycle).
+                            // After the quiesce wait above this will almost always
+                            // succeed; the throw covers the microsecond-window race
+                            // where trySetLabel() loses to a late-arriving retry.
+                            if (!txnCoordinator.isActive() && !flushQ.isEmpty()) {
+                                if (!ensureSharedTransaction()) {
+                                    throw new IllegalStateException(
+                                            "[MultiTxn] Could not open shared transaction during "
+                                            + "savepoint even after quiesce wait (likely trySetLabel "
+                                            + "lost a race with a late retry). Failing the checkpoint "
+                                            + "to preserve atomicity; Flink will retry.");
                                 }
                             }
 
@@ -467,12 +504,21 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
                         // could be orphaned when a shared transaction later overwrites the label.
                         if (multiTableTransactionEnabled && txnCoordinator != null && !flushQ.isEmpty()) {
                             if (!txnCoordinator.isActive()) {
+                                boolean opened;
                                 try {
-                                    ensureSharedTransaction();
+                                    opened = ensureSharedTransaction();
                                 } catch (Exception beginEx) {
                                     LOG.error("[MultiTxn] Failed to eagerly open shared transaction", beginEx);
                                     this.e = beginEx;
                                     // Skip flush/commit to avoid creating orphan independent transactions.
+                                    continue;
+                                }
+                                if (!opened) {
+                                    // ensureSharedTransaction() silently skipped (e.g. a region is
+                                    // flushing/retrying, or trySetLabel lost a race with a concurrent
+                                    // retry). Regions may hold null/stale labels, so an autonomous
+                                    // flush here would create an orphan independent transaction and
+                                    // break multi-table atomicity. Retry on the next scan.
                                     continue;
                                 }
                             } else if (txnCoordinator.getElapsedMs() >= sharedTxnMaxIdleMs) {
@@ -737,7 +783,13 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
                 // Edge case: commitInFlight was set but no shared txn is open yet
                 // (e.g. first write + immediate txnEnd before manager thread ran).
                 // Ensure the shared transaction exists before proceeding.
-                ensureSharedTransaction();
+                if (!ensureSharedTransaction()) {
+                    // A region is flushing/retrying, or label injection lost a race.
+                    // Bail out and retry on the next scan; triggerLoadIfNeeded() below
+                    // would otherwise generate independent labels and break atomicity.
+                    LOG.debug("[MultiTxn] Could not open shared txn in commit path; retrying next scan");
+                    return;
+                }
             }
 
             // Wait for any in-flight autonomous flushes to complete.
@@ -799,10 +851,16 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
 
             // Immediately open a new shared transaction for the next cycle,
             // so any subsequent autonomous flushes are under the new shared label.
-            // This is best-effort: if it fails, the normal path will retry on the next scan.
+            // This is best-effort: if it cannot be opened now (exception, or a region
+            // is flushing/retrying), the normal manager-thread path guards against
+            // autonomous flushes by checking isActive() + ensureSharedTransaction()
+            // again before selecting regions to flush.
             if (!flushQ.isEmpty()) {
                 try {
-                    ensureSharedTransaction();
+                    if (!ensureSharedTransaction()) {
+                        LOG.debug("[MultiTxn] Could not eagerly open next shared transaction after commit; "
+                                + "will retry on next scan");
+                    }
                 } catch (Exception beginEx) {
                     LOG.warn("[MultiTxn] Failed to eagerly open next shared transaction after commit; " +
                             "will retry on next scan: {}", beginEx.getMessage());
@@ -833,8 +891,17 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
      * Called on the manager thread to ensure autonomous flushes always use the shared label.
      *
      * <p>This must only be called when no shared transaction is currently active.
+     *
+     * @return {@code true} if a shared transaction was opened and every region in
+     *         {@code flushQ} received the shared label; {@code false} if the attempt
+     *         was skipped or rolled back due to a transient condition (empty flushQ,
+     *         a region was flushing/retrying, or label injection lost a race with a
+     *         concurrent retry). Callers MUST skip flush/commit work when this
+     *         returns {@code false}, since regions may hold null/stale labels and
+     *         an autonomous flush would create an orphan independent transaction
+     *         that breaks multi-table atomicity. The next manager scan will retry.
      */
-    private void ensureSharedTransaction() {
+    private boolean ensureSharedTransaction() {
         String anyDb = null;
         String anyTable = null;
         for (TransactionTableRegion region : flushQ) {
@@ -848,7 +915,7 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
             }
         }
         if (anyDb == null) {
-            return;
+            return false;
         }
 
         // Ensure no region is retrying — setLabel() silently skips when numRetries > 0,
@@ -857,7 +924,7 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
             if (region.isFlushing() || region.isRetrying()) {
                 LOG.debug("[MultiTxn] Cannot open shared txn: region {} is flushing/retrying",
                         region.getUniqueKey());
-                return;
+                return false;
             }
         }
 
@@ -886,12 +953,13 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
                 for (TransactionTableRegion r : injected) {
                     r.setLabel(null);
                 }
-                return;
+                return false;
             }
             injected.add(region);
         }
         LOG.info("[MultiTxn] Eagerly opened shared transaction: label={}",
                 txnCoordinator.getSharedLabel());
+        return true;
     }
 
     /**
@@ -1085,7 +1153,15 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
         if (actuallyCommitted) {
             lastCommitTimeMs = System.currentTimeMillis();
         }
-        ensureSharedTransaction();
+        // Best-effort: re-open a fresh shared transaction so the next autonomous
+        // flush uses the new shared label. If a region is flushing/retrying now
+        // we'll skip silently — the normal manager-thread path re-checks
+        // isActive() and retries ensureSharedTransaction() before any flush,
+        // so no orphan independent transaction can slip through.
+        if (!ensureSharedTransaction()) {
+            LOG.debug("[MultiTxn] Could not open fresh shared transaction after recycle; "
+                    + "will retry on next scan");
+        }
     }
 
     public void setStreamLoadListener(StreamLoadListener streamLoadListener) {

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/DefaultStreamLoadManager.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/DefaultStreamLoadManager.java
@@ -849,7 +849,18 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
         for (TransactionTableRegion region : flushQ) {
             // Re-check retrying: a region may have entered retry (via fail() on the
             // executor thread) between the bulk check above and this point.
-            if (region.isRetrying()) {
+            //
+            // The isRetrying() check below is still a useful fast-path, but it does
+            // NOT close the race by itself because the monitor is released between
+            // isRetrying() and trySetLabel(). trySetLabel() re-checks numRetries
+            // under the same synchronized block that fail() uses to increment it,
+            // so if a retry starts in that window it returns false and we treat
+            // the region exactly like the isRetrying() branch: roll back the
+            // already-injected labels and re-drive ensureSharedTransaction on the
+            // next scan. This preserves the invariant that every region in
+            // `injected` has actually received the shared label.
+            if (region.isRetrying()
+                    || !region.trySetLabel(txnCoordinator.getSharedLabel())) {
                 LOG.warn("[MultiTxn] Region {} started retrying during ensureSharedTransaction; "
                         + "rolling back and clearing {} already-injected labels",
                         region.getUniqueKey(), injected.size());
@@ -859,7 +870,6 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
                 }
                 return;
             }
-            region.setLabel(txnCoordinator.getSharedLabel());
             injected.add(region);
         }
         LOG.info("[MultiTxn] Eagerly opened shared transaction: label={}",

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/DefaultStreamLoadManager.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/DefaultStreamLoadManager.java
@@ -30,6 +30,7 @@ import com.starrocks.data.load.stream.StreamLoadUtils;
 import com.starrocks.data.load.stream.StreamLoader;
 import com.starrocks.data.load.stream.TableRegion;
 import com.starrocks.data.load.stream.TransactionStreamLoader;
+import com.starrocks.data.load.stream.exception.StreamLoadFailException;
 import com.starrocks.data.load.stream.properties.StreamLoadProperties;
 import com.starrocks.data.load.stream.properties.StreamLoadTableProperties;
 import org.slf4j.Logger;
@@ -697,16 +698,22 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
 
         txnCoordinator.begin(anyDb, anyTable);
 
+        List<TransactionTableRegion> injected = new ArrayList<>();
         for (TransactionTableRegion region : flushQ) {
             // Re-check retrying: a region may have entered retry (via fail() on the
             // executor thread) between the bulk check above and this point.
             if (region.isRetrying()) {
                 LOG.warn("[MultiTxn] Region {} started retrying during ensureSharedTransaction; "
-                        + "rolling back", region.getUniqueKey());
+                        + "rolling back and clearing {} already-injected labels",
+                        region.getUniqueKey(), injected.size());
                 txnCoordinator.reset();
+                for (TransactionTableRegion r : injected) {
+                    r.setLabel(null);
+                }
                 return;
             }
             region.setLabel(txnCoordinator.getSharedLabel());
+            injected.add(region);
         }
         LOG.info("[MultiTxn] Eagerly opened shared transaction: label={}",
                 txnCoordinator.getSharedLabel());
@@ -741,6 +748,34 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
 
         LOG.info("[MultiTxn] Recycling shared transaction approaching timeout: label={}, elapsed={}ms",
                 txnCoordinator.getSharedLabel(), txnCoordinator.getElapsedMs());
+
+        // If any partition still has uncommitted transaction data (ACTIVE state),
+        // we must NOT commit — that would break cross-table atomicity by exposing
+        // a partial source transaction. Instead, fail fast so Flink restarts the
+        // job from the last checkpoint, re-consuming all data since that checkpoint.
+        if (partitionTracker != null) {
+            List<Integer> activePartitions = partitionTracker.getActivePartitions();
+            if (!activePartitions.isEmpty()) {
+                LOG.error("[MultiTxn] Shared transaction approaching timeout but partitions {} "
+                        + "still ACTIVE (no txnEnd received). Rolling back and failing fast. "
+                        + "Upstream must complete source transactions within {}ms. "
+                        + "label={}", activePartitions, sharedTxnMaxIdleMs,
+                        txnCoordinator.getSharedLabel());
+                txnCoordinator.reset();
+                for (TransactionTableRegion region : flushQ) {
+                    if (!region.isRetrying()) {
+                        region.setLabel(null);
+                    }
+                }
+                commitInFlight.set(false);
+                partitionTracker.reset();
+                this.e = new StreamLoadFailException(
+                        "[MultiTxn] Multi-table transaction timeout: upstream must complete " +
+                        "source transactions within " + sharedTxnMaxIdleMs + "ms. " +
+                        "Active partitions without txnEnd: " + activePartitions);
+                return;
+            }
+        }
 
         String anyTable = null;
         for (TransactionTableRegion region : flushQ) {

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/DefaultStreamLoadManager.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/DefaultStreamLoadManager.java
@@ -112,6 +112,31 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
     private long sharedTxnMaxIdleMs = 480_000L;
 
     private final AtomicBoolean commitInFlight = new AtomicBoolean(false);
+
+    /**
+     * Commit interval (ms) cached from {@code properties.getExpectDelayTime()}
+     * at construction time. Read on every manager scan via
+     * {@link #shouldTriggerCommit()}, so we cache it to avoid repeated property
+     * lookups (and to make the contract immutable — the interval is a fixed
+     * value for the lifetime of a manager instance). Only meaningful in
+     * multi-table transaction mode.
+     */
+    private long commitIntervalMs;
+
+    /**
+     * Minimum interval (ms) between two {@code switchChunkForCommit} calls on the
+     * same region in multi-table mode. Computed as
+     * {@code min(1000, max(100, commitInterval/10))} — small enough to batch
+     * frequent txnEnds but capped at 1s to keep data freshness reasonable.
+     */
+    private long miniSwitchIntervalMs;
+
+    /**
+     * Timestamp (epoch ms) of the last successful commit (or construction time).
+     * Used by the manager thread's time-driven commit decision. Only meaningful
+     * in multi-table transaction mode.
+     */
+    private volatile long lastCommitTimeMs;
     /** Timestamp (ms) when commitInFlight was set to true, for timeout detection. */
     private volatile long commitInFlightStartMs;
 
@@ -176,7 +201,19 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
         this.maxWriteBlockCacheBytes = 2 * maxCacheBytes;
         this.scanningFrequency = properties.getScanningFrequency();
         this.multiTableTransactionEnabled = properties.isEnableMultiTableTransaction();
-        this.flushAndCommitStrategy = new FlushAndCommitStrategy(properties, enableAutoCommit);
+        // Pass the (possibly overridden) maxCacheBytes so the strategy's
+        // cache-full flush threshold stays aligned with the manager's
+        // write-block threshold. See review comment P1 on PR #487.
+        this.flushAndCommitStrategy = new FlushAndCommitStrategy(properties, enableAutoCommit, this.maxCacheBytes);
+        // Cache commit interval and compute miniSwitchIntervalMs for multi-table
+        // mode. miniInterval is capped between 100 ms and 1000 ms, targeting
+        // commitInterval / 10 as a sensible default so that a 1 s commit interval
+        // yields 100 ms batching and a 30 s commit interval caps at 1 s batching.
+        // lastCommitTimeMs is initialized in init() (right before the manager
+        // thread starts), so it reflects the start of the scan loop rather than
+        // construction time.
+        this.commitIntervalMs = properties.getExpectDelayTime();
+        this.miniSwitchIntervalMs = Math.min(1000L, Math.max(100L, this.commitIntervalMs / 10L));
         // get timeout from properties's header
         String timeoutStr = properties.getHeaders().get("timeout");
         if (timeoutStr != null) {
@@ -200,7 +237,8 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
         this.writeTriggerFlush = new AtomicBoolean(false);
         this.loadMetrics = new LoadMetrics();
         if (multiTableTransactionEnabled) {
-            this.partitionTracker = new PartitionCommitTracker(properties.getExpectDelayTime());
+            this.partitionTracker = new PartitionCommitTracker();
+            this.lastCommitTimeMs = System.currentTimeMillis();
         }
         if (state.compareAndSet(State.INACTIVE, State.ACTIVE)) {
             this.manager = new Thread(() -> {
@@ -231,16 +269,31 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
                             LOG.info("[MultiTxn] Savepoint: completing shared transaction");
 
                             // Upstream must ensure all source transactions are complete
-                            // before the checkpoint barrier arrives. If any partition is
-                            // still ACTIVE (no txnEnd received), it means upstream violated
-                            // this contract — fail fast rather than silently committing
-                            // partial transaction data.
-                            List<Integer> activePartitions = partitionTracker.getActivePartitions();
-                            if (!activePartitions.isEmpty()) {
+                            // before the checkpoint barrier arrives. Two conditions must
+                            // hold for every region at savepoint time:
+                            //   (a) The owning partition has received at least one txnEnd
+                            //       (no partitions in the ACTIVE state of the tracker).
+                            //   (b) Every region's activeChunk is at a clean transaction
+                            //       boundary, i.e., no write has occurred since its most
+                            //       recent txnEnd. If activeChunk is dirty, the in-progress
+                            //       source transaction has not yet completed.
+                            // Either violation indicates the upstream broke its contract;
+                            // fail fast rather than silently committing partial data.
+                            List<Integer> partitionsWithoutTxnEnd = partitionTracker.getPartitionsWithoutTxnEnd();
+                            if (!partitionsWithoutTxnEnd.isEmpty()) {
                                 throw new IllegalStateException(
-                                        "[MultiTxn] Partitions " + activePartitions + " still have " +
-                                        "uncommitted transaction data at checkpoint. Upstream must " +
+                                        "[MultiTxn] Partitions " + partitionsWithoutTxnEnd + " have written " +
+                                        "data but never received txnEnd at checkpoint. Upstream must " +
                                         "ensure all transactions are complete before checkpoint barrier.");
+                            }
+                            for (TransactionTableRegion region : flushQ) {
+                                if (!region.isActiveChunkCleanBoundary()) {
+                                    throw new IllegalStateException(
+                                            "[MultiTxn] Region " + region.getUniqueKey() + " has in-progress " +
+                                            "transaction data (writes after latest txnEnd) at checkpoint. " +
+                                            "Upstream must ensure all transactions are complete before " +
+                                            "checkpoint barrier.");
+                                }
                             }
 
                             // Ensure a shared transaction is open (may not be if no data
@@ -261,9 +314,10 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
                                 }
                             }
 
-                            // Switch and trigger loads for regions that have been through
-                            // trySwitchAndCommit() (TXN_END_RECEIVED or SWITCHED) but
-                            // may still have inactive chunks not yet sent.
+                            // Force switch remaining activeChunks: since we verified
+                            // above that every region is at a clean boundary, any data
+                            // still in activeChunk belongs to completed source
+                            // transactions and is safe to freeze for commit.
                             for (TransactionTableRegion region : flushQ) {
                                 region.switchChunkForCommit();
                             }
@@ -303,6 +357,14 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
                                         LOG.info("[MultiTxn] No data loaded; rolling back empty txn during savepoint");
                                         txnCoordinator.reset();
                                     }
+                                    // Keep lastCommitTimeMs in sync with actual commit
+                                    // activity so the next shouldTriggerCommit() check on
+                                    // the normal path starts its countdown from the
+                                    // savepoint commit, not from the previous regular
+                                    // commit. This is cosmetic (downstream hasDataLoaded
+                                    // / hasInactiveChunks checks prevent spurious commits),
+                                    // but keeps the time accounting accurate.
+                                    lastCommitTimeMs = System.currentTimeMillis();
                                     allRegionsCommitted = true;
                                 } catch (Exception ex) {
                                     LOG.error("[MultiTxn] Failed to commit shared transaction during savepoint", ex);
@@ -401,16 +463,19 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
                             }
                         }
 
-                        // In multi-table mode, check if partitions are ready to
-                        // switch and commit.  This runs on the manager thread (not
-                        // the task thread) so that the task thread has had time to
-                        // process subsequent records and register all partitions in
-                        // the tracker before allSwitched() is evaluated.
+                        // In multi-table mode, first give the manager-thread
+                        // fallback a chance to force-switch any region whose
+                        // activeChunk is at a clean transaction boundary and has
+                        // been idle long enough (handles the "source paused
+                        // after txnEnd" case). Then check whether the commit
+                        // interval has elapsed AND there is data to commit.
                         if (multiTableTransactionEnabled && partitionTracker != null) {
-                            trySwitchAndCommit();
+                            managerForceSwitchCleanBoundaryRegions();
+                            tryStartTimerDrivenCommit();
                             if (commitInFlight.get()) {
-                                // All partitions switched; skip autonomous flush and
-                                // enter processMultiTableCommit() on the next iteration.
+                                // Commit interval elapsed with data available; skip
+                                // autonomous flush and enter processMultiTableCommit()
+                                // on the next iteration.
                                 continue;
                             }
                         }
@@ -473,69 +538,137 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
             return;
         }
 
-        // Record the txnEnd and immediately switch chunks on the task thread.
-        // This must happen synchronously before returning, because the very next
-        // record from the source may belong to a new transaction.  If we deferred
-        // the switch to the manager thread, the new transaction's write() would
-        // call onWrite() and reset the partition back to ACTIVE, causing the
-        // previous transaction's commit to be lost.
-        boolean transitioned = partitionTracker.onTxnEnd(partition);
-        if (transitioned) {
-            List<TransactionTableRegion> pRegions = partitionRegions.get(partition);
-            if (pRegions != null) {
-                for (TransactionTableRegion region : pRegions) {
-                    region.switchChunkForCommit();
-                }
+        // For each region owned by this partition, invoke tryMiniIntervalSwitch:
+        // - It marks the region's activeChunk as being at a clean transaction
+        //   boundary (since the most recent task-thread event on the region is
+        //   now a txnEnd).
+        // - It performs switchChunkForCommit only if the miniInterval has
+        //   elapsed since the last switch AND activeChunk has data. Otherwise
+        //   the current source transaction batches into the existing activeChunk
+        //   together with previously-completed source transactions, amortizing
+        //   the HTTP-load overhead across multiple txns (N:1 mapping).
+        //
+        // Both the cleanBoundary mark and the conditional switch MUST run on
+        // the task thread (not deferred to the manager thread) because the task
+        // thread is the sole serializer of write() and setCommitAllowed()
+        // events. Marking cleanBoundary=true here guarantees that the flag
+        // reflects the MOST RECENT task-thread event: if the next event is
+        // another write, write0() will flip it back to false before the manager
+        // thread's scan observes it, preserving the invariant that
+        // "cleanBoundary=true" means "activeChunk contains only data from
+        // completed source transactions". Deferring to the manager thread would
+        // open a window where a write and a manager-thread force-switch could
+        // race, potentially freezing partial transaction data.
+        List<TransactionTableRegion> pRegions = partitionRegions.get(partition);
+        int regionCount = pRegions == null ? 0 : pRegions.size();
+        if (pRegions != null) {
+            for (TransactionTableRegion region : pRegions) {
+                region.tryMiniIntervalSwitch();
             }
-            partitionTracker.markSwitched(partition);
-            LOG.debug("[MultiTxn] txnEnd for partition={}, regions immediately switched", partition);
-        } else {
-            LOG.debug("[MultiTxn] txnEnd for partition={}, deferred (already switched)", partition);
+        }
+        partitionTracker.onTxnEnd(partition);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("[MultiTxn] txnEnd recorded for partition={}, regions={}, miniInterval={}ms",
+                    partition, regionCount, miniSwitchIntervalMs);
         }
     }
 
     /**
-     * Attempts to switch ready partitions and trigger a commit if all are switched.
-     * Called on the manager thread (from the normal timer-driven path) so that the
-     * task thread has had time to process subsequent records and register all
-     * partitions before allSwitched() is evaluated.
+     * Manager-thread fallback: force-switch any region whose activeChunk is at a
+     * clean transaction boundary, has data, and has been idle (no task-thread
+     * switch) for at least {@code miniSwitchIntervalMs}.
+     *
+     * <p>This handles the "source paused after a few txnEnds" case: the task
+     * thread has processed a txnEnd without switching (because the previous
+     * switch was too recent), and then no further task-thread events arrive.
+     * Without this fallback, the completed-but-not-yet-frozen data would sit in
+     * activeChunk until the next source write + txnEnd, which could be an
+     * unbounded delay.
+     *
+     * <p>{@link TransactionTableRegion#tryForceCleanSwitch()} handles all the
+     * write-lock acquisition and double-checking of the clean-boundary flag
+     * under the lock, so this loop is racy-safe.
      */
-    private void trySwitchAndCommit() {
-        List<Integer> readyPartitions = partitionTracker.getReadyToSwitch();
-        for (int p : readyPartitions) {
-            List<TransactionTableRegion> pRegions = partitionRegions.get(p);
-            if (pRegions != null) {
-                for (TransactionTableRegion region : pRegions) {
-                    region.switchChunkForCommit();
-                }
-            }
-            partitionTracker.markSwitched(p);
-            LOG.debug("[MultiTxn] partition {} switched, regions={}", p,
-                    pRegions == null ? 0 : pRegions.size());
+    private void managerForceSwitchCleanBoundaryRegions() {
+        for (TransactionTableRegion region : flushQ) {
+            region.tryForceCleanSwitch();
         }
+    }
 
-        if (partitionTracker.allSwitched() && commitInFlight.compareAndSet(false, true)) {
+    /**
+     * Decide whether the manager thread should trigger a commit. Called on every
+     * scan cycle of the manager's main loop. Returns {@code true} only when:
+     *
+     * <ol>
+     *   <li>The commit interval has elapsed since the last successful commit.</li>
+     *   <li>There is data that could be committed: either the shared transaction
+     *       coordinator has already recorded a load (via autonomous flush) or at
+     *       least one region has inactive chunks pending.</li>
+     * </ol>
+     *
+     * <p>If the interval has elapsed but there is no data, we simply skip the
+     * cycle without consuming the interval — the next time data becomes
+     * available, it will be committed immediately.
+     */
+    private boolean shouldTriggerCommit() {
+        if (commitInFlight.get()) {
+            return false;
+        }
+        if (System.currentTimeMillis() - lastCommitTimeMs < commitIntervalMs) {
+            return false;
+        }
+        if (txnCoordinator != null && txnCoordinator.hasDataLoaded()) {
+            return true;
+        }
+        for (TransactionTableRegion region : flushQ) {
+            if (region.hasInactiveChunks()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Attempts to start a time-driven commit cycle. Called on the manager thread
+     * from the normal scan path. Does NOT do any per-region switching — that is
+     * handled by (a) the task thread's {@code tryMiniIntervalSwitch} on each
+     * txnEnd and (b) {@link #managerForceSwitchCleanBoundaryRegions()} for the
+     * source-idle fallback.
+     *
+     * <p>Sets {@code commitInFlight=true} if {@link #shouldTriggerCommit()}
+     * returns true; the main loop will then enter {@code processMultiTableCommit()}
+     * on the next iteration to drive the actual commit protocol.
+     */
+    private void tryStartTimerDrivenCommit() {
+        if (shouldTriggerCommit() && commitInFlight.compareAndSet(false, true)) {
             commitInFlightStartMs = System.currentTimeMillis();
             // No flushable.signal() needed — this method already runs on the
-            // manager thread.  The caller will see commitInFlight==true and
+            // manager thread. The caller will see commitInFlight==true and
             // `continue` to the next iteration which enters processMultiTableCommit().
-            LOG.info("[MultiTxn] All partitions switched, commitInFlight=true");
+            LOG.info("[MultiTxn] Commit interval elapsed with data available, commitInFlight=true");
         }
     }
 
     /**
      * Processes a multi-table commit cycle using the SharedTransactionCoordinator.
-     * Called on the manager thread when commitInFlight=true.
+     * Called on the manager thread when {@code commitInFlight=true}.
      *
-     * <p>Because the shared transaction is eagerly opened (by {@link #ensureSharedTransaction()})
-     * before any autonomous flush, all in-flight HTTP loads already use the shared label.
-     * This method simply:
+     * <p>Because the shared transaction is eagerly opened (by
+     * {@link #ensureSharedTransaction()}) before any autonomous flush, all
+     * in-flight HTTP loads already use the shared label. This method simply:
      * <ol>
-     *   <li>Waits for all in-flight loads to complete</li>
-     *   <li>Triggers loads for any remaining inactive chunks (from switchChunkForCommit)</li>
-     *   <li>Waits again for those loads</li>
-     *   <li>Executes unified prepare + commit</li>
-     *   <li>Opens a new shared transaction for the next cycle</li>
+     *   <li>Waits for any in-flight loads to complete (defers to the next scan
+     *       cycle if any region is still FLUSHING/retrying)</li>
+     *   <li>Triggers loads for any remaining inactive chunks — those produced by
+     *       {@code switchChunkForCommit} or the manager-thread clean-boundary
+     *       fallback that were not yet drained by autonomous flush</li>
+     *   <li>On the next scan cycle, once those triggered loads complete,
+     *       executes a unified commit via the coordinator (multi-table
+     *       transactions skip the prepare step, which StarRocks does not
+     *       support in multi-table mode)</li>
+     *   <li>Resets state ({@code commitInFlight}, {@code partitionTracker},
+     *       region labels, {@code lastCommitTimeMs}) and opens a new shared
+     *       transaction for the next cycle</li>
      * </ol>
      */
     private void processMultiTableCommit() {
@@ -630,6 +763,9 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
             }
             commitInFlight.set(false);
             partitionTracker.reset();
+            // Record the commit time so shouldTriggerCommit() re-starts its
+            // interval countdown from this point.
+            lastCommitTimeMs = System.currentTimeMillis();
             LOG.info("[MultiTxn] Shared transaction cycle completed; commitInFlight=false");
 
             // Immediately open a new shared transaction for the next cycle,
@@ -749,17 +885,23 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
         LOG.info("[MultiTxn] Recycling shared transaction approaching timeout: label={}, elapsed={}ms",
                 txnCoordinator.getSharedLabel(), txnCoordinator.getElapsedMs());
 
-        // If any partition still has uncommitted transaction data (ACTIVE state),
-        // we must NOT commit — that would break cross-table atomicity by exposing
-        // a partial source transaction. Instead, fail fast so Flink restarts the
-        // job from the last checkpoint, re-consuming all data since that checkpoint.
+        // If any region has in-progress source transaction data, we must NOT
+        // commit the recycled transaction — that would expose a partial source
+        // transaction in StarRocks. Two conditions trigger fail-fast:
+        //   (a) Any partition has written data but never received txnEnd
+        //       (ACTIVE in the tracker). This means the source started a
+        //       transaction and never closed it within the timeout window.
+        //   (b) Any region's activeChunk is not at a clean boundary. This
+        //       means a write occurred after the latest txnEnd but before the
+        //       current source transaction completed.
+        // In either case, fail so Flink restarts from the last checkpoint.
         if (partitionTracker != null) {
-            List<Integer> activePartitions = partitionTracker.getActivePartitions();
-            if (!activePartitions.isEmpty()) {
+            List<Integer> partitionsWithoutTxnEnd = partitionTracker.getPartitionsWithoutTxnEnd();
+            if (!partitionsWithoutTxnEnd.isEmpty()) {
                 LOG.error("[MultiTxn] Shared transaction approaching timeout but partitions {} "
-                        + "still ACTIVE (no txnEnd received). Rolling back and failing fast. "
+                        + "have written data without receiving txnEnd. Rolling back and failing fast. "
                         + "Upstream must complete source transactions within {}ms. "
-                        + "label={}", activePartitions, sharedTxnMaxIdleMs,
+                        + "label={}", partitionsWithoutTxnEnd, sharedTxnMaxIdleMs,
                         txnCoordinator.getSharedLabel());
                 txnCoordinator.reset();
                 for (TransactionTableRegion region : flushQ) {
@@ -772,8 +914,103 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
                 this.e = new StreamLoadFailException(
                         "[MultiTxn] Multi-table transaction timeout: upstream must complete " +
                         "source transactions within " + sharedTxnMaxIdleMs + "ms. " +
-                        "Active partitions without txnEnd: " + activePartitions);
+                        "Partitions without txnEnd: " + partitionsWithoutTxnEnd);
                 return;
+            }
+        }
+        List<String> dirtyRegions = null;
+        for (TransactionTableRegion region : flushQ) {
+            if (!region.isActiveChunkCleanBoundary()) {
+                if (dirtyRegions == null) {
+                    dirtyRegions = new ArrayList<>();
+                }
+                dirtyRegions.add(region.getUniqueKey());
+            }
+        }
+        if (dirtyRegions != null) {
+            LOG.error("[MultiTxn] Shared transaction approaching timeout but regions {} "
+                    + "have in-progress transaction data (writes after latest txnEnd). "
+                    + "Rolling back and failing fast. label={}",
+                    dirtyRegions, txnCoordinator.getSharedLabel());
+            txnCoordinator.reset();
+            for (TransactionTableRegion region : flushQ) {
+                if (!region.isRetrying()) {
+                    region.setLabel(null);
+                }
+            }
+            commitInFlight.set(false);
+            if (partitionTracker != null) {
+                partitionTracker.reset();
+            }
+            this.e = new StreamLoadFailException(
+                    "[MultiTxn] Multi-table transaction timeout: regions with in-progress " +
+                    "source transactions: " + dirtyRegions);
+            return;
+        }
+
+        // All regions were observed clean in the pre-check above. Now freeze
+        // their activeChunks atomically using tryForceCleanSwitch(), which
+        // re-checks cleanBoundary under the writeLock. This closes a race
+        // window: between the unlocked pre-check and the actual switch, the
+        // task thread could call write() on a region and flip its
+        // cleanBoundary to false. Using switchChunkForCommit() here would
+        // unconditionally freeze that now-dirty activeChunk (containing an
+        // in-progress source transaction), violating the safety invariant.
+        //
+        // If tryForceCleanSwitch() returns false for a region, one of:
+        //   (a) a concurrent write raced and made the region dirty — its
+        //       data stays in activeChunk and will be committed in a future
+        //       cycle (under the new shared label opened after this recycle);
+        //   (b) activeChunk was already empty — nothing to do;
+        //   (c) miniInterval has not yet elapsed — cannot happen here because
+        //       recycle fires only after sharedTxnMaxIdleMs which is far
+        //       larger than any miniInterval.
+        // In all three cases, skipping the region is safe.
+        for (TransactionTableRegion region : flushQ) {
+            boolean switched = region.tryForceCleanSwitch();
+            if (!switched && !region.isActiveChunkCleanBoundary()) {
+                LOG.warn("[MultiTxn] Recycle: region {} became dirty between pre-check and switch; " +
+                        "its data will be committed in a future cycle", region.getUniqueKey());
+            }
+        }
+        // Drain any newly-frozen inactive chunks into the shared transaction
+        // before committing. We wait synchronously for each region's load to
+        // avoid racing with the subsequent label-clear step.
+        for (TransactionTableRegion region : flushQ) {
+            if (region.triggerLoadIfNeeded()) {
+                txnCoordinator.markDataLoaded();
+            }
+        }
+        // Wait for in-flight loads with a bounded timeout. This point is
+        // reached only after sharedTxnMaxIdleMs has elapsed, so we are already
+        // operating on a timeout budget; an unbounded wait could deadlock the
+        // manager thread if a load hangs (e.g., network stall or a region stuck
+        // in a long retry loop). Cap the total wait at flushTimeoutMs and fail
+        // fast on timeout so Flink can restart the job from the last checkpoint.
+        long recycleWaitStartMs = System.currentTimeMillis();
+        for (TransactionTableRegion region : flushQ) {
+            while (region.isFlushing() || region.isRetrying()) {
+                if (System.currentTimeMillis() - recycleWaitStartMs > flushTimeoutMs) {
+                    LOG.error("[MultiTxn] Recycle wait timeout ({}ms) for region {}, " +
+                            "failing fast. label={}",
+                            flushTimeoutMs, region.getUniqueKey(),
+                            txnCoordinator.getSharedLabel());
+                    txnCoordinator.reset();
+                    for (TransactionTableRegion r : flushQ) {
+                        if (!r.isRetrying()) {
+                            r.setLabel(null);
+                        }
+                    }
+                    commitInFlight.set(false);
+                    if (partitionTracker != null) {
+                        partitionTracker.reset();
+                    }
+                    this.e = new StreamLoadFailException(
+                            "[MultiTxn] Recycle wait timeout: region " + region.getUniqueKey() +
+                            " did not complete its in-flight load within " + flushTimeoutMs + "ms");
+                    return;
+                }
+                LockSupport.parkNanos(1_000_000L);
             }
         }
 
@@ -784,17 +1021,30 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
             }
         }
 
+        boolean actuallyCommitted = false;
         if (anyTable != null && txnCoordinator.hasDataLoaded()) {
             txnCoordinator.prepareAndCommit(anyTable);
+            actuallyCommitted = true;
             LOG.info("[MultiTxn] Recycled shared transaction committed");
         } else {
             txnCoordinator.reset();
             LOG.info("[MultiTxn] Recycled empty shared transaction (rolled back)");
         }
 
-        // Clear labels and open a fresh shared transaction.
+        // Clear labels and reset cycle state before opening a fresh shared transaction.
         for (TransactionTableRegion region : flushQ) {
             region.setLabel(null);
+        }
+        if (partitionTracker != null) {
+            partitionTracker.reset();
+        }
+        // Only advance lastCommitTimeMs on a real commit. A rollback-empty
+        // recycle (no data was ever loaded) is not a commit, and we must not
+        // delay the next commit-interval countdown by pretending one happened.
+        // Otherwise a burst of data immediately after an idle recycle would
+        // have to wait an extra commitInterval before becoming visible.
+        if (actuallyCommitted) {
+            lastCommitTimeMs = System.currentTimeMillis();
         }
         ensureSharedTransaction();
     }
@@ -1107,7 +1357,8 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
                     LabelGenerator labelGenerator = labelGeneratorFactory.create(database, table);
                     TransactionTableRegion newRegion = new TransactionTableRegion(
                             uniqueKey, database, table, this,
-                            tableProperties, streamLoader, labelGenerator, maxRetries, retryIntervalInMs);
+                            tableProperties, streamLoader, labelGenerator, maxRetries, retryIntervalInMs,
+                            multiTableTransactionEnabled, miniSwitchIntervalMs);
                     if (multiTableTransactionEnabled) {
                         newRegion.getHeaders().put("transaction_type", "multi");
                         // If a shared transaction is already open, inject its label so that

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/DefaultStreamLoadManager.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/DefaultStreamLoadManager.java
@@ -1355,10 +1355,19 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
                     String tableKey = StreamLoadUtils.getTableUniqueKey(database, table);
                     StreamLoadTableProperties tableProperties = properties.getTableProperties(tableKey, database, table);
                     LabelGenerator labelGenerator = labelGeneratorFactory.create(database, table);
+                    // In multi-table mode, pass maxWriteBlockCacheBytes (= 2 * multi-table
+                    // buffer size) as the per-region hard cap for an in-progress source
+                    // transaction. This is the exact threshold at which blockIfCacheFull
+                    // would start blocking the task thread; if a single region's activeChunk
+                    // alone exceeds it, deadlock is inevitable because the manager has no
+                    // inactiveChunks to flush (multi-table mode cannot switch activeChunk
+                    // until the next txnEnd arrives). Failing fast here gives a clear error
+                    // instead of a silent hang.
+                    long singleTxnMaxBytes = multiTableTransactionEnabled ? maxWriteBlockCacheBytes : 0L;
                     TransactionTableRegion newRegion = new TransactionTableRegion(
                             uniqueKey, database, table, this,
                             tableProperties, streamLoader, labelGenerator, maxRetries, retryIntervalInMs,
-                            multiTableTransactionEnabled, miniSwitchIntervalMs);
+                            multiTableTransactionEnabled, miniSwitchIntervalMs, singleTxnMaxBytes);
                     if (multiTableTransactionEnabled) {
                         newRegion.getHeaders().put("transaction_type", "multi");
                         // If a shared transaction is already open, inject its label so that

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/FlushAndCommitStrategy.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/FlushAndCommitStrategy.java
@@ -46,12 +46,17 @@ public class FlushAndCommitStrategy implements StreamLoadStrategy {
     private final AtomicLong numCacheTriggerFlush = new AtomicLong(0);
     private final AtomicLong numTableTriggerFlush = new AtomicLong(0);
 
+    private final boolean multiTableTransactionEnabled;
+
     public FlushAndCommitStrategy(StreamLoadProperties properties, boolean enableAutoCommit) {
         this.expectDelayTime = properties.getExpectDelayTime();
         this.scanFrequency = properties.getScanningFrequency();
+        // Integer division: commit may trigger slightly earlier than expectDelayTime
+        // when expectDelayTime is not evenly divisible by scanFrequency
         this.ageThreshold = expectDelayTime / scanFrequency;
         this.maxCacheBytes = properties.getMaxCacheBytes();
         this.enableAutoCommit = enableAutoCommit;
+        this.multiTableTransactionEnabled = properties.isEnableMultiTableTransaction();
 
         LOG.info("{}", this);
     }
@@ -98,8 +103,16 @@ public class FlushAndCommitStrategy implements StreamLoadStrategy {
         return flushRegions;
     }
     
+    /**
+     * In multi-table mode, age-based commit is disabled (commits are event-driven
+     * via PartitionCommitTracker). In normal mode, standard age-based commit applies.
+     */
     public boolean shouldCommit(TableRegion region) {
-        return enableAutoCommit && region.getAge() > ageThreshold;
+        return enableAutoCommit && !multiTableTransactionEnabled && region.getAge() > ageThreshold;
+    }
+
+    public boolean isMultiTableTransactionEnabled() {
+        return multiTableTransactionEnabled;
     }
 
     @Override
@@ -110,6 +123,7 @@ public class FlushAndCommitStrategy implements StreamLoadStrategy {
                 ", ageThreshold=" + ageThreshold +
                 ", maxCacheBytes=" + maxCacheBytes +
                 ", enableAutoCommit=" + enableAutoCommit +
+                ", multiTableTransactionEnabled=" + multiTableTransactionEnabled +
                 ", numAgeTriggerFlush=" + numAgeTriggerFlush +
                 ", numCacheTriggerFlush=" + numCacheTriggerFlush +
                 ", numTableTriggerFlush=" + numTableTriggerFlush +

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/FlushAndCommitStrategy.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/FlushAndCommitStrategy.java
@@ -49,12 +49,27 @@ public class FlushAndCommitStrategy implements StreamLoadStrategy {
     private final boolean multiTableTransactionEnabled;
 
     public FlushAndCommitStrategy(StreamLoadProperties properties, boolean enableAutoCommit) {
+        this(properties, enableAutoCommit, properties.getMaxCacheBytes());
+    }
+
+    /**
+     * Constructor that accepts an explicit {@code maxCacheBytes} threshold.
+     *
+     * <p>In multi-table transaction mode, {@code DefaultStreamLoadManager} overrides
+     * its internal {@code maxCacheBytes} to the multi-table buffer size, but the
+     * {@code FlushAndCommitStrategy} was previously still constructed from
+     * {@code properties.getMaxCacheBytes()}, causing the cache-full flush threshold
+     * in {@link #selectFlushRegions(Queue, long)} to be misaligned with the
+     * manager's write-block threshold. This constructor lets the caller pass the
+     * aligned value explicitly.
+     */
+    public FlushAndCommitStrategy(StreamLoadProperties properties, boolean enableAutoCommit, long maxCacheBytes) {
         this.expectDelayTime = properties.getExpectDelayTime();
         this.scanFrequency = properties.getScanningFrequency();
         // Integer division: commit may trigger slightly earlier than expectDelayTime
         // when expectDelayTime is not evenly divisible by scanFrequency
         this.ageThreshold = expectDelayTime / scanFrequency;
-        this.maxCacheBytes = properties.getMaxCacheBytes();
+        this.maxCacheBytes = maxCacheBytes;
         this.enableAutoCommit = enableAutoCommit;
         this.multiTableTransactionEnabled = properties.isEnableMultiTableTransaction();
 
@@ -68,6 +83,29 @@ public class FlushAndCommitStrategy implements StreamLoadStrategy {
 
     public List<SelectFlushResult> selectFlushRegions(Queue<TransactionTableRegion> regions, long currentCacheBytes) {
         List<SelectFlushResult> flushRegions = new ArrayList<>();
+
+        if (multiTableTransactionEnabled) {
+            // Multi-table mode: selectFlushRegions only drains already-frozen
+            // inactiveChunks. The activeChunk is never flushed by this path —
+            // it can only be switched by switchChunkForCommit (on txnEnd or the
+            // manager's clean-boundary fallback). Age-based commit and
+            // row-count-triggered flush are both meaningless here because:
+            //   - commit is driven by commit interval + shouldTriggerCommit
+            //   - activeChunk never moves to inactive via flush()
+            // So the selection rule collapses to "flush any region whose
+            // inactive queue has data".
+            for (TransactionTableRegion region : regions) {
+                if (region.hasInactiveChunks()) {
+                    numTableTriggerFlush.getAndIncrement();
+                    flushRegions.add(new SelectFlushResult(FlushReason.INACTIVE_DRAIN, region));
+                    LOG.debug("[MultiTxn] Choose region {} to drain inactive chunks",
+                            region.getUniqueKey());
+                }
+            }
+            return flushRegions;
+        }
+
+        // Non-multi-table mode: original behavior unchanged.
         for (TransactionTableRegion region : regions) {
             if (shouldCommit(region)) {
                 numAgeTriggerFlush.getAndIncrement();

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/FlushReason.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/FlushReason.java
@@ -34,5 +34,10 @@ public enum FlushReason {
     // The number of buffered rows reaches the limit
     BUFFER_ROWS_REACH_LIMIT,
     // Force flush, such as DefaultStreamLoadManager.flush
-    FORCE
+    FORCE,
+    // Multi-table transaction mode: drain already-frozen inactive chunks
+    // (produced by switchChunkForCommit) to StarRocks. Autonomous flush in
+    // multi-table mode never switches activeChunk; it only streams out the
+    // pending inactive queue. This reason is purely informational.
+    INACTIVE_DRAIN
 }

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/PartitionCommitTracker.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/PartitionCommitTracker.java
@@ -1,0 +1,234 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.starrocks.data.load.stream.v2;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Tracks per-partition transaction boundary state for multi-table transaction mode.
+ *
+ * <p>Each source partition independently signals when its current transaction is
+ * complete ({@code txnEnd}). A commit is only triggered when <em>all</em> active
+ * partitions have reached a transaction boundary AND the configured flush interval
+ * has elapsed since the last commit.
+ *
+ * <p>This ensures that a {@code switchChunk} (which freezes buffered data for commit)
+ * never captures a partial source transaction from any partition.
+ */
+public class PartitionCommitTracker {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PartitionCommitTracker.class);
+
+    enum PartitionState {
+        /** Partition has written data but has not yet reached a txnEnd. */
+        ACTIVE,
+        /** Partition has received txnEnd but its regions have not been switched yet. */
+        TXN_END_RECEIVED,
+        /** Partition's regions have been switched; waiting for global commit. */
+        SWITCHED
+    }
+
+    private final Map<Integer, PartitionState> partitions = new LinkedHashMap<>();
+    /**
+     * Tracks txnEnd signals that arrived while a partition was SWITCHED (during an
+     * in-flight commit). These are replayed during {@link #reset()} so the boundary
+     * is not lost for the next commit cycle.
+     */
+    private final Set<Integer> pendingTxnEnd = new HashSet<>();
+    private final long commitIntervalMs;
+    private volatile long lastCommitTimeMs;
+
+    public PartitionCommitTracker(long commitIntervalMs) {
+        this.commitIntervalMs = commitIntervalMs;
+        this.lastCommitTimeMs = System.currentTimeMillis();
+    }
+
+    /**
+     * Called when data is written for a partition. Sets the partition to ACTIVE
+     * unless it is already SWITCHED (part of an in-flight commit cycle).
+     *
+     * <p>When a partition is SWITCHED, its previous transaction's data has been
+     * frozen via {@code switchChunkForCommit()} and a commit is pending. New
+     * writes go into the fresh active chunk created by the switch, so there is
+     * no risk of mixing transactions. Resetting to ACTIVE here would lose the
+     * SWITCHED state and prevent the pending commit from completing.
+     */
+    public synchronized void onWrite(int partition) {
+        PartitionState state = partitions.get(partition);
+        if (state == PartitionState.SWITCHED) {
+            return;
+        }
+        partitions.put(partition, PartitionState.ACTIVE);
+        pendingTxnEnd.remove(partition);
+    }
+
+    /**
+     * Called when a txnEnd marker arrives for a partition.
+     *
+     * @return {@code true} if the partition transitioned to TXN_END_RECEIVED and
+     *         should be switched immediately by the caller
+     */
+    public synchronized boolean onTxnEnd(int partition) {
+        PartitionState state = partitions.get(partition);
+        if (state == null) {
+            // Partition was never registered or was evicted after being idle.
+            // Re-register it as TXN_END_RECEIVED so it participates correctly in the
+            // next commit cycle; the empty-chunk case is handled gracefully downstream.
+            LOG.info("[MultiTxn] txnEnd for unknown/evicted partition {}, re-registering", partition);
+            partitions.put(partition, PartitionState.TXN_END_RECEIVED);
+            return true;
+        }
+        if (state == PartitionState.ACTIVE) {
+            partitions.put(partition, PartitionState.TXN_END_RECEIVED);
+            return true;
+        } else if (state == PartitionState.SWITCHED) {
+            // Partition is currently in an in-flight commit cycle. Record the txnEnd
+            // so reset() can promote it to TXN_END_RECEIVED for the next cycle,
+            // preventing the boundary from being lost.
+            pendingTxnEnd.add(partition);
+            LOG.debug("[MultiTxn] txnEnd for SWITCHED partition {}, recorded as pending", partition);
+        }
+        // If already TXN_END_RECEIVED, a second txnEnd accumulates more data into the
+        // same commit cycle (N:1 mapping) — no state change needed.
+        return false;
+    }
+
+    /** Marks a partition as switched (its regions have been frozen for commit). */
+    public synchronized void markSwitched(int partition) {
+        partitions.put(partition, PartitionState.SWITCHED);
+        LOG.debug("[MultiTxn] partition {} marked SWITCHED", partition);
+    }
+
+    /**
+     * Returns partitions that have reached txnEnd but have not yet been switched.
+     * Only returns results when the flush interval has elapsed.
+     */
+    public synchronized List<Integer> getReadyToSwitch() {
+        if (!isIntervalElapsed()) {
+            return Collections.emptyList();
+        }
+        List<Integer> ready = new ArrayList<>();
+        for (Map.Entry<Integer, PartitionState> entry : partitions.entrySet()) {
+            if (entry.getValue() == PartitionState.TXN_END_RECEIVED) {
+                ready.add(entry.getKey());
+            }
+        }
+        return ready;
+    }
+
+    /** Returns {@code true} when all tracked partitions have been switched. */
+    public synchronized boolean allSwitched() {
+        if (partitions.isEmpty()) {
+            return false;
+        }
+        for (PartitionState state : partitions.values()) {
+            if (state != PartitionState.SWITCHED) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean isIntervalElapsed() {
+        return System.currentTimeMillis() - lastCommitTimeMs >= commitIntervalMs;
+    }
+
+    /**
+     * Resets state after a successful commit.
+     *
+     * <p>SWITCHED partitions that received new data during the commit phase will
+     * already have been moved to ACTIVE by {@link #onWrite}, so they are retained.
+     * Remaining SWITCHED partitions (idle — no new data arrived) are removed from
+     * tracking entirely. If they produce data later, {@link #onWrite} will re-register
+     * them. This prevents idle partitions from permanently blocking
+     * {@link #allSwitched()}.
+     *
+     * <p>Partitions that received a txnEnd while SWITCHED (recorded in
+     * {@link #pendingTxnEnd}) are promoted to TXN_END_RECEIVED so the boundary
+     * is preserved for the next commit cycle.
+     */
+    public synchronized void reset() {
+        lastCommitTimeMs = System.currentTimeMillis();
+
+        // Remove idle SWITCHED partitions (those that received no new data during
+        // the commit phase). Partitions that got new writes are already ACTIVE.
+        List<Integer> toRemove = new ArrayList<>();
+        for (Map.Entry<Integer, PartitionState> entry : partitions.entrySet()) {
+            if (entry.getValue() == PartitionState.SWITCHED) {
+                int partition = entry.getKey();
+                if (pendingTxnEnd.contains(partition)) {
+                    // A txnEnd arrived while SWITCHED — promote to TXN_END_RECEIVED
+                    // so the next commit cycle picks it up immediately.
+                    entry.setValue(PartitionState.TXN_END_RECEIVED);
+                    LOG.debug("[MultiTxn] Promoted partition {} to TXN_END_RECEIVED from pending txnEnd",
+                            partition);
+                } else {
+                    toRemove.add(partition);
+                }
+            }
+        }
+
+        for (Integer partition : toRemove) {
+            partitions.remove(partition);
+            LOG.debug("[MultiTxn] Removed idle SWITCHED partition {} from tracking", partition);
+        }
+
+        pendingTxnEnd.clear();
+        LOG.info("[MultiTxn] PartitionCommitTracker reset, partitions: {}", partitions);
+    }
+
+    /**
+     * Returns the list of partitions that are still in ACTIVE state (have not
+     * received a txnEnd marker). In multi-table transaction mode, upstream must
+     * ensure all transactions are complete before a checkpoint barrier arrives.
+     * If any partitions are ACTIVE at savepoint time, it indicates a violation
+     * of this contract.
+     */
+    public synchronized List<Integer> getActivePartitions() {
+        List<Integer> active = new ArrayList<>();
+        for (Map.Entry<Integer, PartitionState> entry : partitions.entrySet()) {
+            if (entry.getValue() == PartitionState.ACTIVE) {
+                active.add(entry.getKey());
+            }
+        }
+        return active;
+    }
+
+    public synchronized boolean isEmpty() {
+        return partitions.isEmpty();
+    }
+
+    @Override
+    public synchronized String toString() {
+        return "PartitionCommitTracker{" +
+                "partitions=" + partitions +
+                ", lastCommitTimeMs=" + lastCommitTimeMs +
+                ", commitIntervalMs=" + commitIntervalMs +
+                '}';
+    }
+}

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/PartitionCommitTracker.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/PartitionCommitTracker.java
@@ -22,201 +22,116 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Tracks per-partition transaction boundary state for multi-table transaction mode.
  *
- * <p>Each source partition independently signals when its current transaction is
- * complete ({@code txnEnd}). A commit is only triggered when <em>all</em> active
- * partitions have reached a transaction boundary AND the configured flush interval
- * has elapsed since the last commit.
+ * <p>In the current design, commit timing is driven by the commit interval and
+ * per-region {@code activeChunkCleanBoundary} flags. The tracker's role has been
+ * reduced to <em>informational/safety</em> bookkeeping:
  *
- * <p>This ensures that a {@code switchChunk} (which freezes buffered data for commit)
- * never captures a partial source transaction from any partition.
+ * <ul>
+ *   <li>Remember which partitions have written data in the current commit cycle
+ *       (used by {@link #getPartitionsWithoutTxnEnd()} to detect upstream contract
+ *       violations at savepoint/recycle time).</li>
+ *   <li>Remember which partitions have received at least one {@code txnEnd} since
+ *       the last commit (the {@code TXN_END_SEEN} state is <em>sticky</em> — it is
+ *       not cleared by subsequent writes).</li>
+ * </ul>
+ *
+ * <p>The tracker no longer drives the switch/commit state machine. It does not
+ * track per-partition "switched" state, does not manage pending txnEnd signals,
+ * and does not decide when to commit. Those responsibilities live in
+ * {@code DefaultStreamLoadManager} (commit timing) and
+ * {@code TransactionTableRegion} (switch timing + clean-boundary flag).
  */
 public class PartitionCommitTracker {
 
     private static final Logger LOG = LoggerFactory.getLogger(PartitionCommitTracker.class);
 
     enum PartitionState {
-        /** Partition has written data but has not yet reached a txnEnd. */
+        /** Partition has written data but has not yet received a txnEnd in the current cycle. */
         ACTIVE,
-        /** Partition has received txnEnd but its regions have not been switched yet. */
-        TXN_END_RECEIVED,
-        /** Partition's regions have been switched; waiting for global commit. */
-        SWITCHED
+        /**
+         * Partition has received at least one txnEnd since the last {@link #reset()}.
+         * <p>This state is <em>sticky</em>: subsequent writes do not transition it
+         * back to {@code ACTIVE}. The purpose is to let savepoint/recycle safety
+         * checks distinguish "partition that never saw a txnEnd" (upstream contract
+         * violation) from "partition that is between source transactions".
+         */
+        TXN_END_SEEN
     }
 
     private final Map<Integer, PartitionState> partitions = new LinkedHashMap<>();
-    /**
-     * Tracks txnEnd signals that arrived while a partition was SWITCHED (during an
-     * in-flight commit). These are replayed during {@link #reset()} so the boundary
-     * is not lost for the next commit cycle.
-     */
-    private final Set<Integer> pendingTxnEnd = new HashSet<>();
-    private final long commitIntervalMs;
-    private volatile long lastCommitTimeMs;
 
-    public PartitionCommitTracker(long commitIntervalMs) {
-        this.commitIntervalMs = commitIntervalMs;
-        this.lastCommitTimeMs = System.currentTimeMillis();
+    public PartitionCommitTracker() {
     }
 
     /**
-     * Called when data is written for a partition. Sets the partition to ACTIVE
-     * unless it is already SWITCHED (part of an in-flight commit cycle).
-     *
-     * <p>When a partition is SWITCHED, its previous transaction's data has been
-     * frozen via {@code switchChunkForCommit()} and a commit is pending. New
-     * writes go into the fresh active chunk created by the switch, so there is
-     * no risk of mixing transactions. Resetting to ACTIVE here would lose the
-     * SWITCHED state and prevent the pending commit from completing.
+     * Called when data is written for a partition. Registers the partition as
+     * {@code ACTIVE} if it is not already tracked; otherwise leaves the state
+     * unchanged (crucially, does not reset {@code TXN_END_SEEN} to {@code ACTIVE}).
      */
     public synchronized void onWrite(int partition) {
-        PartitionState state = partitions.get(partition);
-        if (state == PartitionState.SWITCHED) {
-            return;
+        if (!partitions.containsKey(partition)) {
+            partitions.put(partition, PartitionState.ACTIVE);
         }
-        partitions.put(partition, PartitionState.ACTIVE);
-        pendingTxnEnd.remove(partition);
+        // If already ACTIVE or TXN_END_SEEN: leave unchanged. TXN_END_SEEN is
+        // sticky so that getPartitionsWithoutTxnEnd() continues to report "this
+        // partition has seen at least one txnEnd" across subsequent writes.
     }
 
     /**
-     * Called when a txnEnd marker arrives for a partition.
-     *
-     * @return {@code true} if the partition transitioned to TXN_END_RECEIVED and
-     *         should be switched immediately by the caller
+     * Called when a {@code txnEnd} marker arrives for a partition. Transitions
+     * the partition to {@code TXN_END_SEEN} (registering it if needed).
      */
-    public synchronized boolean onTxnEnd(int partition) {
-        PartitionState state = partitions.get(partition);
-        if (state == null) {
-            // Partition was never registered or was evicted after being idle.
-            // Re-register it as TXN_END_RECEIVED so it participates correctly in the
-            // next commit cycle; the empty-chunk case is handled gracefully downstream.
-            LOG.info("[MultiTxn] txnEnd for unknown/evicted partition {}, re-registering", partition);
-            partitions.put(partition, PartitionState.TXN_END_RECEIVED);
-            return true;
+    public synchronized void onTxnEnd(int partition) {
+        partitions.put(partition, PartitionState.TXN_END_SEEN);
+    }
+
+    /**
+     * Returns partitions that have written data but never received a {@code txnEnd}
+     * in the current commit cycle. This indicates an incomplete source transaction:
+     *
+     * <ul>
+     *   <li>At <b>savepoint</b> time, this is an upstream contract violation — the
+     *       connector must fail fast rather than commit partial transaction data.</li>
+     *   <li>At <b>recycle</b> time (shared transaction approaching timeout), this
+     *       indicates the upstream has not completed its transaction within the
+     *       server-side timeout window — fail fast for the same reason.</li>
+     * </ul>
+     */
+    public synchronized List<Integer> getPartitionsWithoutTxnEnd() {
+        List<Integer> result = new ArrayList<>();
+        for (Map.Entry<Integer, PartitionState> entry : partitions.entrySet()) {
+            if (entry.getValue() == PartitionState.ACTIVE) {
+                result.add(entry.getKey());
+            }
         }
-        if (state == PartitionState.ACTIVE) {
-            partitions.put(partition, PartitionState.TXN_END_RECEIVED);
-            return true;
-        } else if (state == PartitionState.SWITCHED) {
-            // Partition is currently in an in-flight commit cycle. Record the txnEnd
-            // so reset() can promote it to TXN_END_RECEIVED for the next cycle,
-            // preventing the boundary from being lost.
-            pendingTxnEnd.add(partition);
-            LOG.debug("[MultiTxn] txnEnd for SWITCHED partition {}, recorded as pending", partition);
+        return result;
+    }
+
+    /** Returns {@code true} if at least one partition has received a {@code txnEnd}. */
+    public synchronized boolean hasAnyTxnEndSeen() {
+        for (PartitionState state : partitions.values()) {
+            if (state == PartitionState.TXN_END_SEEN) {
+                return true;
+            }
         }
-        // If already TXN_END_RECEIVED, a second txnEnd accumulates more data into the
-        // same commit cycle (N:1 mapping) — no state change needed.
         return false;
     }
 
-    /** Marks a partition as switched (its regions have been frozen for commit). */
-    public synchronized void markSwitched(int partition) {
-        partitions.put(partition, PartitionState.SWITCHED);
-        LOG.debug("[MultiTxn] partition {} marked SWITCHED", partition);
-    }
-
     /**
-     * Returns partitions that have reached txnEnd but have not yet been switched.
-     * Only returns results when the flush interval has elapsed.
-     */
-    public synchronized List<Integer> getReadyToSwitch() {
-        if (!isIntervalElapsed()) {
-            return Collections.emptyList();
-        }
-        List<Integer> ready = new ArrayList<>();
-        for (Map.Entry<Integer, PartitionState> entry : partitions.entrySet()) {
-            if (entry.getValue() == PartitionState.TXN_END_RECEIVED) {
-                ready.add(entry.getKey());
-            }
-        }
-        return ready;
-    }
-
-    /** Returns {@code true} when all tracked partitions have been switched. */
-    public synchronized boolean allSwitched() {
-        if (partitions.isEmpty()) {
-            return false;
-        }
-        for (PartitionState state : partitions.values()) {
-            if (state != PartitionState.SWITCHED) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    private boolean isIntervalElapsed() {
-        return System.currentTimeMillis() - lastCommitTimeMs >= commitIntervalMs;
-    }
-
-    /**
-     * Resets state after a successful commit.
-     *
-     * <p>SWITCHED partitions that received new data during the commit phase will
-     * already have been moved to ACTIVE by {@link #onWrite}, so they are retained.
-     * Remaining SWITCHED partitions (idle — no new data arrived) are removed from
-     * tracking entirely. If they produce data later, {@link #onWrite} will re-register
-     * them. This prevents idle partitions from permanently blocking
-     * {@link #allSwitched()}.
-     *
-     * <p>Partitions that received a txnEnd while SWITCHED (recorded in
-     * {@link #pendingTxnEnd}) are promoted to TXN_END_RECEIVED so the boundary
-     * is preserved for the next commit cycle.
+     * Resets state after a successful commit. All tracked partitions are cleared,
+     * so the next commit cycle starts from an empty tracker. Partitions that
+     * continue to produce data will be re-registered by the next {@link #onWrite}.
      */
     public synchronized void reset() {
-        lastCommitTimeMs = System.currentTimeMillis();
-
-        // Remove idle SWITCHED partitions (those that received no new data during
-        // the commit phase). Partitions that got new writes are already ACTIVE.
-        List<Integer> toRemove = new ArrayList<>();
-        for (Map.Entry<Integer, PartitionState> entry : partitions.entrySet()) {
-            if (entry.getValue() == PartitionState.SWITCHED) {
-                int partition = entry.getKey();
-                if (pendingTxnEnd.contains(partition)) {
-                    // A txnEnd arrived while SWITCHED — promote to TXN_END_RECEIVED
-                    // so the next commit cycle picks it up immediately.
-                    entry.setValue(PartitionState.TXN_END_RECEIVED);
-                    LOG.debug("[MultiTxn] Promoted partition {} to TXN_END_RECEIVED from pending txnEnd",
-                            partition);
-                } else {
-                    toRemove.add(partition);
-                }
-            }
-        }
-
-        for (Integer partition : toRemove) {
-            partitions.remove(partition);
-            LOG.debug("[MultiTxn] Removed idle SWITCHED partition {} from tracking", partition);
-        }
-
-        pendingTxnEnd.clear();
-        LOG.info("[MultiTxn] PartitionCommitTracker reset, partitions: {}", partitions);
-    }
-
-    /**
-     * Returns the list of partitions that are still in ACTIVE state (have not
-     * received a txnEnd marker). In multi-table transaction mode, upstream must
-     * ensure all transactions are complete before a checkpoint barrier arrives.
-     * If any partitions are ACTIVE at savepoint time, it indicates a violation
-     * of this contract.
-     */
-    public synchronized List<Integer> getActivePartitions() {
-        List<Integer> active = new ArrayList<>();
-        for (Map.Entry<Integer, PartitionState> entry : partitions.entrySet()) {
-            if (entry.getValue() == PartitionState.ACTIVE) {
-                active.add(entry.getKey());
-            }
-        }
-        return active;
+        partitions.clear();
+        LOG.info("[MultiTxn] PartitionCommitTracker reset");
     }
 
     public synchronized boolean isEmpty() {
@@ -227,8 +142,6 @@ public class PartitionCommitTracker {
     public synchronized String toString() {
         return "PartitionCommitTracker{" +
                 "partitions=" + partitions +
-                ", lastCommitTimeMs=" + lastCommitTimeMs +
-                ", commitIntervalMs=" + commitIntervalMs +
                 '}';
     }
 }

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/SharedTransactionCoordinator.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/SharedTransactionCoordinator.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.starrocks.data.load.stream.v2;
+
+import com.starrocks.data.load.stream.LabelGenerator;
+import com.starrocks.data.load.stream.LabelGeneratorFactory;
+import com.starrocks.data.load.stream.StreamLoadSnapshot;
+import com.starrocks.data.load.stream.StreamLoader;
+import com.starrocks.data.load.stream.exception.StreamLoadFailException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+
+/**
+ * Coordinates a single StarRocks transaction across multiple table regions.
+ *
+ * <p>In multi-table transaction mode, all table regions within one commit cycle
+ * share a single transaction label. This coordinator manages the lifecycle:
+ * <ol>
+ *   <li>{@link #begin} — generate a shared label and call {@code /api/transaction/begin} once</li>
+ *   <li>Each region sends data via {@code /api/transaction/load} using the shared label</li>
+ *   <li>{@link #prepareAndCommit} — call {@code /api/transaction/prepare} and
+ *       {@code /api/transaction/commit} once for the shared label</li>
+ * </ol>
+ *
+ * <p>The coordinator does not own any data buffers; data management remains in
+ * {@link TransactionTableRegion}.
+ */
+public class SharedTransactionCoordinator {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SharedTransactionCoordinator.class);
+
+    private final StreamLoader streamLoader;
+    private final LabelGeneratorFactory labelGeneratorFactory;
+
+    private String sharedLabel;
+    private String database;
+    private String table;
+
+    /** Tracks whether any HTTP load was sent under the current shared label. */
+    private boolean dataLoaded;
+
+    /** Timestamp (millis) when the current shared transaction was opened. */
+    private long beginTimeMs;
+
+    public SharedTransactionCoordinator(StreamLoader streamLoader,
+                                        LabelGeneratorFactory labelGeneratorFactory) {
+        this.streamLoader = streamLoader;
+        this.labelGeneratorFactory = labelGeneratorFactory;
+    }
+
+    /**
+     * Begins a shared transaction.
+     *
+     * <p>Generates a new label and issues a single {@code /api/transaction/begin}
+     * request to StarRocks at the database level (no table binding). The label is
+     * then injected into all regions that have data to load.
+     *
+     * @param database the database (all tables must be in the same database)
+     * @param anyTable any table in the database (used only for label generation)
+     */
+    public synchronized void begin(String database, String anyTable) {
+        LabelGenerator generator = labelGeneratorFactory.create(database, anyTable);
+        this.sharedLabel = generator.next();
+        this.database = database;
+        this.table = anyTable;
+
+        LOG.info("[MultiTxn] SharedTransaction begin: label={}, db={}", sharedLabel, database);
+
+        this.dataLoaded = false;
+        this.beginTimeMs = System.currentTimeMillis();
+
+        boolean ok = streamLoader.beginTransaction(sharedLabel, database);
+        if (!ok) {
+            throw new StreamLoadFailException(
+                    "Failed to begin shared transaction, label: " + sharedLabel +
+                    ", db: " + database);
+        }
+    }
+
+    /**
+     * Marks that at least one HTTP load has been sent under the current shared label.
+     * Called by the manager when a region triggers a load.
+     */
+    public synchronized void markDataLoaded() {
+        this.dataLoaded = true;
+    }
+
+    /**
+     * Returns {@code true} if any data has been loaded under the current shared label.
+     */
+    public synchronized boolean hasDataLoaded() {
+        return dataLoaded;
+    }
+
+    /**
+     * Injects the shared label into all regions that have pending data.
+     * After this call, each region's {@code streamLoad()} will use the shared label
+     * (because {@code TransactionStreamLoader.begin(region)} skips begin when
+     * label is already set).
+     */
+    public synchronized void injectLabel(Collection<TransactionTableRegion> regions) {
+        for (TransactionTableRegion region : regions) {
+            region.setLabel(sharedLabel);
+        }
+        LOG.info("[MultiTxn] Injected sharedLabel={} into {} regions", sharedLabel, regions.size());
+    }
+
+    /**
+     * Executes a unified prepare + commit for the shared transaction.
+     *
+     * <p>Must be called after all regions have completed their HTTP loads.
+     * Uses any table from the database (StarRocks resolves by label).
+     *
+     * @param anyTable any table in the database
+     */
+    public synchronized void prepareAndCommit(String anyTable) {
+        StreamLoadSnapshot.Transaction txn =
+                new StreamLoadSnapshot.Transaction(database, anyTable, sharedLabel, true);
+
+        // Skip prepare for multi-table transactions — StarRocks does not
+        // support TXN_PREPARE in multi-table transaction mode. Go directly
+        // to commit.
+        LOG.info("[MultiTxn] SharedTransaction commit (skip prepare): label={}", sharedLabel);
+        if (!streamLoader.commit(txn)) {
+            throw new StreamLoadFailException(
+                    "Failed to commit shared transaction, label: " + sharedLabel);
+        }
+
+        LOG.info("[MultiTxn] SharedTransaction committed successfully: label={}", sharedLabel);
+        this.sharedLabel = null;
+        this.database = null;
+        this.table = null;
+        this.dataLoaded = false;
+    }
+
+    public synchronized String getSharedLabel() {
+        return sharedLabel;
+    }
+
+    public synchronized boolean isActive() {
+        return sharedLabel != null;
+    }
+
+    /**
+     * Returns the elapsed time in milliseconds since the shared transaction was opened.
+     * Returns 0 if no transaction is active.
+     */
+    public synchronized long getElapsedMs() {
+        return sharedLabel != null ? System.currentTimeMillis() - beginTimeMs : 0;
+    }
+
+    /**
+     * Attempts to rollback the in-progress shared transaction, then resets state.
+     * Used on error paths and savepoint interruption. If rollback fails, the
+     * StarRocks-side transaction will be cleaned up by its timeout.
+     */
+    public synchronized void reset() {
+        if (sharedLabel != null) {
+            LOG.warn("[MultiTxn] SharedTransactionCoordinator reset, attempting rollback for label={}", sharedLabel);
+            try {
+                StreamLoadSnapshot.Transaction txn =
+                        new StreamLoadSnapshot.Transaction(database, table, sharedLabel, true);
+                streamLoader.rollback(txn);
+                LOG.info("[MultiTxn] Rollback succeeded for label={}", sharedLabel);
+            } catch (Exception ex) {
+                LOG.warn("[MultiTxn] Rollback failed for label={}, will rely on server-side timeout",
+                        sharedLabel, ex);
+            }
+        }
+        this.sharedLabel = null;
+        this.database = null;
+        this.table = null;
+        this.dataLoaded = false;
+    }
+}

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/SharedTransactionCoordinator.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/SharedTransactionCoordinator.java
@@ -78,21 +78,42 @@ public class SharedTransactionCoordinator {
      */
     public synchronized void begin(String database, String anyTable) {
         LabelGenerator generator = labelGeneratorFactory.create(database, anyTable);
-        this.sharedLabel = generator.next();
-        this.database = database;
-        this.table = anyTable;
+        String newLabel = generator.next();
 
-        LOG.info("[MultiTxn] SharedTransaction begin: label={}, db={}", sharedLabel, database);
+        LOG.info("[MultiTxn] SharedTransaction begin: label={}, db={}", newLabel, database);
 
-        this.dataLoaded = false;
-        this.beginTimeMs = System.currentTimeMillis();
-
-        boolean ok = streamLoader.beginTransaction(sharedLabel, database);
+        // Invariant: coordinator state (sharedLabel/database/table) must reflect a
+        // transaction that was actually opened on the FE. We therefore only publish
+        // the new label after beginTransaction() succeeds. If the RPC fails — either
+        // by returning false or by throwing — isActive() continues to report false,
+        // so the next manager cycle will cleanly re-drive ensureSharedTransaction
+        // instead of reusing a ghost label that was never created server-side.
+        boolean ok;
+        try {
+            ok = streamLoader.beginTransaction(newLabel, database);
+        } catch (RuntimeException ex) {
+            clearState();
+            throw ex;
+        }
         if (!ok) {
+            clearState();
             throw new StreamLoadFailException(
-                    "Failed to begin shared transaction, label: " + sharedLabel +
+                    "Failed to begin shared transaction, label: " + newLabel +
                     ", db: " + database);
         }
+
+        this.sharedLabel = newLabel;
+        this.database = database;
+        this.table = anyTable;
+        this.dataLoaded = false;
+        this.beginTimeMs = System.currentTimeMillis();
+    }
+
+    private void clearState() {
+        this.sharedLabel = null;
+        this.database = null;
+        this.table = null;
+        this.dataLoaded = false;
     }
 
     /**

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/SharedTransactionCoordinator.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/SharedTransactionCoordinator.java
@@ -176,6 +176,19 @@ public class SharedTransactionCoordinator {
         return sharedLabel;
     }
 
+    /**
+     * Returns the database of the currently active shared transaction, or
+     * {@code null} when no transaction is active. Callers injecting the shared
+     * label into newly-created regions must reject any region whose database
+     * does not match this value: shared transactions are single-database by
+     * construction (see {@code ensureSharedTransaction}) and a cross-database
+     * label injection would cause the region's first flush to POST to StarRocks
+     * with a label that belongs to a different database.
+     */
+    public synchronized String getDatabase() {
+        return database;
+    }
+
     public synchronized boolean isActive() {
         return sharedLabel != null;
     }

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/StreamLoadManagerV2.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/StreamLoadManagerV2.java
@@ -49,8 +49,23 @@ public class StreamLoadManagerV2 implements StreamLoadManager, Serializable {
     }
 
     @Override
+    public void setCommitAllowed(boolean allowed) {
+        delegateManager.setCommitAllowed(allowed);
+    }
+
+    @Override
+    public void setCommitAllowed(int partition, boolean allowed) {
+        delegateManager.setCommitAllowed(partition, allowed);
+    }
+
+    @Override
     public void write(String uniqueKey, String database, String table, String... rows) {
         delegateManager.write(uniqueKey, database, table, rows);
+    }
+
+    @Override
+    public void write(int partition, String database, String table, String... rows) {
+        delegateManager.write(partition, database, table, rows);
     }
 
     @Override
@@ -111,5 +126,10 @@ public class StreamLoadManagerV2 implements StreamLoadManager, Serializable {
     @Override
     public void setMetricListener(MetricListener metricListener) {
         delegateManager.setMetricListener(metricListener);
+    }
+
+    @Override
+    public Throwable getException() {
+        return delegateManager.getException();
     }
 }

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/TransactionTableRegion.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/TransactionTableRegion.java
@@ -44,6 +44,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.LockSupport;
 
 import static com.starrocks.data.load.stream.exception.ErrorUtils.isRetryable;
 
@@ -70,7 +71,7 @@ public class TransactionTableRegion implements TableRegion {
     private final AtomicLong cacheBytes = new AtomicLong();
     private final AtomicLong cacheRows = new AtomicLong();
     private final AtomicReference<State> state;
-    private final AtomicBoolean ctl = new AtomicBoolean(false);
+    private final AtomicBoolean writeLock = new AtomicBoolean(false);
     private final AtomicLong chunkIdGenerator = new AtomicLong(0);
     private volatile Chunk activeChunk;
     private final ConcurrentLinkedQueue<Chunk> inactiveChunks = new ConcurrentLinkedQueue<>();
@@ -110,11 +111,16 @@ public class TransactionTableRegion implements TableRegion {
         this.activeChunk = new Chunk(properties.getDataFormat(), chunkIdGenerator.getAndIncrement());
         this.maxRetries = maxRetries;
         this.retryIntervalInMs = retryIntervalInMs;
-        initHeaders(properties);
     }
 
     private void initHeaders(StreamLoadTableProperties properties) {
         headers.putAll(properties.getProperties());
+        // Include db and table headers so that transaction stream load
+        // (/api/transaction/load) routes data to the correct table.
+        // In multi-table transaction mode, each region targets a different
+        // table under the same shared label, so these headers are required.
+        headers.put("db", database);
+        headers.put("table", table);
         Optional<String> compressionType = properties.getProperty("compression");
         // To enable csv compression, at the connector side, the user need to set two properties:
         // "format = csv" and "compression = <compression type>". It needs to be converted to one
@@ -165,10 +171,17 @@ public class TransactionTableRegion implements TableRegion {
     }
 
     @Override
-    public void setLabel(String label) {
-        // Reuse the same label to avoid duplicate load if retry happens
+    public synchronized void setLabel(String label) {
+        // Guard against injecting a new shared label while a retry is in progress.
+        // numRetries is mutated under this same monitor (see fail()), so the check
+        // and the assignment are now atomic with respect to concurrent fail() calls.
         if (numRetries > 0 && label != null) {
-            return;
+            LOG.warn("[MultiTxn] setLabel called with label={} while numRetries={}, "
+                    + "existing label={}. Rejecting to preserve retry consistency.",
+                    label, numRetries, this.label);
+            throw new IllegalStateException(
+                    "Cannot set label while region is retrying (numRetries=" + numRetries
+                    + ", existingLabel=" + this.label + ", newLabel=" + label + ")");
         }
         this.label = label;
     }
@@ -181,6 +194,16 @@ public class TransactionTableRegion implements TableRegion {
     @Override
     public long getCacheBytes() {
         return cacheBytes.get();
+    }
+
+    /** Returns the current state as a string for logging purposes. */
+    public String getStateForLog() {
+        return state.get().name();
+    }
+
+    /** Returns {@code true} if the region is currently retrying a failed HTTP load. */
+    public synchronized boolean isRetrying() {
+        return numRetries > 0;
     }
 
     @Override
@@ -198,25 +221,32 @@ public class TransactionTableRegion implements TableRegion {
         return age.get();
     }
 
+    private static final int MAX_SPIN_ATTEMPTS = 10;
+    private static final long SPIN_BACKOFF_NANOS = 1000L; // 1 microsecond initial backoff
+
     @Override
     public int write(byte[] row) {
         if (row == null) {
             return 0;
         }
 
-        int c;
-        if (ctl.compareAndSet(false, true)) {
-            c = write0(row);
-        } else {
-            for (;;) {
-                if (ctl.compareAndSet(false, true)) {
-                    c = write0(row);
-                    break;
+        int spins = 0;
+        for (;;) {
+            if (writeLock.compareAndSet(false, true)) {
+                try {
+                    return write0(row);
+                } finally {
+                    writeLock.set(false);
                 }
             }
+            if (spins < MAX_SPIN_ATTEMPTS) {
+                Thread.yield();
+                spins++;
+            } else {
+                LockSupport.parkNanos(SPIN_BACKOFF_NANOS * (spins - MAX_SPIN_ATTEMPTS + 1));
+                spins++;
+            }
         }
-        ctl.set(false);
-        return c;
     }
 
     private void switchChunk() {
@@ -225,6 +255,61 @@ public class TransactionTableRegion implements TableRegion {
         }
         inactiveChunks.add(activeChunk);
         activeChunk = new Chunk(properties.getDataFormat(), chunkIdGenerator.getAndIncrement());
+    }
+
+    /**
+     * Called by the task thread when a txnEnd marker is received (multi-table mode).
+     *
+     * <p>Moves the active chunk to the inactive queue so the manager thread can
+     * flush it.  This runs on the task thread which is single-threaded in Flink,
+     * so there is no concurrent {@link #write(byte[])} call.
+     */
+    public void switchChunkForCommit() {
+        int spins = 0;
+        for (;;) {
+            if (writeLock.compareAndSet(false, true)) {
+                try {
+                    switchChunk();
+                } finally {
+                    writeLock.set(false);
+                }
+                LOG.debug("[MultiTxn] switchChunkForCommit: db={}, table={}, inactiveChunks={}",
+                        database, table, inactiveChunks.size());
+                return;
+            }
+            if (spins < MAX_SPIN_ATTEMPTS) {
+                Thread.yield();
+                spins++;
+            } else {
+                LockSupport.parkNanos(SPIN_BACKOFF_NANOS * (spins - MAX_SPIN_ATTEMPTS + 1));
+                spins++;
+            }
+        }
+    }
+
+    /**
+     * Called by the manager thread during the commitInFlight phase.
+     *
+     * <p>If the region has inactive chunks that have not yet been sent (state is ACTIVE),
+     * transitions to FLUSHING and starts the HTTP load.  This is different from
+     * {@link #flush(FlushReason)} in that it does NOT call {@link #switchChunk()} —
+     * the task thread has already done that via {@link #switchChunkForCommit()}.
+     *
+     * @return {@code true} if a load was triggered, {@code false} otherwise
+     */
+    public boolean triggerLoadIfNeeded() {
+        if (inactiveChunks.isEmpty()) {
+            // No data to load (region had no data when txnEnd arrived)
+            return false;
+        }
+        if (state.compareAndSet(State.ACTIVE, State.FLUSHING)) {
+            LOG.info("[MultiTxn] triggerLoadIfNeeded: db={}, table={}, label={}, inactiveChunks={}, cacheBytes={}",
+                    database, table, label, inactiveChunks.size(), cacheBytes.get());
+            streamLoad(0);
+            return true;
+        }
+        // Already FLUSHING or COMMITTING — load is in progress
+        return false;
     }
 
     protected int write0(byte[] row) {
@@ -255,18 +340,29 @@ public class TransactionTableRegion implements TableRegion {
         LOG.debug("Try to flush db: {}, table: {}, label: {}, cacheBytes: {}, cacheRows: {}, reason: {}",
                 database, table, label, cacheBytes, cacheRows, reason);
         if (state.compareAndSet(State.ACTIVE, State.FLUSHING)) {
+            int spins = 0;
             for (;;) {
-                if (ctl.compareAndSet(false, true)) {
-                    if (reason != FlushReason.BUFFER_ROWS_REACH_LIMIT ||
-                            activeChunk.numRows() >= properties.getMaxBufferRows()) {
-                        switchChunk();
+                if (writeLock.compareAndSet(false, true)) {
+                    try {
+                        if (reason != FlushReason.BUFFER_ROWS_REACH_LIMIT ||
+                                activeChunk.numRows() >= properties.getMaxBufferRows()) {
+                            switchChunk();
+                        }
+                    } finally {
+                        writeLock.set(false);
                     }
-                    ctl.set(false);
                     break;
+                }
+                if (spins < MAX_SPIN_ATTEMPTS) {
+                    Thread.yield();
+                    spins++;
+                } else {
+                    LockSupport.parkNanos(SPIN_BACKOFF_NANOS * (spins - MAX_SPIN_ATTEMPTS + 1));
+                    spins++;
                 }
             }
             if (!inactiveChunks.isEmpty()) {
-                LOG.info("Flush db: {}, table: {}, label: {}, cacheBytes: {}, cacheRows: {}, reason: {}",
+                LOG.debug("Flush db: {}, table: {}, label: {}, cacheBytes: {}, cacheRows: {}, reason: {}",
                         database, table, label, cacheBytes.get(), cacheRows.get(), reason);
                 streamLoad(0);
                 return true;
@@ -345,6 +441,7 @@ public class TransactionTableRegion implements TableRegion {
         } catch (Throwable e) {
             LOG.error("TransactionTableRegion commit failed, db: {}, table: {}, label: {}", database, table, label, e);
             fail(e);
+            return;
         }
 
         long commitTime = System.currentTimeMillis();
@@ -360,15 +457,18 @@ public class TransactionTableRegion implements TableRegion {
             firstException = e;
         }
 
-        if (numRetries >= maxRetries || !isRetryable(e)) {
-            LOG.error("Failed to flush data for db: {}, table: {} after {} times retry, the last exception is",
-                    database, table, numRetries, e);
-            manager.callback(firstException);
-            return;
+        // Synchronize on 'this' so that the numRetries increment is atomic with
+        // respect to the check in setLabel(), preventing label injection mid-retry.
+        synchronized (this) {
+            if (numRetries >= maxRetries || !isRetryable(e)) {
+                LOG.error("Failed to flush data for db: {}, table: {} after {} times retry, the last exception is",
+                        database, table, numRetries, e);
+                manager.callback(firstException);
+                return;
+            }
+            responseFuture = null;
+            numRetries += 1;
         }
-
-        responseFuture = null;
-        numRetries += 1;
         LOG.warn("Failed to flush data for db: {}, table: {}, and will retry for {} times after {} ms",
                 database, table, numRetries, retryIntervalInMs, e);
         streamLoad(retryIntervalInMs);
@@ -382,17 +482,19 @@ public class TransactionTableRegion implements TableRegion {
         response.setFlushBytes(chunk.rowBytes());
         response.setFlushRows(chunk.numRows());
         manager.callback(response);
-        numRetries = 0;
-        firstException = null;
+        synchronized (this) {
+            numRetries = 0;
+            firstException = null;
+        }
 
         if (!inactiveChunks.isEmpty()) {
-            LOG.info("Stream load continue, db: {}, table: {}, label: {}, cacheBytes: {}, cacheRows: {}",
+            LOG.debug("Stream load continue, db: {}, table: {}, label: {}, cacheBytes: {}, cacheRows: {}",
                     database, table, label, cacheBytes, cacheRows);
             streamLoad(0);
             return;
         }
         if (state.compareAndSet(State.FLUSHING, State.ACTIVE)) {
-            LOG.info("Stream load completed, db: {}, table: {}, label: {}, cacheBytes: {}, cacheRows: {}",
+            LOG.debug("Stream load completed, db: {}, table: {}, label: {}, cacheBytes: {}, cacheRows: {}",
                     database, table, label, cacheBytes, cacheRows);
         }
     }
@@ -405,17 +507,27 @@ public class TransactionTableRegion implements TableRegion {
     protected void streamLoad(int delayMs) {
         try {
             Chunk chunk = inactiveChunks.peek();
-            LOG.info("Stream load chunk, db: {}, table: {}, numRows: {}, rowBytes: {}, chunkBytes: {}",
+            if (chunk == null) {
+                LOG.warn("No inactive chunk available for stream load, db: {}, table: {}", database, table);
+                state.compareAndSet(State.FLUSHING, State.ACTIVE);
+                return;
+            }
+            LOG.debug("Stream load chunk, db: {}, table: {}, numRows: {}, rowBytes: {}, chunkBytes: {}",
                     database, table, chunk.numRows(), chunk.rowBytes(), chunk.chunkBytes());
             responseFuture = streamLoader.send(this, delayMs);
         } catch (Exception e) {
+            state.compareAndSet(State.FLUSHING, State.ACTIVE);
             fail(e);
         }
     }
 
     @Override
     public HttpEntity getHttpEntity() {
-        ChunkHttpEntity entity = new ChunkHttpEntity(uniqueKey, inactiveChunks.peek());
+        Chunk chunk = inactiveChunks.peek();
+        if (chunk == null) {
+            throw new IllegalStateException("No inactive chunk available for HTTP entity, db: " + database + ", table: " + table);
+        }
+        ChunkHttpEntity entity = new ChunkHttpEntity(uniqueKey, chunk);
         return compressionCodec
                 .map(codec -> (HttpEntity) new CompressionHttpEntity(entity, codec))
                 .orElse(entity);

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/TransactionTableRegion.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/TransactionTableRegion.java
@@ -172,16 +172,22 @@ public class TransactionTableRegion implements TableRegion {
 
     @Override
     public synchronized void setLabel(String label) {
-        // Guard against injecting a new shared label while a retry is in progress.
-        // numRetries is mutated under this same monitor (see fail()), so the check
-        // and the assignment are now atomic with respect to concurrent fail() calls.
+        // When a retry is in progress (numRetries > 0), skip setting a new non-null label
+        // to avoid overwriting the label being used by the in-flight retry.
+        //
+        // In the non-multi-table path, TransactionStreamLoader.begin() checks
+        // (label == null) before calling setLabel(), so this branch is normally
+        // unreachable. It serves as a safety net in case of unexpected concurrent
+        // access from the manager thread (e.g. ensureSharedTransaction in multi-table mode).
+        //
+        // We use synchronized (consistent with fail() and isRetrying()) to make the
+        // numRetries check and label assignment atomic, and log a warning for
+        // debuggability, but do NOT throw — throwing would be a behavior change that
+        // could break the non-multi-table retry path if reached under rare timing.
         if (numRetries > 0 && label != null) {
-            LOG.warn("[MultiTxn] setLabel called with label={} while numRetries={}, "
-                    + "existing label={}. Rejecting to preserve retry consistency.",
-                    label, numRetries, this.label);
-            throw new IllegalStateException(
-                    "Cannot set label while region is retrying (numRetries=" + numRetries
-                    + ", existingLabel=" + this.label + ", newLabel=" + label + ")");
+            LOG.warn("setLabel called with label={} while numRetries={}, existing label={}. "
+                    + "Skipping to preserve retry consistency.", label, numRetries, this.label);
+            return;
         }
         this.label = label;
     }
@@ -258,11 +264,17 @@ public class TransactionTableRegion implements TableRegion {
     }
 
     /**
-     * Called by the task thread when a txnEnd marker is received (multi-table mode).
+     * Moves the active chunk to the inactive queue so the manager thread can flush it.
      *
-     * <p>Moves the active chunk to the inactive queue so the manager thread can
-     * flush it.  This runs on the task thread which is single-threaded in Flink,
-     * so there is no concurrent {@link #write(byte[])} call.
+     * <p>Called from two sites:
+     * <ul>
+     *   <li><b>Task thread</b> — on txnEnd marker (multi-table mode)</li>
+     *   <li><b>Manager thread</b> — during savepoint in {@code DefaultStreamLoadManager}.
+     *       At savepoint time the task thread is blocked in {@code flush()},
+     *       so there is no concurrent {@link #write(byte[])} call.</li>
+     * </ul>
+     *
+     * <p>The {@code writeLock} is still acquired for safety.
      */
     public void switchChunkForCommit() {
         int spins = 0;

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/TransactionTableRegion.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/TransactionTableRegion.java
@@ -857,12 +857,21 @@ public class TransactionTableRegion implements TableRegion {
             if (numRetries >= maxRetries || !isRetryable(e)) {
                 LOG.error("Failed to flush data for db: {}, table: {} after {} times retry, the last exception is",
                         database, table, numRetries, e);
+                // Terminal failure: no further retry will re-drive the state
+                // machine back to ACTIVE via complete(). Release FLUSHING now
+                // so the manager's final drain / rollback paths observe a
+                // non-busy region. The manager will see this.e from
+                // callback() below and stop scheduling new work.
+                state.compareAndSet(State.FLUSHING, State.ACTIVE);
                 manager.callback(firstException);
                 return;
             }
             responseFuture = null;
             numRetries += 1;
         }
+        // Retry path: keep state=FLUSHING so the manager cannot CAS(ACTIVE ->
+        // FLUSHING) on the same region while this retry is pending, which
+        // would cause a duplicate send of the same inactive chunk.
         LOG.warn("Failed to flush data for db: {}, table: {}, and will retry for {} times after {} ms",
                 database, table, numRetries, retryIntervalInMs, e);
         streamLoad(retryIntervalInMs);
@@ -910,7 +919,12 @@ public class TransactionTableRegion implements TableRegion {
                     database, table, chunk.numRows(), chunk.rowBytes(), chunk.chunkBytes());
             responseFuture = streamLoader.send(this, delayMs);
         } catch (Exception e) {
-            state.compareAndSet(State.FLUSHING, State.ACTIVE);
+            // Do NOT reset state to ACTIVE here. fail() may schedule a retry
+            // via streamLoad(retryIntervalInMs); while that retry is pending
+            // the region must remain FLUSHING so the manager thread cannot
+            // CAS(ACTIVE -> FLUSHING) and trigger a second concurrent flush
+            // on the same inactive chunk. fail() itself resets to ACTIVE only
+            // when retries are exhausted or the exception is non-retryable.
             fail(e);
         }
     }

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/TransactionTableRegion.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/TransactionTableRegion.java
@@ -813,6 +813,7 @@ public class TransactionTableRegion implements TableRegion {
             streamLoader.getExecutorService().submit(this::doCommit);
         } catch (Exception e) {
             LOG.error("Failed to submit commit task, db: {}, table: {}, label: {}", database, table, label, e);
+            state.compareAndSet(State.COMMITTING, State.ACTIVE);
             throw e;
         }
 
@@ -834,7 +835,16 @@ public class TransactionTableRegion implements TableRegion {
             }
         } catch (Throwable e) {
             LOG.error("TransactionTableRegion commit failed, db: {}, table: {}, label: {}", database, table, label, e);
-            fail(e);
+            // Handle commit errors directly instead of routing through fail(),
+            // which is designed for the flush state machine. fail()'s retry
+            // path calls streamLoad() — wrong for a commit failure — and would
+            // leave the region stuck in COMMITTING. Commit failures are always
+            // terminal: release COMMITTING and propagate to the manager.
+            if (firstException == null) {
+                firstException = e;
+            }
+            state.compareAndSet(State.COMMITTING, State.ACTIVE);
+            manager.callback(firstException);
             return;
         }
 

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/TransactionTableRegion.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/TransactionTableRegion.java
@@ -124,6 +124,27 @@ public class TransactionTableRegion implements TableRegion {
     // Only meaningful when multiTableTransactionEnabled.
     private volatile boolean activeChunkCleanBoundary = true;
 
+    // Bytes written into activeChunk since the most recent clean-boundary
+    // transition (true -> false), i.e. bytes that belong to the currently
+    // in-progress source transaction on this region. Updated under writeLock in
+    // write0() and in the boundary-restoring code paths.
+    //
+    // Every increment here is mirrored (+delta) onto the manager's aggregate
+    // in-progress counter, and every time this region transitions back to a
+    // clean boundary the accumulated value is mirrored (-delta) back to that
+    // counter before being reset to 0. See DefaultStreamLoadManager.
+    //   aggregateInProgressTxnBytes for the deadlock-avoidance motivation.
+    //
+    // Only meaningful when multiTableTransactionEnabled.
+    private long inProgressTxnBytes = 0L;
+
+    // Non-null when {@link #manager} is a DefaultStreamLoadManager. Resolved
+    // once in the constructor so the aggregate-tracking hot path does not need
+    // an instanceof check per row. When null (production builds never hit this
+    // — all regions are created by DefaultStreamLoadManager), aggregate tracking
+    // degrades gracefully and the deadlock guard is skipped.
+    private final DefaultStreamLoadManager aggregateTracker;
+
     public TransactionTableRegion(String uniqueKey,
                             String database,
                             String table,
@@ -153,6 +174,9 @@ public class TransactionTableRegion implements TableRegion {
         this.database = database;
         this.table = table;
         this.manager = manager;
+        this.aggregateTracker = manager instanceof DefaultStreamLoadManager
+                ? (DefaultStreamLoadManager) manager
+                : null;
         this.properties = properties;
         this.streamLoader = streamLoader;
         this.labelGenerator = labelGenerator;
@@ -347,6 +371,27 @@ public class TransactionTableRegion implements TableRegion {
     }
 
     /**
+     * Flushes the in-progress-byte accounting back to the manager's aggregate
+     * counter. Called at every transition of {@code activeChunkCleanBoundary}
+     * from {@code false} to {@code true} (a txnEnd completing an in-progress
+     * source transaction on this region), so that the bytes that were tracked
+     * as "in-progress" stop inflating the global guard. Must be called under
+     * the same serialization context that mutates the boundary flag (either
+     * under {@code writeLock} or on the task thread while no concurrent write
+     * is in flight).
+     */
+    private void releaseInProgressBytes() {
+        if (!multiTableTransactionEnabled || inProgressTxnBytes == 0L) {
+            return;
+        }
+        long delta = inProgressTxnBytes;
+        inProgressTxnBytes = 0L;
+        if (aggregateTracker != null) {
+            aggregateTracker.addAggregateInProgressTxnBytes(-delta);
+        }
+    }
+
+    /**
      * Moves the active chunk to the inactive queue so the manager thread can flush it.
      *
      * <p>Called from two sites:
@@ -371,6 +416,11 @@ public class TransactionTableRegion implements TableRegion {
                         // so it is trivially at a clean transaction boundary.
                         lastSwitchTimeMs = System.currentTimeMillis();
                         activeChunkCleanBoundary = true;
+                        // If this call freezes in-progress bytes (e.g. savepoint
+                        // path switches an unfinished chunk), release them from
+                        // the manager's aggregate guard now that the bytes have
+                        // moved to inactiveChunks and can be flushed.
+                        releaseInProgressBytes();
                     }
                 } finally {
                     writeLock.set(false);
@@ -445,6 +495,12 @@ public class TransactionTableRegion implements TableRegion {
         // itself sets cleanBoundary=true on the new activeChunk, but if we skip
         // the switch we still want the old activeChunk flagged as clean.
         activeChunkCleanBoundary = true;
+        // The txnEnd for this region ends the in-progress source transaction:
+        // rows previously tagged as in-progress are now committed, regardless of
+        // whether the chunk switch below actually happens. Drain the per-region
+        // counter back to the manager's aggregate guard so other regions regain
+        // headroom even when miniInterval batching defers the physical switch.
+        releaseInProgressBytes();
 
         // Step 2: Only switch if miniInterval has elapsed AND the activeChunk
         // has data. An empty activeChunk would produce an empty inactive chunk
@@ -594,6 +650,31 @@ public class TransactionTableRegion implements TableRegion {
                                 + "must fit within 2 * sink.transaction.multi-table.buffer-size. "
                                 + "Reduce the source transaction size or increase the buffer size.");
             }
+            // (3) Aggregate fail-fast across regions. Even when each region
+            //     stays under multiTableSingleTxnMaxBytes, a single source
+            //     transaction spanning many tables can collectively push the
+            //     manager-level cache past maxWriteBlockCacheBytes. Because no
+            //     region has reached a clean boundary yet, no chunk can be
+            //     switched/flushed and blockIfCacheFull would park the task
+            //     thread indefinitely. Guard against that aggregate deadlock
+            //     here by checking the manager's in-progress byte counter
+            //     before we extend activeChunk.
+            if (aggregateTracker != null) {
+                long projected = aggregateTracker.getAggregateInProgressTxnBytes() + row.length;
+                long writeBlockLimit = aggregateTracker.getMaxWriteBlockCacheBytes();
+                if (projected > writeBlockLimit) {
+                    throw new IllegalStateException(
+                            "Aggregate in-progress source-transaction bytes across all tables ("
+                                    + projected + " bytes) would exceed the multi-table write-block "
+                                    + "threshold (" + writeBlockLimit + " bytes). Multi-table mode "
+                                    + "cannot switch activeChunks mid-transaction, so the combined "
+                                    + "payload of a single source transaction across all tables "
+                                    + "must fit within 2 * sink.transaction.multi-table.buffer-size. "
+                                    + "Reduce the source transaction size or increase the buffer "
+                                    + "size. Offending region: db=" + database + ", table=" + table
+                                    + ".");
+                }
+            }
         }
         // Multi-table mode: outside the two branches above we do NOT switch
         // mid-transaction. A switch inside an in-progress source transaction
@@ -616,6 +697,12 @@ public class TransactionTableRegion implements TableRegion {
             // whose txnEnd has not yet arrived. The manager thread must not
             // force-switch in this state.
             activeChunkCleanBoundary = false;
+            // Track this row as in-progress and mirror to the manager's
+            // aggregate counter so cross-region accumulation can be bounded.
+            inProgressTxnBytes += row.length;
+            if (aggregateTracker != null) {
+                aggregateTracker.addAggregateInProgressTxnBytes(row.length);
+            }
         }
         return row.length;
     }

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/TransactionTableRegion.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/TransactionTableRegion.java
@@ -88,6 +88,21 @@ public class TransactionTableRegion implements TableRegion {
     // Multi-table transaction mode flag
     private final boolean multiTableTransactionEnabled;
 
+    // Hard upper bound (bytes) for activeChunk while an in-progress source
+    // transaction is being accumulated. Only meaningful in multi-table mode.
+    //
+    // Multi-table mode deliberately disables size/row-based chunk switching
+    // (see write0) to keep a source transaction atomic under the shared
+    // label, which means activeChunk cannot be drained until the next txnEnd
+    // arrives. If a single region's activeChunk grows past the task thread's
+    // blockIfCacheFull hard threshold (maxWriteBlockCacheBytes), deadlock is
+    // inevitable because the manager has no inactiveChunks to flush. Fail
+    // fast when this threshold is exceeded so the user gets a clear error
+    // instead of a silent hang.
+    //
+    // A value of 0 disables the check (used by the legacy constructor).
+    private final long multiTableSingleTxnMaxBytes;
+
     // Minimum interval (ms) between two switchChunkForCommit calls on this region.
     // Only meaningful when multiTableTransactionEnabled. Used to batch multiple
     // source transactions into a single inactive chunk, reducing HTTP request
@@ -119,7 +134,7 @@ public class TransactionTableRegion implements TableRegion {
                             int maxRetries,
                             int retryIntervalInMs) {
         this(uniqueKey, database, table, manager, properties, streamLoader,
-                labelGenerator, maxRetries, retryIntervalInMs, false, 0L);
+                labelGenerator, maxRetries, retryIntervalInMs, false, 0L, 0L);
     }
 
     public TransactionTableRegion(String uniqueKey,
@@ -132,7 +147,8 @@ public class TransactionTableRegion implements TableRegion {
                             int maxRetries,
                             int retryIntervalInMs,
                             boolean multiTableTransactionEnabled,
-                            long miniSwitchIntervalMs) {
+                            long miniSwitchIntervalMs,
+                            long multiTableSingleTxnMaxBytes) {
         this.uniqueKey = uniqueKey;
         this.database = database;
         this.table = table;
@@ -152,6 +168,7 @@ public class TransactionTableRegion implements TableRegion {
         this.retryIntervalInMs = retryIntervalInMs;
         this.multiTableTransactionEnabled = multiTableTransactionEnabled;
         this.miniSwitchIntervalMs = miniSwitchIntervalMs;
+        this.multiTableSingleTxnMaxBytes = multiTableSingleTxnMaxBytes;
     }
 
     private void initHeaders(StreamLoadTableProperties properties) {
@@ -510,13 +527,59 @@ public class TransactionTableRegion implements TableRegion {
                     || activeChunk.numRows() >= properties.getMaxBufferRows()) {
                 switchChunk();
             }
+        } else if (multiTableSingleTxnMaxBytes > 0) {
+            // Multi-table mode — two separate concerns are handled here:
+            //
+            // (1) Clean-boundary safe switch. tryMiniIntervalSwitch batches
+            //     multiple back-to-back source transactions into one activeChunk
+            //     to amortize HTTP-load overhead. When miniInterval has not yet
+            //     elapsed, it leaves previously-completed transactions sitting
+            //     in activeChunk without switching. If the accumulated batch
+            //     grows past half the write-block hard cap, the next in-progress
+            //     transaction would start with too little headroom and the
+            //     fail-fast below could wrongly reject a normal-sized new
+            //     transaction. Override the miniInterval batching here by
+            //     force-switching when we are still AT a clean transaction
+            //     boundary (most recent event was a txnEnd) and activeChunk
+            //     is already half-full. The switch is safe because it does
+            //     not split an in-progress source transaction — activeChunk
+            //     currently holds only completed transactions.
+            if (activeChunkCleanBoundary
+                    && activeChunk.numRows() > 0
+                    && activeChunk.chunkBytes() >= multiTableSingleTxnMaxBytes / 2) {
+                switchChunk();
+                lastSwitchTimeMs = System.currentTimeMillis();
+                // activeChunkCleanBoundary stays true — the new empty chunk
+                // is trivially at a clean transaction boundary.
+            }
+            // (2) Fail-fast on a single oversized in-progress transaction.
+            //     After any clean-boundary safe switch above, if adding this
+            //     row would still push activeChunk past the write-block hard
+            //     cap, the current in-progress source transaction alone is
+            //     too large. Multi-table mode cannot switch activeChunk
+            //     mid-transaction, so blockIfCacheFull would stall the task
+            //     thread while the manager has no inactiveChunks to drain —
+            //     a silent deadlock. Surface a clear error instead.
+            if (activeChunk.estimateChunkSize(row) > multiTableSingleTxnMaxBytes) {
+                throw new IllegalStateException(
+                        "In-progress source transaction for db=" + database + ", table=" + table
+                                + " exceeded the multi-table transaction write-block threshold ("
+                                + multiTableSingleTxnMaxBytes + " bytes). Multi-table mode cannot "
+                                + "switch activeChunk mid-transaction, so a single source transaction "
+                                + "must fit within 2 * sink.transaction.multi-table.buffer-size. "
+                                + "Reduce the source transaction size or increase the buffer size.");
+            }
         }
-        // Multi-table mode: do NOT switch mid-transaction. A switch at this point
-        // would move partial source-transaction data into inactiveChunks, which
-        // the manager's commit path may then load under the shared label before
-        // the source transaction has reached its txnEnd. Instead, activeChunk
-        // grows until the next setCommitAllowed (txnEnd) triggers a clean switch.
-        // Memory is bounded by blockIfCacheFull via maxWriteBlockCacheBytes.
+        // Multi-table mode: outside the two branches above we do NOT switch
+        // mid-transaction. A switch inside an in-progress source transaction
+        // would move partial transaction data into inactiveChunks, which the
+        // manager's commit path may then load under the shared label before
+        // the transaction has reached its txnEnd — breaking source-transaction
+        // atomicity. Instead, activeChunk grows until the next setCommitAllowed
+        // (txnEnd) triggers a clean switch, or the clean-boundary safe switch
+        // above drains previously-completed batched transactions, or the
+        // fail-fast above rejects a single oversized transaction to avoid the
+        // blockIfCacheFull deadlock.
 
         activeChunk.addRow(row);
         cacheBytes.addAndGet(row.length);

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/TransactionTableRegion.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/TransactionTableRegion.java
@@ -85,6 +85,30 @@ public class TransactionTableRegion implements TableRegion {
     // First exception if retry many times
     private volatile Throwable firstException;
 
+    // Multi-table transaction mode flag
+    private final boolean multiTableTransactionEnabled;
+
+    // Minimum interval (ms) between two switchChunkForCommit calls on this region.
+    // Only meaningful when multiTableTransactionEnabled. Used to batch multiple
+    // source transactions into a single inactive chunk, reducing HTTP request
+    // overhead and chunk metadata fragmentation.
+    private final long miniSwitchIntervalMs;
+
+    // Timestamp (epoch ms) of the last switchChunkForCommit on this region.
+    // Initial value 0 ensures the first txnEnd always triggers a switch.
+    // Only meaningful when multiTableTransactionEnabled.
+    private volatile long lastSwitchTimeMs = 0L;
+
+    // Whether activeChunk is currently at a "clean transaction boundary".
+    // - true: the most recent task-thread event on this region was either
+    //   a txnEnd (setCommitAllowed) or a switch; all data in activeChunk
+    //   belongs to fully-committed source transactions and is safe to freeze.
+    // - false: a write occurred after the most recent txnEnd; activeChunk may
+    //   contain data from an in-progress source transaction and must NOT be
+    //   switched until the next txnEnd arrives.
+    // Only meaningful when multiTableTransactionEnabled.
+    private volatile boolean activeChunkCleanBoundary = true;
+
     public TransactionTableRegion(String uniqueKey,
                             String database,
                             String table,
@@ -94,6 +118,21 @@ public class TransactionTableRegion implements TableRegion {
                             LabelGenerator labelGenerator,
                             int maxRetries,
                             int retryIntervalInMs) {
+        this(uniqueKey, database, table, manager, properties, streamLoader,
+                labelGenerator, maxRetries, retryIntervalInMs, false, 0L);
+    }
+
+    public TransactionTableRegion(String uniqueKey,
+                            String database,
+                            String table,
+                            StreamLoadManager manager,
+                            StreamLoadTableProperties properties,
+                            StreamLoader streamLoader,
+                            LabelGenerator labelGenerator,
+                            int maxRetries,
+                            int retryIntervalInMs,
+                            boolean multiTableTransactionEnabled,
+                            long miniSwitchIntervalMs) {
         this.uniqueKey = uniqueKey;
         this.database = database;
         this.table = table;
@@ -111,6 +150,8 @@ public class TransactionTableRegion implements TableRegion {
         this.activeChunk = new Chunk(properties.getDataFormat(), chunkIdGenerator.getAndIncrement());
         this.maxRetries = maxRetries;
         this.retryIntervalInMs = retryIntervalInMs;
+        this.multiTableTransactionEnabled = multiTableTransactionEnabled;
+        this.miniSwitchIntervalMs = miniSwitchIntervalMs;
     }
 
     private void initHeaders(StreamLoadTableProperties properties) {
@@ -282,6 +323,13 @@ public class TransactionTableRegion implements TableRegion {
             if (writeLock.compareAndSet(false, true)) {
                 try {
                     switchChunk();
+                    if (multiTableTransactionEnabled) {
+                        // Record the switch time for miniInterval bookkeeping.
+                        // The new activeChunk (created by switchChunk) is empty,
+                        // so it is trivially at a clean transaction boundary.
+                        lastSwitchTimeMs = System.currentTimeMillis();
+                        activeChunkCleanBoundary = true;
+                    }
                 } finally {
                     writeLock.set(false);
                 }
@@ -324,15 +372,163 @@ public class TransactionTableRegion implements TableRegion {
         return false;
     }
 
-    protected int write0(byte[] row) {
-        if (activeChunk.estimateChunkSize(row) > properties.getChunkLimit()
-                || activeChunk.numRows() >= properties.getMaxBufferRows()) {
-            switchChunk();
+    /**
+     * Called on the task thread when a source txnEnd is received for the
+     * partition owning this region. Performs three bookkeeping steps:
+     *
+     * <ol>
+     *   <li>Mark the activeChunk as being at a "clean transaction boundary":
+     *       regardless of whether a switch actually happens, the most recent
+     *       event on this region is now a txnEnd, which means all data in
+     *       the current activeChunk belongs to fully-committed source
+     *       transactions.</li>
+     *   <li>If the miniInterval has elapsed since the last switch AND there
+     *       is data to freeze, call {@link #switchChunkForCommit()} to move
+     *       the activeChunk into the inactive queue where it can be drained
+     *       by autonomous flush.</li>
+     *   <li>Otherwise, leave activeChunk untouched — additional source
+     *       transactions can still accumulate into it, batching multiple
+     *       complete transactions into a single HTTP request when the next
+     *       switch does happen.</li>
+     * </ol>
+     *
+     * <p>Only meaningful in multi-table transaction mode. Callers must not
+     * invoke this method when {@code multiTableTransactionEnabled} is false.
+     */
+    public void tryMiniIntervalSwitch() {
+        // Step 1: The task thread has just observed a txnEnd for this region.
+        // Mark the current activeChunk as clean so that the manager-thread
+        // fallback can force-switch it later if the source goes idle.
+        // This must happen BEFORE the switch decision because switchChunkForCommit
+        // itself sets cleanBoundary=true on the new activeChunk, but if we skip
+        // the switch we still want the old activeChunk flagged as clean.
+        activeChunkCleanBoundary = true;
+
+        // Step 2: Only switch if miniInterval has elapsed AND the activeChunk
+        // has data. An empty activeChunk would produce an empty inactive chunk
+        // which wastes a chunk slot and an HTTP request.
+        long now = System.currentTimeMillis();
+        if (now - lastSwitchTimeMs >= miniSwitchIntervalMs
+                && activeChunk != null && activeChunk.numRows() > 0) {
+            switchChunkForCommit();
         }
+    }
+
+    /**
+     * Called by the manager thread during its normal scan loop. If the
+     * activeChunk is at a clean transaction boundary, has data, and the
+     * miniInterval has elapsed since the last switch, force-switch it so
+     * the data can be drained by autonomous flush and committed on the
+     * next commit cycle.
+     *
+     * <p>This is the "source idle" fallback: when the upstream source pauses
+     * after a few txnEnds and no further task-thread events arrive, the
+     * manager thread takes over the responsibility of freezing completed
+     * transaction data into inactiveChunks.
+     *
+     * <p><b>Safety:</b> The method acquires writeLock and re-checks the
+     * clean-boundary flag under the lock. This guarantees that if a task
+     * thread write is concurrently in progress, either (a) the task thread
+     * runs first and the re-check sees {@code false} (we abort), or (b) the
+     * force-switch runs first and the task thread's subsequent write targets
+     * a fresh activeChunk.
+     *
+     * <p>Only meaningful in multi-table transaction mode.
+     *
+     * @return {@code true} if a switch was performed, {@code false} otherwise
+     */
+    public boolean tryForceCleanSwitch() {
+        // Fast path checks without acquiring the lock.
+        // Note: cacheRows covers both activeChunk and inactiveChunks, so it is
+        // a coarser filter than we need here. Check activeChunk.numRows()
+        // directly so a region whose inactiveChunks still have pending data but
+        // whose activeChunk is empty doesn't force us to acquire the lock just
+        // to bail out inside it.
+        if (!activeChunkCleanBoundary) {
+            return false;
+        }
+        Chunk snapshot = activeChunk;  // volatile load
+        if (snapshot == null || snapshot.numRows() == 0) {
+            return false;
+        }
+        long now = System.currentTimeMillis();
+        if (now - lastSwitchTimeMs < miniSwitchIntervalMs) {
+            return false;
+        }
+
+        // Slow path: acquire writeLock and re-check under the lock
+        if (!writeLock.compareAndSet(false, true)) {
+            // Task thread holds the lock, retry on next scan
+            return false;
+        }
+        try {
+            // Re-check clean boundary under the lock: if a task thread write
+            // happened between the fast-path check and now, cleanBoundary will
+            // be false and we must abort to avoid freezing partial transaction
+            // data.
+            if (!activeChunkCleanBoundary) {
+                return false;
+            }
+            if (activeChunk == null || activeChunk.numRows() == 0) {
+                return false;
+            }
+            switchChunk();
+            lastSwitchTimeMs = System.currentTimeMillis();
+            activeChunkCleanBoundary = true;
+            LOG.debug("[MultiTxn] tryForceCleanSwitch: db={}, table={}, inactiveChunks={}",
+                    database, table, inactiveChunks.size());
+            return true;
+        } finally {
+            writeLock.set(false);
+        }
+    }
+
+    /**
+     * Returns {@code true} if the activeChunk is currently at a clean
+     * transaction boundary (all data belongs to completed source transactions).
+     */
+    public boolean isActiveChunkCleanBoundary() {
+        return activeChunkCleanBoundary;
+    }
+
+    /** Returns {@code true} if {@code inactiveChunks} is non-empty. */
+    public boolean hasInactiveChunks() {
+        return !inactiveChunks.isEmpty();
+    }
+
+    /** Returns the timestamp (epoch ms) of the last switchChunkForCommit. */
+    public long getLastSwitchTimeMs() {
+        return lastSwitchTimeMs;
+    }
+
+    protected int write0(byte[] row) {
+        if (!multiTableTransactionEnabled) {
+            // Non-multi-table: original behavior — switch when a single row would
+            // exceed chunk size or row limits, so individual HTTP requests stay
+            // bounded.
+            if (activeChunk.estimateChunkSize(row) > properties.getChunkLimit()
+                    || activeChunk.numRows() >= properties.getMaxBufferRows()) {
+                switchChunk();
+            }
+        }
+        // Multi-table mode: do NOT switch mid-transaction. A switch at this point
+        // would move partial source-transaction data into inactiveChunks, which
+        // the manager's commit path may then load under the shared label before
+        // the source transaction has reached its txnEnd. Instead, activeChunk
+        // grows until the next setCommitAllowed (txnEnd) triggers a clean switch.
+        // Memory is bounded by blockIfCacheFull via maxWriteBlockCacheBytes.
 
         activeChunk.addRow(row);
         cacheBytes.addAndGet(row.length);
         cacheRows.incrementAndGet();
+
+        if (multiTableTransactionEnabled) {
+            // A write after a clean boundary transitions the region to "dirty":
+            // activeChunk now holds at least one row from a source transaction
+            // whose txnEnd has not yet arrived. The manager thread must not
+            // force-switch in this state.
+            activeChunkCleanBoundary = false;
+        }
         return row.length;
     }
 
@@ -352,27 +548,38 @@ public class TransactionTableRegion implements TableRegion {
         LOG.debug("Try to flush db: {}, table: {}, label: {}, cacheBytes: {}, cacheRows: {}, reason: {}",
                 database, table, label, cacheBytes, cacheRows, reason);
         if (state.compareAndSet(State.ACTIVE, State.FLUSHING)) {
-            int spins = 0;
-            for (;;) {
-                if (writeLock.compareAndSet(false, true)) {
-                    try {
-                        if (reason != FlushReason.BUFFER_ROWS_REACH_LIMIT ||
-                                activeChunk.numRows() >= properties.getMaxBufferRows()) {
-                            switchChunk();
+            if (!multiTableTransactionEnabled) {
+                // Non-multi-table: original behavior — acquire writeLock and
+                // optionally switch activeChunk into the inactive queue before
+                // streaming.
+                int spins = 0;
+                for (;;) {
+                    if (writeLock.compareAndSet(false, true)) {
+                        try {
+                            if (reason != FlushReason.BUFFER_ROWS_REACH_LIMIT ||
+                                    activeChunk.numRows() >= properties.getMaxBufferRows()) {
+                                switchChunk();
+                            }
+                        } finally {
+                            writeLock.set(false);
                         }
-                    } finally {
-                        writeLock.set(false);
+                        break;
                     }
-                    break;
-                }
-                if (spins < MAX_SPIN_ATTEMPTS) {
-                    Thread.yield();
-                    spins++;
-                } else {
-                    LockSupport.parkNanos(SPIN_BACKOFF_NANOS * (spins - MAX_SPIN_ATTEMPTS + 1));
-                    spins++;
+                    if (spins < MAX_SPIN_ATTEMPTS) {
+                        Thread.yield();
+                        spins++;
+                    } else {
+                        LockSupport.parkNanos(SPIN_BACKOFF_NANOS * (spins - MAX_SPIN_ATTEMPTS + 1));
+                        spins++;
+                    }
                 }
             }
+            // Multi-table mode: never touch activeChunk here. Autonomous flush
+            // only drains already-frozen inactiveChunks (produced by
+            // switchChunkForCommit at txnEnd or manager-thread clean-boundary
+            // fallback). This preserves the invariant that every chunk reaching
+            // StarRocks under the shared label comes from a completed source
+            // transaction.
             if (!inactiveChunks.isEmpty()) {
                 LOG.debug("Flush db: {}, table: {}, label: {}, cacheBytes: {}, cacheRows: {}, reason: {}",
                         database, table, label, cacheBytes.get(), cacheRows.get(), reason);

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/TransactionTableRegion.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/TransactionTableRegion.java
@@ -242,12 +242,37 @@ public class TransactionTableRegion implements TableRegion {
         // numRetries check and label assignment atomic, and log a warning for
         // debuggability, but do NOT throw — throwing would be a behavior change that
         // could break the non-multi-table retry path if reached under rare timing.
+        // Multi-table callers that need to detect the skip must use
+        // {@link #trySetLabel(String)} instead.
+        trySetLabel(label);
+    }
+
+    /**
+     * Atomically sets the label iff no retry is in progress, returning whether
+     * the label was applied.
+     *
+     * <p>Unlike {@link #setLabel(String)}, the outcome is surfaced to the caller
+     * rather than silently swallowed. This is used by multi-table mode's
+     * {@code ensureSharedTransaction()} so that a retry starting between the
+     * bulk {@code isRetrying()} check and label injection is detected and the
+     * shared-transaction setup is rolled back — preventing the manager from
+     * treating a region as "joined the shared transaction" when the region
+     * actually still holds its previous (stale or null) label.
+     *
+     * @param label the label to set (may be {@code null} to clear)
+     * @return {@code true} if the label was applied; {@code false} if a retry
+     *         is in progress and the non-null label assignment was skipped.
+     *         Clearing the label ({@code label == null}) always returns
+     *         {@code true}.
+     */
+    public synchronized boolean trySetLabel(String label) {
         if (numRetries > 0 && label != null) {
             LOG.warn("setLabel called with label={} while numRetries={}, existing label={}. "
                     + "Skipping to preserve retry consistency.", label, numRetries, this.label);
-            return;
+            return false;
         }
         this.label = label;
+        return true;
     }
 
     @Override

--- a/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/FlushAndCommitStrategyTest.java
+++ b/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/FlushAndCommitStrategyTest.java
@@ -90,12 +90,130 @@ public class FlushAndCommitStrategyTest {
         assertSame(FlushReason.CACHE_FULL, resultList.get(0).getReason());
     }
 
+    /**
+     * In multi-table mode, {@code selectFlushRegions} must ignore age-based
+     * commit, {@code shouldFlush()} row-limit signals, and cache-full
+     * triggers, and only return regions whose {@code inactiveChunks} is
+     * non-empty. The commit cadence is controlled by
+     * {@code DefaultStreamLoadManager.shouldTriggerCommit()} instead.
+     */
+    @Test
+    public void testMultiTableModeSelectsOnlyRegionsWithInactiveChunks() {
+        StreamLoadProperties properties = StreamLoadProperties.builder()
+                .expectDelayTime(1000)
+                .scanningFrequency(50)
+                .cacheMaxBytes(1024 * 1024)
+                .enableMultiTableTransaction()
+                .build();
+        FlushAndCommitStrategy strategy = new FlushAndCommitStrategy(properties, true);
+
+        // Age-triggered in non-multi-table mode, but should be ignored here.
+        TransactionTableRegion oldButEmpty =
+                mockMultiTableRegion("u1", 1000, 100, FlushReason.NONE, false);
+        // Has inactive chunks → should be selected.
+        TransactionTableRegion pendingDrain =
+                mockMultiTableRegion("u2", 1, 200, FlushReason.NONE, true);
+        // shouldFlush=BUFFER_ROWS_REACH_LIMIT in non-multi-table mode, but
+        // this signal is ignored in multi-table mode.
+        TransactionTableRegion rowLimitReached =
+                mockMultiTableRegion("u3", 1, 300, FlushReason.BUFFER_ROWS_REACH_LIMIT, false);
+
+        LinkedList<TransactionTableRegion> queue = new LinkedList<>();
+        queue.add(oldButEmpty);
+        queue.add(pendingDrain);
+        queue.add(rowLimitReached);
+        long cacheBytes = queue.stream().mapToLong(TransactionTableRegion::getCacheBytes).sum();
+
+        List<FlushAndCommitStrategy.SelectFlushResult> resultList =
+                strategy.selectFlushRegions(queue, cacheBytes);
+
+        assertEquals("Only regions with inactive chunks should be selected in multi-table mode",
+                1, resultList.size());
+        assertSame(pendingDrain, resultList.get(0).getRegion());
+        assertSame("Multi-table drain should use INACTIVE_DRAIN reason",
+                FlushReason.INACTIVE_DRAIN, resultList.get(0).getReason());
+    }
+
+    /**
+     * In multi-table mode, even when the total cached bytes exceed
+     * {@code maxCacheBytes}, {@code selectFlushRegions} must NOT pick a
+     * region whose only data is in {@code activeChunk} — the activeChunk may
+     * contain in-progress source transaction data that must not be flushed
+     * until the next txnEnd arrives. Back-pressure via {@code blockIfCacheFull}
+     * is the correct mechanism for limiting memory growth in this case.
+     */
+    @Test
+    public void testMultiTableModeIgnoresCacheFullWhenNoInactive() {
+        StreamLoadProperties properties = StreamLoadProperties.builder()
+                .expectDelayTime(1000)
+                .scanningFrequency(50)
+                .cacheMaxBytes(100) // very small so cacheBytes > maxCacheBytes easily
+                .enableMultiTableTransaction()
+                .build();
+        FlushAndCommitStrategy strategy = new FlushAndCommitStrategy(properties, true);
+
+        // Three regions all with only active-chunk data (no inactive chunks);
+        // total cacheBytes >> maxCacheBytes.
+        TransactionTableRegion r1 = mockMultiTableRegion("u1", 1, 200, FlushReason.NONE, false);
+        TransactionTableRegion r2 = mockMultiTableRegion("u2", 1, 300, FlushReason.NONE, false);
+        TransactionTableRegion r3 = mockMultiTableRegion("u3", 1, 500, FlushReason.NONE, false);
+
+        LinkedList<TransactionTableRegion> queue = new LinkedList<>();
+        queue.add(r1);
+        queue.add(r2);
+        queue.add(r3);
+        long cacheBytes = queue.stream().mapToLong(TransactionTableRegion::getCacheBytes).sum();
+
+        List<FlushAndCommitStrategy.SelectFlushResult> resultList =
+                strategy.selectFlushRegions(queue, cacheBytes);
+
+        assertEquals("Cache-full must not pick a region without inactive chunks in multi-table mode",
+                0, resultList.size());
+    }
+
+    /**
+     * Sanity check for the explicit {@code maxCacheBytes} constructor path
+     * added to fix the review P1 comment: the strategy must use the value
+     * passed in, not {@code properties.getMaxCacheBytes()}.
+     */
+    @Test
+    public void testExplicitMaxCacheBytesConstructor() {
+        StreamLoadProperties properties = StreamLoadProperties.builder()
+                .expectDelayTime(1000)
+                .scanningFrequency(50)
+                .cacheMaxBytes(100) // would trigger cache-full with a naive strategy
+                .build();
+        // Override to a much larger value (simulating the multi-table buffer override).
+        long overriddenMaxCacheBytes = 10 * 1024 * 1024L;
+        FlushAndCommitStrategy strategy =
+                new FlushAndCommitStrategy(properties, true, overriddenMaxCacheBytes);
+
+        // Small current cacheBytes well below the override; cache-full must NOT fire.
+        TransactionTableRegion region = mockRegion("u1", 1, 500, FlushReason.NONE);
+        LinkedList<TransactionTableRegion> queue = new LinkedList<>();
+        queue.add(region);
+
+        List<FlushAndCommitStrategy.SelectFlushResult> resultList =
+                strategy.selectFlushRegions(queue, 500);
+
+        assertEquals("No flush expected: 500 bytes is below the overridden maxCacheBytes",
+                0, resultList.size());
+    }
+
     private static TransactionTableRegion mockRegion(String uniqueKey, long age, long cacheBytes, FlushReason flushReason) {
         TransactionTableRegion region = mock(TransactionTableRegion.class);
         when(region.getUniqueKey()).thenReturn(uniqueKey);
         when(region.getAge()).thenReturn(age);
         when(region.getCacheBytes()).thenReturn(cacheBytes);
         when(region.shouldFlush()).thenReturn(flushReason);
+        return region;
+    }
+
+    private static TransactionTableRegion mockMultiTableRegion(
+            String uniqueKey, long age, long cacheBytes,
+            FlushReason flushReason, boolean hasInactiveChunks) {
+        TransactionTableRegion region = mockRegion(uniqueKey, age, cacheBytes, flushReason);
+        when(region.hasInactiveChunks()).thenReturn(hasInactiveChunks);
         return region;
     }
 }

--- a/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/MockedStarRocksHttpServer.java
+++ b/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/MockedStarRocksHttpServer.java
@@ -41,6 +41,7 @@ import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Minimal mock of StarRocks FE HTTP APIs for tests.
@@ -141,6 +142,11 @@ public class MockedStarRocksHttpServer {
 
     private final Random random = new Random(1234);
 
+    private final AtomicInteger beginCount = new AtomicInteger(0);
+    private final AtomicInteger loadCount = new AtomicInteger(0);
+    private final AtomicInteger prepareCount = new AtomicInteger(0);
+    private final AtomicInteger commitCount = new AtomicInteger(0);
+
     private MockedStarRocksHttpServer(int port, boolean enforceAuth, String username, String password) throws IOException {
         this.bindAddress = new InetSocketAddress("127.0.0.1", port);
         this.server = HttpServer.create(this.bindAddress, 0);
@@ -194,6 +200,18 @@ public class MockedStarRocksHttpServer {
     public void setRollbackOverride(ResponseOverride override) { this.rollbackOverride = override; }
 
     public void setStreamLoadOverride(ResponseOverride override) { this.streamLoadOverride = override; }
+
+    public int getBeginCount() { return beginCount.get(); }
+    public int getLoadCount() { return loadCount.get(); }
+    public int getPrepareCount() { return prepareCount.get(); }
+    public int getCommitCount() { return commitCount.get(); }
+
+    public void resetCounters() {
+        beginCount.set(0);
+        loadCount.set(0);
+        prepareCount.set(0);
+        commitCount.set(0);
+    }
 
     public void putErrorLog(String label, String content) {
         errorLogs.put(label, content);
@@ -347,11 +365,17 @@ public class MockedStarRocksHttpServer {
             String label = h.getFirst("label");
             String db = h.getFirst("db");
             String table = h.getFirst("table");
-            if (label == null || db == null || table == null) {
+            String txnType = h.getFirst("transaction_type");
+            boolean isMultiTable = "multi".equals(txnType);
+            if (label == null || db == null || (table == null && !isMultiTable)) {
                 sendJson(exchange, 400, toJson(mapOf("Status", StreamLoadConstants.RESULT_STATUS_FAILED, "Message", "Missing label/db/table")));
                 return;
             }
+            if (table == null) {
+                table = "__multi_table__";
+            }
 
+            beginCount.incrementAndGet();
             ResponseOverride override = beginOverride;
             LabelKey key = new LabelKey(db, table, label);
             LabelInfo info = getOrCreateLabel(key);
@@ -400,6 +424,7 @@ public class MockedStarRocksHttpServer {
 
             // consume body
             readBody(exchange);
+            loadCount.incrementAndGet();
 
             ResponseOverride override = txnLoadOverride;
             if (override != null) {
@@ -451,11 +476,17 @@ public class MockedStarRocksHttpServer {
             String label = h.getFirst("label");
             String db = h.getFirst("db");
             String table = h.getFirst("table");
-            if (label == null || db == null || table == null) {
+            String txnType = h.getFirst("transaction_type");
+            boolean isMultiTable = "multi".equals(txnType);
+            if (label == null || db == null || (table == null && !isMultiTable)) {
                 sendJson(exchange, 400, toJson(mapOf("Status", StreamLoadConstants.RESULT_STATUS_FAILED, "Message", "Missing label/db/table")));
                 return;
             }
+            if (table == null) {
+                table = "__multi_table__";
+            }
 
+            prepareCount.incrementAndGet();
             ResponseOverride override = prepareOverride;
             if (override != null) {
                 if (override.includeErrorURL && override.errorLogContent != null) {
@@ -495,11 +526,17 @@ public class MockedStarRocksHttpServer {
             String label = h.getFirst("label");
             String db = h.getFirst("db");
             String table = h.getFirst("table");
-            if (label == null || db == null || table == null) {
+            String txnType = h.getFirst("transaction_type");
+            boolean isMultiTable = "multi".equals(txnType);
+            if (label == null || db == null || (table == null && !isMultiTable)) {
                 sendJson(exchange, 400, toJson(mapOf("Status", StreamLoadConstants.RESULT_STATUS_FAILED, "Message", "Missing label/db/table")));
                 return;
             }
+            if (table == null) {
+                table = "__multi_table__";
+            }
 
+            commitCount.incrementAndGet();
             ResponseOverride override = commitOverride;
             if (override != null) {
                 if (override.includeErrorURL && override.errorLogContent != null) {
@@ -537,9 +574,14 @@ public class MockedStarRocksHttpServer {
             String label = h.getFirst("label");
             String db = h.getFirst("db");
             String table = h.getFirst("table");
-            if (label == null || db == null || table == null) {
+            String txnType = h.getFirst("transaction_type");
+            boolean isMultiTable = "multi".equals(txnType);
+            if (label == null || db == null || (table == null && !isMultiTable)) {
                 sendJson(exchange, 400, toJson(mapOf("Status", StreamLoadConstants.RESULT_STATUS_FAILED, "Message", "Missing label/db/table")));
                 return;
+            }
+            if (table == null) {
+                table = "__multi_table__";
             }
 
             ResponseOverride override = rollbackOverride;

--- a/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/v2/PartitionCommitTrackerTest.java
+++ b/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/v2/PartitionCommitTrackerTest.java
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.starrocks.data.load.stream.v2;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+public class PartitionCommitTrackerTest {
+
+    /**
+     * Verifies the pending txnEnd promotion path:
+     * 1. Partition 0 writes data → ACTIVE
+     * 2. Partition 0 receives txnEnd → TXN_END_RECEIVED
+     * 3. Partition 0 is marked SWITCHED (commit in flight)
+     * 4. While SWITCHED, another txnEnd arrives → recorded in pendingTxnEnd
+     * 5. After reset(), the partition is promoted to TXN_END_RECEIVED (not removed)
+     */
+    @Test
+    public void testPendingTxnEndPromotedAfterReset() {
+        PartitionCommitTracker tracker = new PartitionCommitTracker(0);
+
+        // Step 1-2: write + txnEnd
+        tracker.onWrite(0);
+        boolean shouldSwitch = tracker.onTxnEnd(0);
+        Assert.assertTrue("Should switch on first txnEnd", shouldSwitch);
+
+        // Step 3: mark switched (simulates commit in flight)
+        tracker.markSwitched(0);
+        Assert.assertTrue("All should be switched", tracker.allSwitched());
+
+        // Step 4: another txnEnd arrives while SWITCHED
+        boolean shouldSwitch2 = tracker.onTxnEnd(0);
+        Assert.assertFalse("Should NOT switch for SWITCHED partition", shouldSwitch2);
+
+        // Step 5: reset after commit completes
+        tracker.reset();
+
+        // The partition should be promoted to TXN_END_RECEIVED, not removed
+        Assert.assertFalse("Tracker should not be empty after pending promotion", tracker.isEmpty());
+
+        // It should be ready to switch immediately (interval=0)
+        List<Integer> readyToSwitch = tracker.getReadyToSwitch();
+        Assert.assertEquals("Promoted partition should be ready to switch", 1, readyToSwitch.size());
+        Assert.assertEquals(Integer.valueOf(0), readyToSwitch.get(0));
+
+        // No active partitions (it's TXN_END_RECEIVED, not ACTIVE)
+        Assert.assertTrue("No ACTIVE partitions expected", tracker.getActivePartitions().isEmpty());
+    }
+
+    /**
+     * Verifies that idle SWITCHED partitions (no pending txnEnd, no new writes)
+     * are removed from tracking during reset().
+     */
+    @Test
+    public void testIdleSwitchedPartitionRemovedOnReset() {
+        PartitionCommitTracker tracker = new PartitionCommitTracker(0);
+
+        tracker.onWrite(0);
+        tracker.onTxnEnd(0);
+        tracker.markSwitched(0);
+
+        // No pending txnEnd, no new writes → idle
+        tracker.reset();
+
+        Assert.assertTrue("Idle SWITCHED partition should be removed", tracker.isEmpty());
+    }
+
+    /**
+     * Verifies that a SWITCHED partition receiving new writes (via onWrite)
+     * stays SWITCHED (not demoted to ACTIVE), because writes go into
+     * the fresh active chunk and must not disrupt the pending commit.
+     */
+    @Test
+    public void testWriteDuringSwitchedDoesNotDemote() {
+        PartitionCommitTracker tracker = new PartitionCommitTracker(0);
+
+        tracker.onWrite(0);
+        tracker.onTxnEnd(0);
+        tracker.markSwitched(0);
+
+        // New write arrives while SWITCHED
+        tracker.onWrite(0);
+
+        // Should still be all-switched (write doesn't change SWITCHED state)
+        Assert.assertTrue("allSwitched should still be true", tracker.allSwitched());
+    }
+
+    /**
+     * Verifies the basic state machine: ACTIVE → TXN_END_RECEIVED → SWITCHED.
+     */
+    @Test
+    public void testBasicStateTransitions() {
+        PartitionCommitTracker tracker = new PartitionCommitTracker(0);
+
+        // Initially empty
+        Assert.assertTrue(tracker.isEmpty());
+        Assert.assertFalse(tracker.allSwitched());
+
+        // Write → ACTIVE
+        tracker.onWrite(0);
+        Assert.assertFalse(tracker.isEmpty());
+        List<Integer> active = tracker.getActivePartitions();
+        Assert.assertEquals(1, active.size());
+        Assert.assertEquals(Integer.valueOf(0), active.get(0));
+
+        // txnEnd → TXN_END_RECEIVED
+        tracker.onTxnEnd(0);
+        Assert.assertTrue("No active after txnEnd", tracker.getActivePartitions().isEmpty());
+        Assert.assertFalse("Not yet switched", tracker.allSwitched());
+
+        // markSwitched → SWITCHED
+        tracker.markSwitched(0);
+        Assert.assertTrue("All switched", tracker.allSwitched());
+    }
+
+    /**
+     * Verifies that txnEnd for an unknown/evicted partition re-registers it
+     * as TXN_END_RECEIVED.
+     */
+    @Test
+    public void testTxnEndForUnknownPartitionReRegisters() {
+        PartitionCommitTracker tracker = new PartitionCommitTracker(0);
+
+        // txnEnd for a never-seen partition
+        boolean shouldSwitch = tracker.onTxnEnd(42);
+        Assert.assertTrue("Unknown partition should be switched", shouldSwitch);
+        Assert.assertFalse("Tracker should not be empty", tracker.isEmpty());
+        Assert.assertTrue("No ACTIVE partitions", tracker.getActivePartitions().isEmpty());
+    }
+
+    /**
+     * Verifies N:1 mapping: multiple txnEnd for the same ACTIVE partition
+     * stays in TXN_END_RECEIVED without error.
+     */
+    @Test
+    public void testMultipleTxnEndForSamePartition() {
+        PartitionCommitTracker tracker = new PartitionCommitTracker(0);
+
+        tracker.onWrite(0);
+        boolean first = tracker.onTxnEnd(0);
+        Assert.assertTrue("First txnEnd should trigger switch", first);
+
+        // Second txnEnd while still TXN_END_RECEIVED (N:1 accumulation)
+        boolean second = tracker.onTxnEnd(0);
+        Assert.assertFalse("Second txnEnd should not trigger switch again", second);
+    }
+
+    /**
+     * Verifies that allSwitched() blocks when only some partitions are switched.
+     */
+    @Test
+    public void testAllSwitchedBlocksOnPartialSwitch() {
+        PartitionCommitTracker tracker = new PartitionCommitTracker(0);
+
+        tracker.onWrite(0);
+        tracker.onWrite(1);
+
+        tracker.onTxnEnd(0);
+        tracker.markSwitched(0);
+
+        // Partition 1 is still ACTIVE
+        Assert.assertFalse("allSwitched should be false with one ACTIVE", tracker.allSwitched());
+
+        tracker.onTxnEnd(1);
+        tracker.markSwitched(1);
+        Assert.assertTrue("allSwitched should be true when all switched", tracker.allSwitched());
+    }
+
+    /**
+     * Verifies that getReadyToSwitch() respects the commit interval.
+     */
+    @Test
+    public void testGetReadyToSwitchRespectsInterval() throws InterruptedException {
+        // 200ms interval
+        PartitionCommitTracker tracker = new PartitionCommitTracker(200);
+
+        tracker.onWrite(0);
+        tracker.onTxnEnd(0);
+
+        // Immediately after construction, interval has not elapsed
+        List<Integer> ready = tracker.getReadyToSwitch();
+        Assert.assertTrue("Should not be ready before interval elapses", ready.isEmpty());
+
+        Thread.sleep(250);
+
+        ready = tracker.getReadyToSwitch();
+        Assert.assertEquals("Should be ready after interval elapses", 1, ready.size());
+    }
+}

--- a/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/v2/PartitionCommitTrackerTest.java
+++ b/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/v2/PartitionCommitTrackerTest.java
@@ -23,185 +23,170 @@ import org.junit.Test;
 
 import java.util.List;
 
+/**
+ * Tests for the simplified {@link PartitionCommitTracker}. In the current design
+ * the tracker is an informational/safety aid only: it tracks which partitions
+ * have written data and which have seen at least one {@code txnEnd} since the
+ * last commit. It no longer drives commit timing or switch decisions.
+ */
 public class PartitionCommitTrackerTest {
 
     /**
-     * Verifies the pending txnEnd promotion path:
-     * 1. Partition 0 writes data → ACTIVE
-     * 2. Partition 0 receives txnEnd → TXN_END_RECEIVED
-     * 3. Partition 0 is marked SWITCHED (commit in flight)
-     * 4. While SWITCHED, another txnEnd arrives → recorded in pendingTxnEnd
-     * 5. After reset(), the partition is promoted to TXN_END_RECEIVED (not removed)
-     */
-    @Test
-    public void testPendingTxnEndPromotedAfterReset() {
-        PartitionCommitTracker tracker = new PartitionCommitTracker(0);
-
-        // Step 1-2: write + txnEnd
-        tracker.onWrite(0);
-        boolean shouldSwitch = tracker.onTxnEnd(0);
-        Assert.assertTrue("Should switch on first txnEnd", shouldSwitch);
-
-        // Step 3: mark switched (simulates commit in flight)
-        tracker.markSwitched(0);
-        Assert.assertTrue("All should be switched", tracker.allSwitched());
-
-        // Step 4: another txnEnd arrives while SWITCHED
-        boolean shouldSwitch2 = tracker.onTxnEnd(0);
-        Assert.assertFalse("Should NOT switch for SWITCHED partition", shouldSwitch2);
-
-        // Step 5: reset after commit completes
-        tracker.reset();
-
-        // The partition should be promoted to TXN_END_RECEIVED, not removed
-        Assert.assertFalse("Tracker should not be empty after pending promotion", tracker.isEmpty());
-
-        // It should be ready to switch immediately (interval=0)
-        List<Integer> readyToSwitch = tracker.getReadyToSwitch();
-        Assert.assertEquals("Promoted partition should be ready to switch", 1, readyToSwitch.size());
-        Assert.assertEquals(Integer.valueOf(0), readyToSwitch.get(0));
-
-        // No active partitions (it's TXN_END_RECEIVED, not ACTIVE)
-        Assert.assertTrue("No ACTIVE partitions expected", tracker.getActivePartitions().isEmpty());
-    }
-
-    /**
-     * Verifies that idle SWITCHED partitions (no pending txnEnd, no new writes)
-     * are removed from tracking during reset().
-     */
-    @Test
-    public void testIdleSwitchedPartitionRemovedOnReset() {
-        PartitionCommitTracker tracker = new PartitionCommitTracker(0);
-
-        tracker.onWrite(0);
-        tracker.onTxnEnd(0);
-        tracker.markSwitched(0);
-
-        // No pending txnEnd, no new writes → idle
-        tracker.reset();
-
-        Assert.assertTrue("Idle SWITCHED partition should be removed", tracker.isEmpty());
-    }
-
-    /**
-     * Verifies that a SWITCHED partition receiving new writes (via onWrite)
-     * stays SWITCHED (not demoted to ACTIVE), because writes go into
-     * the fresh active chunk and must not disrupt the pending commit.
-     */
-    @Test
-    public void testWriteDuringSwitchedDoesNotDemote() {
-        PartitionCommitTracker tracker = new PartitionCommitTracker(0);
-
-        tracker.onWrite(0);
-        tracker.onTxnEnd(0);
-        tracker.markSwitched(0);
-
-        // New write arrives while SWITCHED
-        tracker.onWrite(0);
-
-        // Should still be all-switched (write doesn't change SWITCHED state)
-        Assert.assertTrue("allSwitched should still be true", tracker.allSwitched());
-    }
-
-    /**
-     * Verifies the basic state machine: ACTIVE → TXN_END_RECEIVED → SWITCHED.
+     * Verifies the basic state transitions: a partition starts in ACTIVE after
+     * the first {@code onWrite}, then transitions to TXN_END_SEEN after
+     * {@code onTxnEnd}.
      */
     @Test
     public void testBasicStateTransitions() {
-        PartitionCommitTracker tracker = new PartitionCommitTracker(0);
+        PartitionCommitTracker tracker = new PartitionCommitTracker();
 
         // Initially empty
         Assert.assertTrue(tracker.isEmpty());
-        Assert.assertFalse(tracker.allSwitched());
+        Assert.assertFalse(tracker.hasAnyTxnEndSeen());
 
-        // Write → ACTIVE
+        // Write → ACTIVE (partition not yet seen a txnEnd)
         tracker.onWrite(0);
         Assert.assertFalse(tracker.isEmpty());
-        List<Integer> active = tracker.getActivePartitions();
-        Assert.assertEquals(1, active.size());
-        Assert.assertEquals(Integer.valueOf(0), active.get(0));
+        List<Integer> withoutTxnEnd = tracker.getPartitionsWithoutTxnEnd();
+        Assert.assertEquals(1, withoutTxnEnd.size());
+        Assert.assertEquals(Integer.valueOf(0), withoutTxnEnd.get(0));
+        Assert.assertFalse(tracker.hasAnyTxnEndSeen());
 
-        // txnEnd → TXN_END_RECEIVED
+        // txnEnd → TXN_END_SEEN
         tracker.onTxnEnd(0);
-        Assert.assertTrue("No active after txnEnd", tracker.getActivePartitions().isEmpty());
-        Assert.assertFalse("Not yet switched", tracker.allSwitched());
-
-        // markSwitched → SWITCHED
-        tracker.markSwitched(0);
-        Assert.assertTrue("All switched", tracker.allSwitched());
+        Assert.assertTrue("hasAnyTxnEndSeen should be true after onTxnEnd",
+                tracker.hasAnyTxnEndSeen());
+        Assert.assertTrue("No partitions without txnEnd after onTxnEnd",
+                tracker.getPartitionsWithoutTxnEnd().isEmpty());
     }
 
     /**
-     * Verifies that txnEnd for an unknown/evicted partition re-registers it
-     * as TXN_END_RECEIVED.
+     * Verifies the sticky property: once a partition is TXN_END_SEEN, subsequent
+     * {@code onWrite} calls must not demote it back to ACTIVE. This is important
+     * so {@code getPartitionsWithoutTxnEnd()} correctly distinguishes "partition
+     * that never saw a txnEnd" from "partition that is between source transactions".
      */
     @Test
-    public void testTxnEndForUnknownPartitionReRegisters() {
-        PartitionCommitTracker tracker = new PartitionCommitTracker(0);
-
-        // txnEnd for a never-seen partition
-        boolean shouldSwitch = tracker.onTxnEnd(42);
-        Assert.assertTrue("Unknown partition should be switched", shouldSwitch);
-        Assert.assertFalse("Tracker should not be empty", tracker.isEmpty());
-        Assert.assertTrue("No ACTIVE partitions", tracker.getActivePartitions().isEmpty());
-    }
-
-    /**
-     * Verifies N:1 mapping: multiple txnEnd for the same ACTIVE partition
-     * stays in TXN_END_RECEIVED without error.
-     */
-    @Test
-    public void testMultipleTxnEndForSamePartition() {
-        PartitionCommitTracker tracker = new PartitionCommitTracker(0);
+    public void testTxnEndSeenIsSticky() {
+        PartitionCommitTracker tracker = new PartitionCommitTracker();
 
         tracker.onWrite(0);
-        boolean first = tracker.onTxnEnd(0);
-        Assert.assertTrue("First txnEnd should trigger switch", first);
+        tracker.onTxnEnd(0);
+        Assert.assertTrue(tracker.hasAnyTxnEndSeen());
+        Assert.assertTrue(tracker.getPartitionsWithoutTxnEnd().isEmpty());
 
-        // Second txnEnd while still TXN_END_RECEIVED (N:1 accumulation)
-        boolean second = tracker.onTxnEnd(0);
-        Assert.assertFalse("Second txnEnd should not trigger switch again", second);
+        // Subsequent writes must NOT move the partition back to ACTIVE
+        tracker.onWrite(0);
+        tracker.onWrite(0);
+        tracker.onWrite(0);
+
+        Assert.assertTrue("TXN_END_SEEN state must be sticky across onWrite calls",
+                tracker.hasAnyTxnEndSeen());
+        Assert.assertTrue("Partition must not reappear in without-txnEnd list",
+                tracker.getPartitionsWithoutTxnEnd().isEmpty());
     }
 
     /**
-     * Verifies that allSwitched() blocks when only some partitions are switched.
+     * Verifies that {@code onTxnEnd} registers a previously-unknown partition
+     * directly into TXN_END_SEEN (no prior {@code onWrite} required).
      */
     @Test
-    public void testAllSwitchedBlocksOnPartialSwitch() {
-        PartitionCommitTracker tracker = new PartitionCommitTracker(0);
+    public void testTxnEndForUnknownPartition() {
+        PartitionCommitTracker tracker = new PartitionCommitTracker();
+
+        tracker.onTxnEnd(42);
+        Assert.assertFalse("Tracker should not be empty", tracker.isEmpty());
+        Assert.assertTrue("Partition 42 should be TXN_END_SEEN",
+                tracker.hasAnyTxnEndSeen());
+        Assert.assertTrue("Partition 42 should not appear in without-txnEnd list",
+                tracker.getPartitionsWithoutTxnEnd().isEmpty());
+    }
+
+    /**
+     * Verifies that multiple partitions can be tracked independently and that
+     * {@code getPartitionsWithoutTxnEnd()} returns only those still lacking a txnEnd.
+     */
+    @Test
+    public void testMultiplePartitions() {
+        PartitionCommitTracker tracker = new PartitionCommitTracker();
 
         tracker.onWrite(0);
         tracker.onWrite(1);
+        tracker.onWrite(2);
 
-        tracker.onTxnEnd(0);
-        tracker.markSwitched(0);
+        List<Integer> withoutTxnEnd = tracker.getPartitionsWithoutTxnEnd();
+        Assert.assertEquals("All three partitions start in ACTIVE", 3, withoutTxnEnd.size());
 
-        // Partition 1 is still ACTIVE
-        Assert.assertFalse("allSwitched should be false with one ACTIVE", tracker.allSwitched());
-
+        // Only partition 1 sees a txnEnd
         tracker.onTxnEnd(1);
-        tracker.markSwitched(1);
-        Assert.assertTrue("allSwitched should be true when all switched", tracker.allSwitched());
+
+        withoutTxnEnd = tracker.getPartitionsWithoutTxnEnd();
+        Assert.assertEquals("Partitions 0 and 2 still lack txnEnd", 2, withoutTxnEnd.size());
+        Assert.assertTrue(withoutTxnEnd.contains(0));
+        Assert.assertTrue(withoutTxnEnd.contains(2));
+        Assert.assertFalse(withoutTxnEnd.contains(1));
     }
 
     /**
-     * Verifies that getReadyToSwitch() respects the commit interval.
+     * Verifies that {@code reset()} clears all tracked partitions so the next
+     * commit cycle starts from an empty tracker.
      */
     @Test
-    public void testGetReadyToSwitchRespectsInterval() throws InterruptedException {
-        // 200ms interval
-        PartitionCommitTracker tracker = new PartitionCommitTracker(200);
+    public void testResetClearsAllPartitions() {
+        PartitionCommitTracker tracker = new PartitionCommitTracker();
+
+        tracker.onWrite(0);
+        tracker.onWrite(1);
+        tracker.onTxnEnd(0);
+        tracker.onTxnEnd(1);
+
+        Assert.assertFalse(tracker.isEmpty());
+        Assert.assertTrue(tracker.hasAnyTxnEndSeen());
+
+        tracker.reset();
+
+        Assert.assertTrue("Tracker should be empty after reset", tracker.isEmpty());
+        Assert.assertFalse("hasAnyTxnEndSeen should be false after reset",
+                tracker.hasAnyTxnEndSeen());
+        Assert.assertTrue("No partitions without txnEnd after reset",
+                tracker.getPartitionsWithoutTxnEnd().isEmpty());
+    }
+
+    /**
+     * Verifies that {@code onWrite} on an existing ACTIVE partition is idempotent
+     * (does not accidentally register new entries).
+     */
+    @Test
+    public void testRepeatedWritesOnSamePartition() {
+        PartitionCommitTracker tracker = new PartitionCommitTracker();
+
+        for (int i = 0; i < 100; i++) {
+            tracker.onWrite(5);
+        }
+
+        List<Integer> withoutTxnEnd = tracker.getPartitionsWithoutTxnEnd();
+        Assert.assertEquals("Only one partition should be tracked",
+                1, withoutTxnEnd.size());
+        Assert.assertEquals(Integer.valueOf(5), withoutTxnEnd.get(0));
+    }
+
+    /**
+     * Verifies the "multiple complete source transactions within one commit cycle"
+     * scenario (N:1 mapping). Multiple {@code onTxnEnd} calls on the same partition
+     * should leave it in TXN_END_SEEN and remain consistent.
+     */
+    @Test
+    public void testMultipleTxnEndsSamePartition() {
+        PartitionCommitTracker tracker = new PartitionCommitTracker();
 
         tracker.onWrite(0);
         tracker.onTxnEnd(0);
+        tracker.onWrite(0);
+        tracker.onTxnEnd(0);
+        tracker.onWrite(0);
+        tracker.onTxnEnd(0);
 
-        // Immediately after construction, interval has not elapsed
-        List<Integer> ready = tracker.getReadyToSwitch();
-        Assert.assertTrue("Should not be ready before interval elapses", ready.isEmpty());
-
-        Thread.sleep(250);
-
-        ready = tracker.getReadyToSwitch();
-        Assert.assertEquals("Should be ready after interval elapses", 1, ready.size());
+        Assert.assertTrue(tracker.hasAnyTxnEndSeen());
+        Assert.assertTrue(tracker.getPartitionsWithoutTxnEnd().isEmpty());
     }
 }

--- a/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/v2/StreamLoadManagerMultiTableTest.java
+++ b/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/v2/StreamLoadManagerMultiTableTest.java
@@ -1,0 +1,975 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.starrocks.data.load.stream.v2;
+
+import com.starrocks.data.load.stream.MockedStarRocksHttpServer;
+import com.starrocks.data.load.stream.StreamLoadDataFormat;
+import com.starrocks.data.load.stream.properties.StreamLoadProperties;
+import com.starrocks.data.load.stream.properties.StreamLoadTableProperties;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class StreamLoadManagerMultiTableTest {
+
+    private static final String USERNAME = "root";
+    private static final String PASSWORD = "";
+
+    private MockedStarRocksHttpServer mockedServer;
+
+    @Before
+    public void setUp() throws Exception {
+        mockedServer = MockedStarRocksHttpServer.builder()
+                .port(0)
+                .enforceAuth(USERNAME, PASSWORD)
+                .build();
+        mockedServer.start();
+    }
+
+    @After
+    public void tearDown() {
+        if (mockedServer != null) {
+            mockedServer.stop();
+        }
+    }
+
+    private StreamLoadProperties buildMultiTableProperties(int flushIntervalMs) {
+        StreamLoadTableProperties tableProps = StreamLoadTableProperties.builder()
+                .database("test")
+                .table("orders")
+                .streamLoadDataFormat(StreamLoadDataFormat.JSON)
+                .maxBufferRows(100000)
+                .build();
+
+        return StreamLoadProperties.builder()
+                .loadUrls(mockedServer.getBaseUrl())
+                .username(USERNAME)
+                .password(PASSWORD)
+                .version("4.0.0")
+                .enableMultiTableTransaction()
+                .labelPrefix("test-mtxn-")
+                .defaultTableProperties(tableProps)
+                .expectDelayTime(flushIntervalMs)
+                .scanningFrequency(50)
+                .ioThreadCount(2)
+                .build();
+    }
+
+    /**
+     * Single partition: write data to two tables, send txnEnd, verify commit.
+     * Verifies that the shared transaction coordinator is used (1 begin, 1 prepare, 1 commit).
+     */
+    @Test
+    public void testSinglePartitionWriteAndCommit() throws Exception {
+        StreamLoadProperties properties = buildMultiTableProperties(100);
+        StreamLoadManagerV2 manager = new StreamLoadManagerV2(properties, true);
+        manager.init();
+
+        try {
+            mockedServer.resetCounters();
+
+            int partition = 0;
+            manager.write(partition, "test", "orders",
+                    "{\"order_id\":1, \"customer_id\":100, \"total_amount\":99.99}");
+            manager.setCommitAllowed(partition, false);
+
+            manager.write(partition, "test", "order_items",
+                    "{\"item_id\":1, \"order_id\":1, \"product_name\":\"widget\", \"quantity\":2}");
+            manager.setCommitAllowed(partition, true);
+
+            Thread.sleep(500);
+            Assert.assertNull("No exception expected", manager.getException());
+
+            manager.flush();
+            Assert.assertNull("No exception expected after flush", manager.getException());
+
+            // At least 1 begin (shared transaction is eagerly opened; after commit,
+            // a new one is opened for the next cycle, and savepoint may open yet another).
+            Assert.assertTrue("Expected at least 1 begin for shared transaction",
+                    mockedServer.getBeginCount() >= 1);
+            Assert.assertTrue("Expected at least 1 load call (one per table)",
+                    mockedServer.getLoadCount() >= 1);
+            // Multi-table transactions skip prepare and go directly to commit.
+            Assert.assertEquals("Expected exactly 1 commit for single shared transaction",
+                    1, mockedServer.getCommitCount());
+        } finally {
+            manager.close();
+        }
+    }
+
+    /**
+     * Two partitions sharing one sink: commit only triggers when BOTH
+     * partitions have reached txnEnd.
+     */
+    @Test
+    public void testMultiPartitionCommitWaitsForAll() throws Exception {
+        StreamLoadProperties properties = buildMultiTableProperties(100);
+        StreamLoadManagerV2 manager = new StreamLoadManagerV2(properties, true);
+        manager.init();
+
+        try {
+            // Partition 0 writes + txnEnd
+            manager.write(0, "test", "orders",
+                    "{\"order_id\":1, \"customer_id\":100}");
+            manager.setCommitAllowed(0, true);
+
+            // Only partition 0 has txnEnd. Partition 1 hasn't even started.
+            // But there's also only partition 0 active, so commit may trigger.
+            Thread.sleep(300);
+            Assert.assertNull("No exception after P0 txnEnd", manager.getException());
+
+            // Now partition 1 writes + txnEnd
+            manager.write(1, "test", "orders",
+                    "{\"order_id\":2, \"customer_id\":101}");
+            manager.setCommitAllowed(1, false);
+
+            manager.write(1, "test", "order_items",
+                    "{\"item_id\":1, \"order_id\":2}");
+            manager.setCommitAllowed(1, true);
+
+            Thread.sleep(500);
+            Assert.assertNull("No exception after P1 txnEnd", manager.getException());
+
+            manager.flush();
+            Assert.assertNull("No exception after flush", manager.getException());
+        } finally {
+            manager.close();
+        }
+    }
+
+    /**
+     * Verifies that data is NOT committed while no partition has sent txnEnd.
+     * The shared transaction is eagerly opened (begin), but commit only
+     * happens after txnEnd.
+     */
+    @Test
+    public void testCommitNotTriggeredWithoutTxnEnd() throws Exception {
+        StreamLoadProperties properties = buildMultiTableProperties(100);
+        StreamLoadManagerV2 manager = new StreamLoadManagerV2(properties, true);
+        manager.init();
+
+        try {
+            mockedServer.resetCounters();
+
+            manager.write(0, "test", "orders",
+                    "{\"order_id\":1, \"customer_id\":100}");
+            manager.setCommitAllowed(0, false);
+
+            Thread.sleep(300);
+            Assert.assertNull("No exception expected", manager.getException());
+            // Shared transaction is eagerly opened, so begin may have been called.
+            // But commit must NOT have happened yet.
+            Assert.assertEquals("No commit expected before txnEnd", 0, mockedServer.getCommitCount());
+
+            manager.setCommitAllowed(0, true);
+            Thread.sleep(300);
+            Assert.assertNull("No exception expected after txnEnd", manager.getException());
+
+            manager.flush();
+            Assert.assertNull("No exception expected after flush", manager.getException());
+        } finally {
+            manager.close();
+        }
+    }
+
+    /**
+     * N:1 mapping: multiple source transactions accumulate before commit.
+     */
+    @Test
+    public void testMultipleTransactionsAccumulate() throws Exception {
+        StreamLoadProperties properties = buildMultiTableProperties(500);
+        StreamLoadManagerV2 manager = new StreamLoadManagerV2(properties, true);
+        manager.init();
+
+        try {
+            // Txn 1
+            manager.write(0, "test", "orders", "{\"order_id\":1}");
+            manager.setCommitAllowed(0, true);
+
+            // Txn 2 (interval not elapsed yet, so txn 1 data stays in active chunk)
+            manager.write(0, "test", "orders", "{\"order_id\":2}");
+            manager.setCommitAllowed(0, true);
+
+            // Wait for interval
+            Thread.sleep(600);
+
+            // Txn 3 triggers the interval check
+            manager.write(0, "test", "orders", "{\"order_id\":3}");
+            manager.setCommitAllowed(0, true);
+
+            Thread.sleep(500);
+            Assert.assertNull("No exception expected", manager.getException());
+
+            manager.flush();
+            Assert.assertNull("No exception expected after flush", manager.getException());
+        } finally {
+            manager.close();
+        }
+    }
+
+    /**
+     * Savepoint (flush) commits the active shared transaction even when
+     * txnEnd has not been received (interval-based commit threshold is very high).
+     * Verifies exactly 1 prepare + commit via the savepoint path.
+     * The shared transaction is eagerly opened, so begin count may be >= 1.
+     */
+    @Test
+    public void testSavepointCommitsMultiTableTransaction() throws Exception {
+        StreamLoadProperties properties = buildMultiTableProperties(60000); // 60s interval — never fires
+        StreamLoadManagerV2 manager = new StreamLoadManagerV2(properties, true);
+        manager.init();
+
+        try {
+            mockedServer.resetCounters();
+
+            manager.write(0, "test", "orders",
+                    "{\"order_id\":1, \"customer_id\":100}");
+            manager.write(0, "test", "order_items",
+                    "{\"item_id\":1, \"order_id\":1}");
+
+            // Mark partition as committed so savepoint can proceed
+            manager.setCommitAllowed(0, true);
+            manager.flush();
+            Assert.assertNull("No exception expected after flush", manager.getException());
+
+            // The shared transaction is eagerly opened, so at least 1 begin.
+            // Savepoint path commits the active shared transaction (skipping prepare for multi-table).
+            Assert.assertTrue("Savepoint should issue at least 1 begin",
+                    mockedServer.getBeginCount() >= 1);
+            Assert.assertEquals("Savepoint should issue exactly 1 commit",
+                    1, mockedServer.getCommitCount());
+        } finally {
+            manager.close();
+        }
+    }
+
+    /**
+     * An evicted (idle) partition that later receives txnEnd should be
+     * automatically re-registered and participate in the next commit cycle.
+     *
+     * <p>This tests the {@code onTxnEnd()} fix that re-registers evicted partitions
+     * instead of ignoring them.
+     */
+    @Test
+    public void testEvictedPartitionReRegisters() throws Exception {
+        // Very short interval (100 ms) to trigger multiple rapid commit cycles
+        StreamLoadProperties properties = buildMultiTableProperties(100);
+        StreamLoadManagerV2 manager = new StreamLoadManagerV2(properties, true);
+        manager.init();
+
+        try {
+            mockedServer.resetCounters();
+
+            // Commit cycle 1 — only partition 0
+            manager.write(0, "test", "orders", "{\"order_id\":1}");
+            manager.setCommitAllowed(0, true);
+            Thread.sleep(400);
+
+            // Commit cycle 2 — only partition 0 (partition 0 resets to ACTIVE)
+            manager.write(0, "test", "orders", "{\"order_id\":2}");
+            manager.setCommitAllowed(0, true);
+            Thread.sleep(400);
+
+            // Commit cycle 3 — only partition 0 (3rd cycle: idle count reaches MAX_IDLE_CYCLES)
+            manager.write(0, "test", "orders", "{\"order_id\":3}");
+            manager.setCommitAllowed(0, true);
+            Thread.sleep(400);
+
+            // After 3 idle commit cycles, partition 0 would be evicted.
+            // Now partition 0 sends txnEnd again — it must be re-registered, not ignored.
+            manager.write(0, "test", "orders", "{\"order_id\":4}");
+            manager.setCommitAllowed(0, true);
+            Thread.sleep(400);
+
+            manager.flush();
+            Assert.assertNull("No exception expected after evicted partition re-registers",
+                    manager.getException());
+
+            // At least 4 complete commit cycles must have occurred
+            Assert.assertTrue("Expected at least 4 commits across re-registration cycles",
+                    mockedServer.getCommitCount() >= 4);
+        } finally {
+            manager.close();
+        }
+    }
+
+    /**
+     * Regions from different databases must be rejected: multi-table transactions
+     * require all tables to share the same StarRocks database.
+     */
+    @Test
+    public void testCrossDbWriteIsRejected() throws Exception {
+        StreamLoadProperties properties = buildMultiTableProperties(100);
+        StreamLoadManagerV2 manager = new StreamLoadManagerV2(properties, true);
+        manager.init();
+
+        try {
+            // Write to two different databases in the same commit cycle
+            manager.write(0, "db_a", "orders", "{\"order_id\":1}");
+            manager.write(0, "db_b", "payments", "{\"payment_id\":1}");
+            manager.setCommitAllowed(0, true);
+
+            // Give manager thread time to attempt commit
+            Thread.sleep(500);
+
+            // Manager should have recorded an error about mismatched databases
+            Assert.assertNotNull("Expected exception for cross-database write",
+                    manager.getException());
+            Assert.assertTrue("Exception should mention database mismatch",
+                    manager.getException().getMessage().contains("same database"));
+        } finally {
+            manager.close();
+        }
+    }
+
+    /**
+     * Verifies that autonomous flush (triggered by buffer thresholds) uses the
+     * shared transaction label rather than generating an independent label.
+     * This is the key scenario that was previously subject to data loss.
+     *
+     * <p>With the eager shared transaction approach, the shared label is injected
+     * before any autonomous flush can occur, so all loads use the shared label.
+     * After txnEnd, the commit cycle commits all data (including data from
+     * autonomous flushes) under the single shared transaction.
+     */
+    @Test
+    public void testAutonomousFlushUsesSharedLabel() throws Exception {
+        // Use a very small buffer (1 byte effective) to trigger autonomous flush immediately.
+        StreamLoadTableProperties tableProps = StreamLoadTableProperties.builder()
+                .database("test")
+                .table("orders")
+                .streamLoadDataFormat(StreamLoadDataFormat.JSON)
+                .maxBufferRows(1) // Flush after every row
+                .build();
+
+        StreamLoadProperties properties = StreamLoadProperties.builder()
+                .loadUrls(mockedServer.getBaseUrl())
+                .username(USERNAME)
+                .password(PASSWORD)
+                .version("4.0.0")
+                .enableMultiTableTransaction()
+                .labelPrefix("test-autoflush-")
+                .defaultTableProperties(tableProps)
+                .expectDelayTime(100)
+                .scanningFrequency(50)
+                .ioThreadCount(2)
+                .build();
+
+        StreamLoadManagerV2 manager = new StreamLoadManagerV2(properties, true);
+        manager.init();
+
+        try {
+            mockedServer.resetCounters();
+
+            // Write multiple rows — with maxBufferRows=1, autonomous flush should trigger
+            manager.write(0, "test", "orders", "{\"order_id\":1}");
+            manager.write(0, "test", "orders", "{\"order_id\":2}");
+            manager.write(0, "test", "orders", "{\"order_id\":3}");
+
+            // Give manager thread time to process autonomous flushes
+            Thread.sleep(500);
+            Assert.assertNull("No exception during autonomous flush", manager.getException());
+
+            // Now send txnEnd to trigger commit
+            manager.setCommitAllowed(0, true);
+            Thread.sleep(500);
+            Assert.assertNull("No exception after txnEnd", manager.getException());
+
+            manager.flush();
+            Assert.assertNull("No exception after flush", manager.getException());
+
+            // All data should have been committed under shared transactions.
+            // The critical assertion: at least 1 commit happened (data wasn't lost).
+            Assert.assertTrue("Expected at least 1 commit (autonomous flush data not lost)",
+                    mockedServer.getCommitCount() >= 1);
+            // Loads should have occurred (autonomous flushes).
+            Assert.assertTrue("Expected at least 1 load from autonomous flush",
+                    mockedServer.getLoadCount() >= 1);
+        } finally {
+            manager.close();
+        }
+    }
+
+    /**
+     * Non-multi-table mode is completely unaffected by the new code paths.
+     */
+    @Test
+    public void testNonMultiTableModeUnaffected() throws Exception {
+        StreamLoadTableProperties tableProps = StreamLoadTableProperties.builder()
+                .database("test")
+                .table("tbl1")
+                .streamLoadDataFormat(StreamLoadDataFormat.JSON)
+                .maxBufferRows(100000)
+                .build();
+
+        StreamLoadProperties properties = StreamLoadProperties.builder()
+                .loadUrls(mockedServer.getBaseUrl())
+                .username(USERNAME)
+                .password(PASSWORD)
+                .version("3.5.0")
+                .enableTransaction()
+                .labelPrefix("test-normal-")
+                .defaultTableProperties(tableProps)
+                .expectDelayTime(1000)
+                .scanningFrequency(50)
+                .ioThreadCount(2)
+                .build();
+
+        StreamLoadManagerV2 manager = new StreamLoadManagerV2(properties, true);
+        manager.init();
+
+        try {
+            manager.write(null, "test", "tbl1",
+                    "{\"id\":1, \"name\":\"test\"}");
+
+            manager.flush();
+            Assert.assertNull("No exception expected", manager.getException());
+        } finally {
+            manager.close();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Item 10: Constructor parameter validation
+    // -------------------------------------------------------------------------
+
+    /**
+     * Multi-table transaction mode requires TransactionStreamLoader (i.e. transaction
+     * must be enabled). Enabling multi-table without transaction should throw.
+     *
+     * <p>Note: {@code enableMultiTableTransaction()} in the builder already sets
+     * {@code enableTransaction = true}, so we test the indirect path: multi-table
+     * with maxRetries > 0, which forces DefaultStreamLoader instead of
+     * TransactionStreamLoader.
+     */
+    @Test
+    public void testConstructorRejectsMultiTableWithRetries() {
+        StreamLoadTableProperties tableProps = StreamLoadTableProperties.builder()
+                .database("test")
+                .table("orders")
+                .streamLoadDataFormat(StreamLoadDataFormat.JSON)
+                .build();
+
+        StreamLoadProperties properties = StreamLoadProperties.builder()
+                .loadUrls(mockedServer.getBaseUrl())
+                .username(USERNAME)
+                .password(PASSWORD)
+                .version("4.0.0")
+                .enableMultiTableTransaction()
+                .maxRetries(3)
+                .labelPrefix("test-")
+                .defaultTableProperties(tableProps)
+                .expectDelayTime(100)
+                .scanningFrequency(50)
+                .ioThreadCount(2)
+                .build();
+
+        try {
+            new StreamLoadManagerV2(properties, true);
+            Assert.fail("Expected IllegalArgumentException for multi-table with retries");
+        } catch (IllegalArgumentException e) {
+            Assert.assertTrue("Should mention TransactionStreamLoader",
+                    e.getMessage().contains("TransactionStreamLoader"));
+        }
+    }
+
+    /**
+     * Manual commit mode (enableAutoCommit=false) requires transaction support.
+     * Without it, construction should throw.
+     */
+    @Test
+    public void testConstructorRejectsManualCommitWithoutTransaction() {
+        StreamLoadTableProperties tableProps = StreamLoadTableProperties.builder()
+                .database("test")
+                .table("orders")
+                .streamLoadDataFormat(StreamLoadDataFormat.JSON)
+                .build();
+
+        // Build properties WITHOUT enableTransaction
+        StreamLoadProperties properties = StreamLoadProperties.builder()
+                .loadUrls(mockedServer.getBaseUrl())
+                .username(USERNAME)
+                .password(PASSWORD)
+                .version("4.0.0")
+                .labelPrefix("test-")
+                .defaultTableProperties(tableProps)
+                .expectDelayTime(100)
+                .scanningFrequency(50)
+                .ioThreadCount(2)
+                .build();
+
+        try {
+            new StreamLoadManagerV2(properties, false);
+            Assert.fail("Expected IllegalArgumentException for manual commit without transaction");
+        } catch (IllegalArgumentException e) {
+            Assert.assertTrue("Should mention transaction stream load",
+                    e.getMessage().contains("transaction stream load"));
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Item 9: setCommitAllowed(boolean) is no-op in multi-table mode
+    // -------------------------------------------------------------------------
+
+    /**
+     * The legacy {@code setCommitAllowed(boolean)} without partition parameter
+     * is a no-op in multi-table mode. Verifies that calling it does not cause
+     * errors and does not trigger a commit (the commit counter stays at 0).
+     */
+    @Test
+    public void testLegacySetCommitAllowedIsNoOpInMultiTableMode() throws Exception {
+        StreamLoadProperties properties = buildMultiTableProperties(60000);
+        StreamLoadManagerV2 manager = new StreamLoadManagerV2(properties, true);
+        manager.init();
+
+        try {
+            mockedServer.resetCounters();
+
+            manager.write(0, "test", "orders", "{\"order_id\":1}");
+
+            // Call the legacy no-partition variant — should be a no-op
+            manager.setCommitAllowed(true);
+            Thread.sleep(300);
+            Assert.assertNull("No exception expected from no-op setCommitAllowed", manager.getException());
+
+            // No commit should have been triggered by the legacy call
+            Assert.assertEquals("No commit from legacy setCommitAllowed",
+                    0, mockedServer.getCommitCount());
+
+            // Mark partition committed so flush can proceed, then clean up
+            manager.setCommitAllowed(0, true);
+            manager.flush();
+            Assert.assertNull("No exception after flush", manager.getException());
+        } finally {
+            manager.close();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Item 4: Commit failure — exception propagation and state cleanup
+    // -------------------------------------------------------------------------
+
+    /**
+     * When commit fails (server returns error), the manager should capture the
+     * exception and propagate it to the caller.
+     */
+    @Test
+    public void testCommitFailurePropagatesException() throws Exception {
+        StreamLoadProperties properties = buildMultiTableProperties(100);
+        StreamLoadManagerV2 manager = new StreamLoadManagerV2(properties, true);
+        manager.init();
+
+        try {
+            // Inject commit failure
+            MockedStarRocksHttpServer.ResponseOverride commitFail =
+                    new MockedStarRocksHttpServer.ResponseOverride();
+            commitFail.status = "Fail";
+            commitFail.message = "disk full";
+            mockedServer.setCommitOverride(commitFail);
+
+            manager.write(0, "test", "orders", "{\"order_id\":1}");
+            manager.setCommitAllowed(0, true);
+
+            // Wait for manager thread to attempt commit
+            Thread.sleep(500);
+
+            // The exception should have been captured
+            Assert.assertNotNull("Expected exception from commit failure",
+                    manager.getException());
+        } finally {
+            manager.close();
+        }
+    }
+
+    /**
+     * Multi-table transactions skip prepare and go directly to commit,
+     * so a prepare override should have no effect. Verify that the
+     * transaction completes successfully even with a prepare override set.
+     */
+    @Test
+    public void testPrepareSkippedInMultiTableMode() throws Exception {
+        StreamLoadProperties properties = buildMultiTableProperties(100);
+        StreamLoadManagerV2 manager = new StreamLoadManagerV2(properties, true);
+        manager.init();
+
+        try {
+            mockedServer.resetCounters();
+
+            // Set a prepare failure override — should have no effect in multi-table mode
+            MockedStarRocksHttpServer.ResponseOverride prepareFail =
+                    new MockedStarRocksHttpServer.ResponseOverride();
+            prepareFail.status = "Fail";
+            prepareFail.message = "prepare failed";
+            mockedServer.setPrepareOverride(prepareFail);
+
+            manager.write(0, "test", "orders", "{\"order_id\":1}");
+            manager.setCommitAllowed(0, true);
+
+            Thread.sleep(500);
+
+            // No exception expected — prepare is skipped in multi-table mode
+            Assert.assertNull("No exception expected (prepare is skipped in multi-table mode)",
+                    manager.getException());
+
+            manager.flush();
+            Assert.assertNull("No exception after flush", manager.getException());
+
+            // Verify prepare was never called
+            Assert.assertEquals("Prepare should be skipped in multi-table mode",
+                    0, mockedServer.getPrepareCount());
+            // Commit should have occurred
+            Assert.assertTrue("Commit should have occurred",
+                    mockedServer.getCommitCount() >= 1);
+        } finally {
+            manager.close();
+        }
+    }
+
+    /**
+     * When begin fails (cannot open shared transaction), the manager should
+     * capture the exception.
+     */
+    @Test
+    public void testBeginFailurePropagatesException() throws Exception {
+        StreamLoadProperties properties = buildMultiTableProperties(100);
+
+        // Inject begin failure BEFORE init so the eager open fails
+        MockedStarRocksHttpServer.ResponseOverride beginFail =
+                new MockedStarRocksHttpServer.ResponseOverride();
+        beginFail.status = "Fail";
+        beginFail.message = "too many running transactions";
+        mockedServer.setBeginOverride(beginFail);
+
+        StreamLoadManagerV2 manager = new StreamLoadManagerV2(properties, true);
+        manager.init();
+
+        try {
+            manager.write(0, "test", "orders", "{\"order_id\":1}");
+            manager.setCommitAllowed(0, true);
+
+            Thread.sleep(500);
+
+            Assert.assertNotNull("Expected exception from begin failure",
+                    manager.getException());
+        } finally {
+            manager.close();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Item 3: Flush timeout
+    // -------------------------------------------------------------------------
+
+    /**
+     * Verifies that when flush takes longer than the configured timeout,
+     * a RuntimeException is thrown.
+     *
+     * <p>We set timeout=1 via headers (flushTimeoutMs = 1*1100 = 1100ms),
+     * then make commit hang by failing repeatedly so flush never completes.
+     */
+    @Test
+    public void testFlushTimeout() throws Exception {
+        StreamLoadTableProperties tableProps = StreamLoadTableProperties.builder()
+                .database("test")
+                .table("orders")
+                .streamLoadDataFormat(StreamLoadDataFormat.JSON)
+                .maxBufferRows(100000)
+                .build();
+
+        StreamLoadProperties properties = StreamLoadProperties.builder()
+                .loadUrls(mockedServer.getBaseUrl())
+                .username(USERNAME)
+                .password(PASSWORD)
+                .version("4.0.0")
+                .enableMultiTableTransaction()
+                .labelPrefix("test-timeout-")
+                .defaultTableProperties(tableProps)
+                .expectDelayTime(60000) // never auto-commit
+                .scanningFrequency(50)
+                .ioThreadCount(2)
+                .addHeader("timeout", "1") // 1 second → flushTimeoutMs = 1100ms
+                .build();
+
+        StreamLoadManagerV2 manager = new StreamLoadManagerV2(properties, true);
+        manager.init();
+
+        try {
+            // Make commit always fail so flush() can never complete
+            MockedStarRocksHttpServer.ResponseOverride commitFail =
+                    new MockedStarRocksHttpServer.ResponseOverride();
+            commitFail.status = "Fail";
+            commitFail.message = "simulated hang";
+            mockedServer.setCommitOverride(commitFail);
+
+            manager.write(0, "test", "orders", "{\"order_id\":1}");
+            manager.setCommitAllowed(0, true);
+
+            // flush() should eventually throw due to timeout (1100ms)
+            try {
+                manager.flush();
+                // flush may succeed if the manager thread captures the commit error first
+                // In that case, getException should be non-null
+                if (manager.getException() != null) {
+                    return; // commit failure was captured — acceptable outcome
+                }
+                Assert.fail("Expected RuntimeException from flush timeout or commit failure");
+            } catch (RuntimeException e) {
+                Assert.assertTrue("Exception should mention timeout or commit failure",
+                        e.getMessage().contains("timeout") || e.getMessage().contains("Fail"));
+            }
+        } finally {
+            manager.close();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Item 1: Write blocking / backpressure (blockIfCacheFull)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Verifies that writes are accepted and eventually committed when using a
+     * very small buffer size. With a tiny {@code multiTableTransactionBufferSize},
+     * the write path will trigger flush signals (soft threshold) and potentially
+     * block writes (hard threshold at 2× buffer size).
+     *
+     * <p>This exercises the {@code blockIfCacheFull()} code path.
+     */
+    @Test(timeout = 15000)
+    public void testWriteBlockingWithSmallBuffer() throws Exception {
+        StreamLoadTableProperties tableProps = StreamLoadTableProperties.builder()
+                .database("test")
+                .table("orders")
+                .streamLoadDataFormat(StreamLoadDataFormat.JSON)
+                .maxBufferRows(100000)
+                .build();
+
+        StreamLoadProperties properties = StreamLoadProperties.builder()
+                .loadUrls(mockedServer.getBaseUrl())
+                .username(USERNAME)
+                .password(PASSWORD)
+                .version("4.0.0")
+                .enableMultiTableTransaction()
+                .multiTableTransactionBufferSize(2048) // 2KB — small but allows writes to proceed
+                .labelPrefix("test-backpressure-")
+                .defaultTableProperties(tableProps)
+                .expectDelayTime(100)
+                .scanningFrequency(50)
+                .ioThreadCount(2)
+                .build();
+
+        StreamLoadManagerV2 manager = new StreamLoadManagerV2(properties, true);
+        manager.init();
+
+        try {
+            mockedServer.resetCounters();
+
+            // Write enough data to exceed the soft threshold (2048 bytes).
+            // Each JSON row is ~40-50 bytes. 50 rows ≈ 2500 bytes, exceeding
+            // soft threshold but not blocking indefinitely at 2x hard threshold.
+            for (int i = 0; i < 50; i++) {
+                manager.write(0, "test", "orders",
+                        String.format("{\"order_id\":%d, \"customer_id\":%d}", i, i * 10));
+            }
+
+            manager.setCommitAllowed(0, true);
+            Thread.sleep(500);
+            Assert.assertNull("No exception expected during backpressure writes",
+                    manager.getException());
+
+            manager.flush();
+            Assert.assertNull("No exception after flush", manager.getException());
+
+            // Data should have been committed despite the small buffer
+            Assert.assertTrue("Expected at least 1 commit",
+                    mockedServer.getCommitCount() >= 1);
+            // The small buffer should have triggered multiple flush signals
+            Assert.assertTrue("Expected multiple loads due to small buffer",
+                    mockedServer.getLoadCount() >= 1);
+        } finally {
+            manager.close();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Item 2: Shared transaction timeout recycling
+    // -------------------------------------------------------------------------
+
+    /**
+     * Verifies that shared transactions are recycled before the server-side timeout.
+     *
+     * <p>We set timeout=1 via headers (sharedTxnMaxIdleMs = 1*800 = 800ms).
+     * The manager's eager open creates a shared transaction; if no data is committed
+     * within 800ms, it should be recycled (rolled back and a new one opened).
+     *
+     * <p>We verify by checking that more begin calls than commit calls occur
+     * (the extra begins come from recycling).
+     */
+    @Test
+    public void testSharedTransactionRecycling() throws Exception {
+        StreamLoadTableProperties tableProps = StreamLoadTableProperties.builder()
+                .database("test")
+                .table("orders")
+                .streamLoadDataFormat(StreamLoadDataFormat.JSON)
+                .maxBufferRows(100000)
+                .build();
+
+        StreamLoadProperties properties = StreamLoadProperties.builder()
+                .loadUrls(mockedServer.getBaseUrl())
+                .username(USERNAME)
+                .password(PASSWORD)
+                .version("4.0.0")
+                .enableMultiTableTransaction()
+                .labelPrefix("test-recycle-")
+                .defaultTableProperties(tableProps)
+                .expectDelayTime(60000) // never auto-commit
+                .scanningFrequency(50)
+                .ioThreadCount(2)
+                .addHeader("timeout", "1") // sharedTxnMaxIdleMs = 800ms
+                .build();
+
+        StreamLoadManagerV2 manager = new StreamLoadManagerV2(properties, true);
+        manager.init();
+
+        try {
+            mockedServer.resetCounters();
+
+            // Write a row so the manager opens a shared transaction
+            manager.write(0, "test", "orders", "{\"order_id\":1}");
+
+            // Wait longer than sharedTxnMaxIdleMs (800ms) for recycling to occur.
+            // The recycling is checked each scanningFrequency (50ms), so after ~900ms
+            // the transaction should have been recycled at least once.
+            Thread.sleep(1500);
+            Assert.assertNull("No exception during recycling", manager.getException());
+
+            // Recycling means: original begin + rollback/commit + new begin
+            // So we expect more begins than commits.
+            int beginCount = mockedServer.getBeginCount();
+            Assert.assertTrue("Expected at least 2 begins from recycling, got: " + beginCount,
+                    beginCount >= 2);
+
+            // Clean up
+            manager.setCommitAllowed(0, true);
+            Thread.sleep(300);
+            manager.flush();
+            Assert.assertNull("No exception after flush", manager.getException());
+        } finally {
+            manager.close();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Item 7: Large batch stress test
+    // -------------------------------------------------------------------------
+
+    /**
+     * Writes a large number of rows across multiple tables and partitions,
+     * verifying that all data is committed without errors.
+     */
+    @Test
+    public void testLargeBatchMultiTableStress() throws Exception {
+        StreamLoadProperties properties = buildMultiTableProperties(200);
+        StreamLoadManagerV2 manager = new StreamLoadManagerV2(properties, true);
+        manager.init();
+
+        try {
+            mockedServer.resetCounters();
+
+            int rowsPerTable = 500;
+            // Partition 0 writes to "orders"
+            for (int i = 0; i < rowsPerTable; i++) {
+                manager.write(0, "test", "orders",
+                        String.format("{\"order_id\":%d,\"customer_id\":%d,\"total\":%.2f}",
+                                i, i * 10, i * 1.5));
+            }
+            // Partition 1 writes to "order_items"
+            for (int i = 0; i < rowsPerTable; i++) {
+                manager.write(1, "test", "order_items",
+                        String.format("{\"item_id\":%d,\"order_id\":%d,\"qty\":%d}",
+                                i, i / 3, i % 10 + 1));
+            }
+
+            // Signal both partitions done
+            manager.setCommitAllowed(0, true);
+            manager.setCommitAllowed(1, true);
+
+            Thread.sleep(800);
+            Assert.assertNull("No exception during large batch write", manager.getException());
+
+            manager.flush();
+            Assert.assertNull("No exception after flush", manager.getException());
+
+            Assert.assertTrue("Expected at least 1 commit for large batch",
+                    mockedServer.getCommitCount() >= 1);
+            Assert.assertTrue("Expected multiple load calls for large batch",
+                    mockedServer.getLoadCount() >= 2);
+        } finally {
+            manager.close();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Item 8: Dynamic new table added at runtime
+    // -------------------------------------------------------------------------
+
+    /**
+     * Verifies that a new table can be written at runtime after the shared
+     * transaction is already open. The new region should be injected with
+     * the existing shared label.
+     */
+    @Test
+    public void testDynamicNewTableAfterSharedTxnOpen() throws Exception {
+        StreamLoadProperties properties = buildMultiTableProperties(100);
+        StreamLoadManagerV2 manager = new StreamLoadManagerV2(properties, true);
+        manager.init();
+
+        try {
+            mockedServer.resetCounters();
+
+            // Write to first table — this triggers eager shared txn open
+            manager.write(0, "test", "orders", "{\"order_id\":1}");
+            Thread.sleep(200); // let manager thread open the shared txn
+
+            // Now write to a brand new table that didn't exist when the shared txn opened.
+            // The getCacheRegion() code path should create a new region and inject
+            // the existing shared label into it.
+            manager.write(0, "test", "payments", "{\"payment_id\":1,\"amount\":42.0}");
+
+            // Also write to a third table
+            manager.write(0, "test", "shipments", "{\"shipment_id\":1,\"tracking\":\"ABC\"}");
+
+            manager.setCommitAllowed(0, true);
+            Thread.sleep(500);
+            Assert.assertNull("No exception when adding new table at runtime",
+                    manager.getException());
+
+            manager.flush();
+            Assert.assertNull("No exception after flush", manager.getException());
+
+            // All 3 tables' data should be committed under shared transaction(s)
+            Assert.assertTrue("Expected at least 1 commit", mockedServer.getCommitCount() >= 1);
+            // At least 3 load calls (one per table)
+            Assert.assertTrue("Expected at least 3 loads (one per table)",
+                    mockedServer.getLoadCount() >= 3);
+        } finally {
+            manager.close();
+        }
+    }
+}

--- a/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/v2/StreamLoadManagerMultiTableTest.java
+++ b/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/v2/StreamLoadManagerMultiTableTest.java
@@ -1353,4 +1353,172 @@ public class StreamLoadManagerMultiTableTest {
             manager.close();
         }
     }
+
+    /**
+     * Verifies the aggregate fail-fast guard across multiple regions within a
+     * single source transaction.
+     *
+     * <p>The per-region {@code multiTableSingleTxnMaxBytes} check in
+     * {@code TransactionTableRegion.write0} only sees one region's activeChunk
+     * at a time. A single source transaction that splits its payload across
+     * several tables can keep each region's chunk comfortably under the
+     * per-region hard cap while the combined payload pushes the manager-level
+     * {@code currentCacheBytes} past {@code maxWriteBlockCacheBytes}. At that
+     * point the task thread would be parked in {@code blockIfCacheFull} with
+     * no region at a clean boundary, and the txnEnd marker needed to unblock
+     * any region can never be delivered — a silent deadlock.
+     *
+     * <p>This test writes rows alternately to three tables without calling
+     * {@code setCommitAllowed}, simulating one source transaction that spans
+     * all three. No single region exceeds the per-region cap; the deadlock
+     * is only avoidable via the aggregate in-progress byte guard in the
+     * manager. We expect an {@link IllegalStateException} with a clear
+     * "aggregate" remediation hint, raised before {@code blockIfCacheFull}
+     * could park the task thread.
+     */
+    @Test(timeout = 10000)
+    public void testFailFastOnAggregateInProgressBytesAcrossRegions() throws Exception {
+        // 1 KB buffer → hard cap (maxWriteBlockCacheBytes) = 2 KB.
+        // Per-region fail-fast threshold is also 2 KB, so each individual
+        // region can grow almost to 2 KB without tripping the per-region
+        // check. Spreading writes across three tables keeps each region well
+        // under that limit while the aggregate grows past 2 KB.
+        StreamLoadProperties properties = buildMultiTableProperties(60000, 1024L);
+        StreamLoadManagerV2 manager = new StreamLoadManagerV2(properties, true);
+        manager.init();
+
+        try {
+            IllegalStateException caught = null;
+            int rowsWritten = 0;
+            String[] tables = {"orders", "items", "customers"};
+            try {
+                // Round-robin across three tables on one partition without any
+                // setCommitAllowed call. Each row is ~68 bytes; each region's
+                // activeChunk grows by one row per three iterations, so after
+                // ~90 iterations each region holds ~30 rows (~2 KB each, well
+                // under the per-region 2 KB cap when viewed individually) but
+                // the aggregate is ~6 KB (3× hard cap). The aggregate guard
+                // should fire long before any region approaches its own cap.
+                for (int i = 0; i < 300; i++) {
+                    String table = tables[i % tables.length];
+                    manager.write(0, "test", table,
+                            String.format(
+                                    "{\"id\":%06d,\"customer_id\":%06d,\"notes\":\"pad-block-%04d\"}",
+                                    i, i, i));
+                    rowsWritten++;
+                }
+                Assert.fail("Expected IllegalStateException for aggregate in-progress overflow, "
+                        + "but write() succeeded after " + rowsWritten + " rows");
+            } catch (IllegalStateException e) {
+                caught = e;
+            }
+
+            Assert.assertNotNull(
+                    "Expected IllegalStateException for aggregate in-progress overflow", caught);
+            Assert.assertTrue(
+                    "Error message should identify it as the aggregate guard: " + caught.getMessage(),
+                    caught.getMessage().toLowerCase().contains("aggregate"));
+            Assert.assertTrue(
+                    "Error message should mention the write-block threshold: " + caught.getMessage(),
+                    caught.getMessage().contains("write-block"));
+            Assert.assertTrue(
+                    "Error message should suggest a remediation: " + caught.getMessage(),
+                    caught.getMessage().contains("buffer-size")
+                            || caught.getMessage().contains("buffer size"));
+            // Sanity: the aggregate guard must fire before blockIfCacheFull
+            // parks the task thread. currentCacheBytes crosses the 2 KB hard
+            // cap at ~30 rows (30 × 68 ≈ 2040 B), so the guard should fire
+            // near that point, not after hundreds of rows.
+            Assert.assertTrue(
+                    "Aggregate guard should trigger near the hard-cap boundary, "
+                            + "but rowsWritten=" + rowsWritten,
+                    rowsWritten < 60);
+        } finally {
+            try {
+                manager.close();
+            } catch (Exception ignore) {
+                // close() after an exception is best-effort.
+            }
+        }
+    }
+
+    /**
+     * Positive counterpart to {@link #testFailFastOnAggregateInProgressBytesAcrossRegions}:
+     * verifies that a {@code setCommitAllowed} actually drains the manager's
+     * aggregate in-progress byte counter, so a second multi-region source
+     * transaction of the same size proceeds without tripping the aggregate
+     * fail-fast.
+     *
+     * <p>This pins down the release path (
+     * {@code TransactionTableRegion.releaseInProgressBytes} invoked from
+     * {@code tryMiniIntervalSwitch} on txnEnd). A regression that forgets to
+     * subtract the per-region in-progress bytes back to the manager aggregate
+     * would leave stale bytes in the counter: the second sweep's writes plus
+     * the stale 1st-sweep bytes would cross the write-block threshold and
+     * wrongly throw {@link IllegalStateException}.
+     *
+     * <p>The two sweeps are each sized so that, <em>individually</em>, they
+     * stay well below the 2 KB hard cap, but <em>together without the
+     * drain</em> they would cross it. Exact sizing: each sweep writes ~25
+     * rows (≈ 68 B/row) across three tables → ~1.7 KB of in-progress bytes.
+     * With drain: second sweep peaks at ~1.7 KB &lt; 2 KB → no exception.
+     * Without drain: combined ≈ 3.4 KB &gt; 2 KB → fail-fast fires on the
+     * second sweep.
+     */
+    @Test(timeout = 15000)
+    public void testCommitDrainsAggregateInProgressBytes() throws Exception {
+        StreamLoadProperties properties = buildMultiTableProperties(60000, 1024L);
+        StreamLoadManagerV2 manager = new StreamLoadManagerV2(properties, true);
+        manager.init();
+
+        try {
+            mockedServer.resetCounters();
+
+            String[] tables = {"orders", "items", "customers"};
+            final int rowsPerSweep = 25; // ~1.7 KB aggregate per sweep
+
+            // Sweep #1: round-robin three tables, then txnEnd. The txnEnd on
+            // partition 0 fans out to all regions and must drain their
+            // per-region inProgressTxnBytes back to the manager aggregate.
+            for (int i = 0; i < rowsPerSweep; i++) {
+                String table = tables[i % tables.length];
+                manager.write(0, "test", table,
+                        String.format(
+                                "{\"id\":%06d,\"customer_id\":%06d,\"notes\":\"pad-block-%04d\"}",
+                                i, i, i));
+            }
+            manager.setCommitAllowed(0, true);
+            Assert.assertNull("No exception after sweep #1 txnEnd",
+                    manager.getException());
+
+            // Sweep #2: same size and shape. If the drain worked, the
+            // aggregate counter started this sweep at (near) 0 and peaks at
+            // ~1.7 KB, comfortably under the 2 KB cap. If the drain silently
+            // regresses, the aggregate still carries sweep #1's ~1.7 KB, and
+            // sweep #2 would cross 2 KB partway through and throw.
+            for (int i = 0; i < rowsPerSweep; i++) {
+                String table = tables[i % tables.length];
+                manager.write(0, "test", table,
+                        String.format(
+                                "{\"id\":%06d,\"customer_id\":%06d,\"notes\":\"pad-block-%04d\"}",
+                                100 + i, 100 + i, 100 + i));
+            }
+            manager.setCommitAllowed(0, true);
+            Assert.assertNull("No exception after sweep #2 txnEnd — the "
+                            + "aggregate guard should not misfire after a clean txnEnd drain",
+                    manager.getException());
+
+            manager.flush();
+            Assert.assertNull("No exception after flush", manager.getException());
+
+            // Both sweeps must have produced at least one commit against the
+            // mocked server — otherwise we haven't actually exercised the
+            // drain path.
+            Assert.assertTrue(
+                    "Expected at least 1 commit after sweeps: " + mockedServer.getCommitCount(),
+                    mockedServer.getCommitCount() >= 1);
+        } finally {
+            manager.close();
+        }
+    }
 }

--- a/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/v2/StreamLoadManagerMultiTableTest.java
+++ b/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/v2/StreamLoadManagerMultiTableTest.java
@@ -1130,4 +1130,205 @@ public class StreamLoadManagerMultiTableTest {
             manager.close();
         }
     }
+
+    // -------------------------------------------------------------------------
+    // Item 11: Multi-table single-txn fail-fast / clean-boundary safe switch
+    // -------------------------------------------------------------------------
+
+    /**
+     * Builds multi-table properties with an explicit {@code buffer-size} so
+     * tests can drive the fail-fast / safe-switch thresholds with small,
+     * easy-to-reason-about values.
+     */
+    private StreamLoadProperties buildMultiTableProperties(int flushIntervalMs, long bufferSize) {
+        StreamLoadTableProperties tableProps = StreamLoadTableProperties.builder()
+                .database("test")
+                .table("orders")
+                .streamLoadDataFormat(StreamLoadDataFormat.JSON)
+                .maxBufferRows(100000)
+                .build();
+
+        return StreamLoadProperties.builder()
+                .loadUrls(mockedServer.getBaseUrl())
+                .username(USERNAME)
+                .password(PASSWORD)
+                .version("4.0.0")
+                .enableMultiTableTransaction()
+                .multiTableTransactionBufferSize(bufferSize)
+                .labelPrefix("test-mtxn-")
+                .defaultTableProperties(tableProps)
+                .expectDelayTime(flushIntervalMs)
+                .scanningFrequency(50)
+                .ioThreadCount(2)
+                .build();
+    }
+
+    /**
+     * Verifies the fail-fast on a single oversized in-progress transaction.
+     *
+     * <p>In multi-table mode, {@code TransactionTableRegion.write0} cannot
+     * switch activeChunk mid-transaction (doing so would split a source
+     * transaction across chunks and break atomicity under the shared label).
+     * If one source transaction alone grows past the write-block hard cap
+     * (2 &times; buffer size), {@code blockIfCacheFull} would deadlock the task
+     * thread because the manager has no inactiveChunks to drain. The region
+     * should instead throw {@link IllegalStateException} before the deadlock
+     * state is reachable.
+     *
+     * <p>This test uses a very small buffer (1KB &rarr; hard cap 2KB) and writes
+     * fixed-width 68-byte rows to a single partition without ever calling
+     * {@code setCommitAllowed}, simulating one huge source transaction. It
+     * expects an {@link IllegalStateException} with a clear remediation hint.
+     * A very large commit interval is used so the manager thread cannot
+     * independently drive a commit cycle.
+     */
+    @Test(timeout = 10000)
+    public void testFailFastOnOversizedSingleTransaction() throws Exception {
+        // 1 KB buffer → hard cap = 2 KB → safe switch threshold = 1 KB.
+        StreamLoadProperties properties = buildMultiTableProperties(60000, 1024L);
+        StreamLoadManagerV2 manager = new StreamLoadManagerV2(properties, true);
+        manager.init();
+
+        try {
+            IllegalStateException caught = null;
+            int rowsWritten = 0;
+            // Each row is a fixed 68-byte JSON document. Writing one row at a
+            // time to ONE partition without setCommitAllowed drives activeChunk
+            // past the 2 KB hard cap. The fail-fast in write0 fires on the row
+            // whose addition would push activeChunk past the cap: after 29
+            // rows chunkBytes = 69*29 + 1 = 2002, so the 30th row's estimate
+            // 2002 + 68 + 1 = 2071 > 2048 triggers the throw. This happens
+            // BEFORE blockIfCacheFull could block the task thread, because
+            // raw bytes after 29 rows = 29 * 68 = 1972 < 2048 hard cap.
+            try {
+                for (int i = 0; i < 200; i++) {
+                    manager.write(0, "test", "orders",
+                            String.format(
+                                    "{\"order_id\":%05d,\"customer_id\":%06d,\"notes\":\"padding-block-%04d\"}",
+                                    i, i, i));
+                    rowsWritten++;
+                }
+                Assert.fail("Expected IllegalStateException for oversized single txn, "
+                        + "but write() succeeded after " + rowsWritten + " rows");
+            } catch (IllegalStateException e) {
+                caught = e;
+            }
+
+            Assert.assertNotNull("Expected IllegalStateException for oversized single txn", caught);
+            Assert.assertTrue(
+                    "Error message should identify the region: " + caught.getMessage(),
+                    caught.getMessage().contains("db=test")
+                            && caught.getMessage().contains("table=orders"));
+            Assert.assertTrue(
+                    "Error message should mention the write-block threshold: " + caught.getMessage(),
+                    caught.getMessage().contains("write-block threshold"));
+            Assert.assertTrue(
+                    "Error message should suggest a remediation: " + caught.getMessage(),
+                    caught.getMessage().contains("buffer-size")
+                            || caught.getMessage().contains("buffer size"));
+            // Sanity: the fail-fast must fire reasonably close to the hard
+            // cap. At 68 bytes/row the cap is reached near row 30, so we
+            // shouldn't have written more than ~40 rows before the throw.
+            Assert.assertTrue(
+                    "Fail-fast should trigger near the hard-cap boundary, "
+                            + "but rowsWritten=" + rowsWritten,
+                    rowsWritten < 50);
+        } finally {
+            try {
+                manager.close();
+            } catch (Exception ignore) {
+                // close() after an exception is best-effort; underlying state
+                // is not guaranteed to be clean.
+            }
+        }
+    }
+
+    /**
+     * Verifies that the fail-fast on oversized single transaction does NOT
+     * misfire when multiple small source transactions are batched into one
+     * activeChunk because {@code miniInterval} has not yet elapsed.
+     *
+     * <p>Without the clean-boundary safe switch in {@code write0}, a sequence
+     * of modest-sized back-to-back source transactions — each individually
+     * well within the buffer — could accumulate in activeChunk past half the
+     * write-block hard cap, leaving no headroom for the next transaction.
+     * The next transaction's mid-stream writes would then wrongly trip the
+     * fail-fast even though neither of the involved source transactions is
+     * oversized.
+     *
+     * <p>With the safe switch, when a new source transaction's first write
+     * arrives and activeChunk is already at or above the soft threshold
+     * (half the hard cap), the region force-switches the accumulated
+     * completed transactions into inactiveChunks (overriding the miniInterval
+     * batching) so the new transaction gets a fresh activeChunk with full
+     * headroom.
+     *
+     * <p>Parameters (buffer=512B, commitInterval=10s → miniInterval=1000ms)
+     * ensure the tight write loop stays inside one miniInterval window. With
+     * 55-byte rows and 5 rows per txn, activeChunk reaches ~281B after Txn1,
+     * ~561B after Txn2, etc. Without the safe switch, Txn4 row 4's estimate
+     * (1065 B) would exceed the 1024 B hard cap and trip the fail-fast. With
+     * the safe switch, Txn3's first row (chunkBytes=561 ≥ 512) force-switches
+     * the accumulated Txn1+Txn2 data into inactiveChunks, giving Txn3+Txn4
+     * a fresh activeChunk and allowing all 5 txns to complete.
+     */
+    @Test(timeout = 15000)
+    public void testBatchedTransactionsDoNotFalseFailFast() throws Exception {
+        // 512 B buffer → hard cap = 1024 B → safe switch threshold = 512 B.
+        // 10 s commit interval → miniInterval = 1000 ms (commitInterval / 10,
+        // clamped to [100, 1000]). The tight write loop stays well within
+        // one miniInterval window so tryMiniIntervalSwitch MUST skip its
+        // switch — the clean-boundary safe switch in write0 is the only
+        // mechanism that can prevent activeChunk from growing past the cap.
+        StreamLoadProperties properties = buildMultiTableProperties(10000, 512L);
+        StreamLoadManagerV2 manager = new StreamLoadManagerV2(properties, true);
+        manager.init();
+
+        try {
+            mockedServer.resetCounters();
+
+            // 5 back-to-back source transactions on the same partition. Each
+            // writes 5 fixed-width 55-byte rows (chunkBytes grows by ~280 B
+            // per txn due to delimiters).
+            // - Txn #0 triggers the first switch unconditionally (initial
+            //   lastSwitchTimeMs = 0, so miniInterval is considered elapsed).
+            //   After Txn #0's switch, activeChunk is empty.
+            // - Txn #1..#4 fall inside the miniInterval window, so
+            //   tryMiniIntervalSwitch skips its switch, keeping activeChunk
+            //   growing across txn boundaries.
+            // - After Txn #2, activeChunk is ~561 B (> safe switch threshold
+            //   512), so write0's clean-boundary safe switch must fire on
+            //   the first row of Txn #3, draining Txn #1+#2 into
+            //   inactiveChunks. Without the safe switch, Txn #4's mid-stream
+            //   writes would push activeChunk past the 1024 B hard cap and
+            //   trip the fail-fast.
+            for (int txn = 0; txn < 5; txn++) {
+                for (int r = 0; r < 5; r++) {
+                    manager.write(0, "test", "orders",
+                            String.format(
+                                    "{\"order_id\":%05d,\"customer_id\":%05d,\"notes\":\"t%d-r%02d\"}",
+                                    txn * 100 + r, r * 10, txn, r));
+                }
+                manager.setCommitAllowed(0, true);
+            }
+
+            Assert.assertNull(
+                    "No exception expected — the clean-boundary safe switch should drain "
+                            + "batched completed transactions before the fail-fast would misfire",
+                    manager.getException());
+
+            manager.flush();
+            Assert.assertNull("No exception after flush", manager.getException());
+
+            // At least one HTTP load and commit must have happened — proves
+            // the batched transactions were actually drained rather than
+            // accumulating indefinitely in activeChunk.
+            Assert.assertTrue("Expected at least 1 load call for batched txns",
+                    mockedServer.getLoadCount() >= 1);
+            Assert.assertTrue("Expected at least 1 commit for batched txns",
+                    mockedServer.getCommitCount() >= 1);
+        } finally {
+            manager.close();
+        }
+    }
 }

--- a/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/v2/StreamLoadManagerMultiTableTest.java
+++ b/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/v2/StreamLoadManagerMultiTableTest.java
@@ -853,6 +853,11 @@ public class StreamLoadManagerMultiTableTest {
             // Write a row so the manager opens a shared transaction
             manager.write(0, "test", "orders", "{\"order_id\":1}");
 
+            // Signal txnEnd so partition 0 is no longer ACTIVE.
+            // Without this, recycling would detect an active partition and fail
+            // (by design, to protect cross-table atomicity).
+            manager.setCommitAllowed(0, true);
+
             // Wait longer than sharedTxnMaxIdleMs (800ms) for recycling to occur.
             // The recycling is checked each scanningFrequency (50ms), so after ~900ms
             // the transaction should have been recycled at least once.

--- a/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/v2/StreamLoadManagerMultiTableTest.java
+++ b/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/v2/StreamLoadManagerMultiTableTest.java
@@ -73,6 +73,28 @@ public class StreamLoadManagerMultiTableTest {
     }
 
     /**
+     * Multi-table mode is fundamentally incompatible with SDK manual-commit
+     * mode (enableAutoCommit=false). The manager's timer-driven path
+     * autonomously drives shared-transaction commits once commitIntervalMs
+     * has elapsed, which would publish data before an external 2PC caller's
+     * explicit snapshot/commit step. The constructor must reject this
+     * combination up front instead of silently auto-publishing.
+     */
+    @Test
+    public void testConstructorRejectsMultiTableWithManualCommit() {
+        StreamLoadProperties properties = buildMultiTableProperties(100);
+        try {
+            new DefaultStreamLoadManager(properties, false);
+            Assert.fail("Expected IllegalArgumentException for multi-table + manual commit");
+        } catch (IllegalArgumentException e) {
+            Assert.assertTrue(
+                    "Error should mention multi-table and enableAutoCommit: " + e.getMessage(),
+                    e.getMessage().contains("Multi-table transaction mode")
+                            && e.getMessage().contains("enableAutoCommit"));
+        }
+    }
+
+    /**
      * Single partition: write data to two tables, send txnEnd, verify commit.
      * Verifies that the shared transaction coordinator is used (1 begin, 1 prepare, 1 commit).
      */

--- a/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/v2/StreamLoadManagerMultiTableTest.java
+++ b/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/v2/StreamLoadManagerMultiTableTest.java
@@ -977,4 +977,157 @@ public class StreamLoadManagerMultiTableTest {
             manager.close();
         }
     }
+
+    // -------------------------------------------------------------------------
+    // miniInterval batching and source-idle fallback tests
+    // -------------------------------------------------------------------------
+
+    /**
+     * Verifies that multiple rapid txnEnds within a single miniInterval window
+     * are batched into a single switchChunk, so only one HTTP /transaction/load
+     * request is issued instead of one per txnEnd.
+     *
+     * <p>With commitInterval=2000ms, miniSwitchIntervalMs = min(1000, max(100,
+     * 2000/10)) = 200ms. A burst of 10 txnEnds issued within ~50ms should all
+     * land on the same activeChunk: the first txnEnd triggers the first switch
+     * (lastSwitchTimeMs starts at 0, so "now - 0 >> 200" → switch immediately),
+     * and all subsequent txnEnds within the next 200ms are batched into the new
+     * activeChunk without producing additional switches. The final commit
+     * observes roughly 1-2 HTTP loads rather than 10.
+     */
+    @Test
+    public void testMiniIntervalBatching() throws Exception {
+        // commitInterval=2000ms → miniInterval=200ms
+        StreamLoadProperties properties = buildMultiTableProperties(2000);
+        StreamLoadManagerV2 manager = new StreamLoadManagerV2(properties, true);
+        manager.init();
+
+        try {
+            mockedServer.resetCounters();
+
+            // Issue 10 rapid write+txnEnd cycles. The first txnEnd triggers a
+            // switch (freezing the single row from the first write); the next 9
+            // all fall within miniInterval=200ms of the first switch and must
+            // NOT produce additional switches — they accumulate into the new
+            // activeChunk.
+            for (int i = 0; i < 10; i++) {
+                manager.write(0, "test", "orders",
+                        String.format("{\"order_id\":%d,\"customer_id\":%d}", i, i * 10));
+                manager.setCommitAllowed(0, true);
+            }
+
+            // Wait for the commit interval (2000ms) to elapse and the manager
+            // thread to drain everything. The total elapsed time from the first
+            // write through this sleep must be >= commitInterval so that
+            // shouldTriggerCommit() fires.
+            Thread.sleep(2500);
+            Assert.assertNull("No exception during batching test", manager.getException());
+
+            manager.flush();
+            Assert.assertNull("No exception after flush", manager.getException());
+
+            // The critical assertion: load count must be substantially less
+            // than 10 (the number of txnEnds). With miniInterval batching, we
+            // expect 1-3 loads total (one per chunk that was actually switched,
+            // plus possibly one from the final savepoint/flush force-switch).
+            //
+            // Without batching (the old "switch every txnEnd" behavior), we
+            // would see ~10 loads. So loadCount <= 5 is a conservative check
+            // that catches regression while tolerating timing variance.
+            int loadCount = mockedServer.getLoadCount();
+            Assert.assertTrue(
+                    "Expected loadCount <= 5 with miniInterval batching, got " + loadCount +
+                    " (would be ~10 without batching)",
+                    loadCount <= 5);
+            // Still expect at least one load and one commit — data must actually flow.
+            Assert.assertTrue("Expected at least 1 load", loadCount >= 1);
+            Assert.assertTrue("Expected at least 1 commit", mockedServer.getCommitCount() >= 1);
+        } finally {
+            manager.close();
+        }
+    }
+
+    /**
+     * Verifies the manager-thread clean-boundary fallback: when the source
+     * pauses after a txnEnd whose switch was skipped by miniInterval batching,
+     * the manager thread's periodic tryForceCleanSwitch() must eventually
+     * freeze the pending activeChunk data so it becomes committable.
+     *
+     * <p>Scenario:
+     * <pre>
+     *   T=0:     write + txnEnd (1st) → switchChunkForCommit, lastSwitchTime=0
+     *   T=50ms:  write + txnEnd (2nd) → miniInterval (200ms) NOT elapsed, SKIP
+     *            activeChunk now holds txn2 data; cleanBoundary = true
+     *   T=50ms+: source goes idle (no more writes/txnEnds)
+     *   T=~250ms: manager scan notices cleanBoundary=true AND miniInterval has
+     *            elapsed → force-switch → txn2 data moves to inactiveChunks
+     *   T=2000ms+: commit interval elapsed + hasDataLoaded → commit
+     * </pre>
+     *
+     * <p>Without the fallback, txn2's data would sit in activeChunk indefinitely
+     * and only the first txnEnd's data would commit, leading to incomplete data
+     * visibility and eventual shared-transaction timeout. The test asserts that
+     * all data committed via exactly one commit cycle.
+     */
+    @Test
+    public void testSourceIdleForceSwitchFallback() throws Exception {
+        // commitInterval=2000ms → miniInterval=200ms
+        StreamLoadProperties properties = buildMultiTableProperties(2000);
+        StreamLoadManagerV2 manager = new StreamLoadManagerV2(properties, true);
+        manager.init();
+
+        try {
+            mockedServer.resetCounters();
+
+            // 1st write + txnEnd: triggers the very first switchChunkForCommit
+            // (lastSwitchTimeMs = 0 initially, so "now - 0" is huge >> miniInterval).
+            manager.write(0, "test", "orders", "{\"order_id\":1}");
+            manager.setCommitAllowed(0, true);
+
+            // Small pause — still well within miniInterval of 200ms.
+            Thread.sleep(50);
+
+            // 2nd write + txnEnd: miniInterval (200ms) has NOT yet elapsed
+            // since the 1st switch, so tryMiniIntervalSwitch() on the task
+            // thread must NOT freeze activeChunk. The data stays in
+            // activeChunk with cleanBoundary = true (because the most recent
+            // task-thread event was a txnEnd).
+            manager.write(0, "test", "orders", "{\"order_id\":2}");
+            manager.setCommitAllowed(0, true);
+
+            // Record the load count BEFORE the source goes idle. It reflects
+            // only the first chunk that was switched (possibly still in-flight).
+            int loadsBeforeIdle = mockedServer.getLoadCount();
+
+            // Now simulate source pause. The manager thread must on its own
+            // observe that activeChunk is clean AND miniInterval has elapsed,
+            // and call tryForceCleanSwitch() to freeze the pending row. Then
+            // shouldTriggerCommit() must eventually fire (after the full
+            // commitInterval=2000ms from the last commit time) and drive a
+            // commit cycle.
+            Thread.sleep(3000);
+
+            Assert.assertNull("No exception during source idle", manager.getException());
+
+            // By now, BOTH rows must have been loaded: the first switched by
+            // the task thread, the second by the manager-thread fallback.
+            // Without the fallback, loadCount would remain at loadsBeforeIdle.
+            int loadsAfterIdle = mockedServer.getLoadCount();
+            Assert.assertTrue(
+                    "Expected manager-thread fallback to force-switch and load " +
+                    "the second row (loadsBefore=" + loadsBeforeIdle +
+                    ", loadsAfter=" + loadsAfterIdle + ")",
+                    loadsAfterIdle > loadsBeforeIdle || loadsAfterIdle >= 2);
+
+            // And a commit must have happened — otherwise the data is just
+            // sitting in an uncommitted shared transaction.
+            Assert.assertTrue("Expected at least 1 commit after idle fallback",
+                    mockedServer.getCommitCount() >= 1);
+
+            manager.flush();
+            Assert.assertNull("No exception after flush", manager.getException());
+        } finally {
+            manager.close();
+        }
+    }
 }


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
- Add WriteMultipleTablesWithTransaction.java example with TransactionAssembler (KeyedProcessFunction) for Kafka transaction assembly
- Introduce DefaultStarRocksRowData for dynamic multi-table routing (database-name=*, table-name=*)
- Extend StarRocksRowData interface with isTransactionEnd() for txn boundary control
- Use SinkFunctionFactory.createSinkFunction() for standard Flink SinkFunction
- Add per-table StreamLoadTableProperties configuration support
- Add docs (EN/CN) for multi-table transaction stream load usage
- Add MultiTableTransactionITTest and StreamLoadManagerMultiTableTest
- Enhance StreamLoader, TransactionStreamLoader, StreamLoadManagerV2 for multi-table txn
- Replace non-compilable TxnBatch/writeBatch design with Flink DataStream API patterns

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

