### PR TITLE
[Chore] Improve flink-connector-release skill: release-note groups, docs version check, README

### DIFF
--- a/.claude/skills/flink-connector-release/SKILL.md
+++ b/.claude/skills/flink-connector-release/SKILL.md
@@ -49,7 +49,7 @@ immediately if any stage fails — later stages depend on earlier ones having pa
 ```
 cd .claude/skills/flink-connector-release          # from the repo root
 scripts/00_preflight.sh               # environment readiness check (read-only, changes nothing)
-scripts/01_tag.sh         1.2.15      # checks repo/tag state, sets srfc.version=1.2.15, commits the de-SNAPSHOT + tags v1.2.15 (no push)
+scripts/01_tag.sh         1.2.15      # checks repo/tag state + docs Version-requirements row, sets srfc.version=1.2.15, commits the de-SNAPSHOT + tags v1.2.15 (no push)
 scripts/02_install_sdk.sh 1.2.15      # checkout the tag; install the stream-load SDK FROM the tag
 scripts/03_build_verify.sh            # build each version via build.sh + STRICTLY verify; NO deploy
 git push origin v1.2.15               # push the tag ONLY after 03 passes
@@ -61,7 +61,11 @@ scripts/06_upload_release.sh RELEASE_NOTES.md   # upload your notes + jars as a 
 Why this order matters:
 
 - **01 before 02/03**: the tag must point at the de-SNAPSHOT commit so the jars' version
-  numbers and embedded git fingerprints reflect the release commit.
+  numbers and embedded git fingerprints reflect the release commit. 01 also checks that `main`'s
+  user docs (`docs/content/connector-sink.md` and `connector-source.md`) already list this release
+  in their **Version requirements** table — a forgotten doc bump is caught here, while it is still
+  cheap to fix. A missing row is not fatal: confirm interactively (or set `CONFIRM_DOCS_VERSION=<version>`
+  non-interactively) to release anyway.
 - **02 before 03**: the connector shades the SDK into its jar. Installing the SDK from the tag
   (stage 02) plus re-checking the bundled SDK's commit in every built jar (stage 03) guarantees
   the *tag's* SDK is what ships, not a stale remote `1.1-SNAPSHOT` with a different commit.
@@ -82,11 +86,15 @@ Why this order matters:
 **Writing the notes is not scripted** — you (the agent running this) compose them from the template;
 stage 06 only uploads them. Copy [`assets/release-note-template.md`](assets/release-note-template.md)
 to a file (e.g. `RELEASE_NOTES.md`) and fill it in: `## What's Changed` grouped into **Features** /
-**Enhancements** / **BugFix** — one line per PR, `- <desc> [#NNN](pr-url)`; the repo's
-`[Feature]` / `[Enhancement]` / `[BugFix]` commit-subject prefixes map straight to these groups —
-then **## Contributors** (PR authors as `[handle](profile-url)`). Use the previous release as a
-reference, e.g. [v1.2.14](https://github.com/StarRocks/starrocks-connector-for-apache-flink/releases/tag/v1.2.14).
-List the merged PRs with `git log --first-parent --pretty='%s' <prev-tag>..v<version>`.
+**Enhancements** / **BugFix** / **Doc** / **Tool** / **Other** — one line per PR, `- <desc> [#NNN](pr-url)`;
+the repo's commit-subject prefixes map to these groups as `[Feature]`→Features, `[Enhancement]`→Enhancements,
+`[BugFix]`→BugFix, `[Doc]`→Doc, `[Chore]` (release/CI/skill tooling)→Tool, and anything else (or no
+recognizable prefix)→Other — then **## Contributors** (PR authors as `[handle](profile-url)`). Cover
+**every** merged PR; only the version-bump and the `[Release]` commit itself are dropped. Omit any group
+that ends up empty. List the merged PRs with `git log --first-parent --pretty='%s' <prev-tag>..v<version>`,
+then **show the full PR list with its included/excluded group mapping and confirm the grouping with the
+user before creating the draft.** Use the previous release as a reference, e.g.
+[v1.2.15](https://github.com/StarRocks/starrocks-connector-for-apache-flink/releases/tag/v1.2.15).
 
 Then **upload** with `scripts/06_upload_release.sh`, which only does the upload: it downloads the
 published per-version jars (versions read from the repo) and creates a **draft** release with your
@@ -126,6 +134,9 @@ Any failure makes it exit non-zero with a clear `DO NOT DEPLOY` message.
 - Treat every script's non-zero exit as a hard stop; surface its output to the user.
 - Never edit a published artifact or suggest "re-deploying to fix" — explain that Central is
   immutable and the fix is a new version.
+- `scripts/01_tag.sh` warns (and stops) if `main`'s docs do not list the release in their
+  **Version requirements** table. Surface this to the user; only continue if they confirm the doc
+  bump is intentionally skipped — interactively, or by setting `CONFIRM_DOCS_VERSION=<version>`.
 - `scripts/04_deploy.sh` is outward-facing and irreversible. Do not bypass its confirmation;
   if running non-interactively, the user must explicitly set `CONFIRM_DEPLOY=<version>`.
 - `scripts/06_upload_release.sh` only creates a **draft** GitHub release — never publish it; a

--- a/.claude/skills/flink-connector-release/SKILL.md
+++ b/.claude/skills/flink-connector-release/SKILL.md
@@ -88,8 +88,8 @@ stage 06 only uploads them. Copy [`assets/release-note-template.md`](assets/rele
 to a file (e.g. `RELEASE_NOTES.md`) and fill it in: `## What's Changed` grouped into **Features** /
 **Enhancements** / **BugFix** / **Doc** / **Tool** / **Other** — one line per PR, `- <desc> [#NNN](pr-url)`;
 the repo's commit-subject prefixes map to these groups as `[Feature]`→Features, `[Enhancement]`→Enhancements,
-`[BugFix]`→BugFix, `[Doc]`→Doc, `[Chore]` (release/CI/skill tooling)→Tool, and anything else (or no
-recognizable prefix)→Other — then **## Contributors** (PR authors as `[handle](profile-url)`). Cover
+`[BugFix]`→BugFix, `[Doc]`→Doc, `[Tool]` / `[Chore]` (build/CI/release/skill tooling)→Tool, and anything
+else (or no recognizable prefix)→Other — then **## Contributors** (PR authors as `[handle](profile-url)`). Cover
 **every** merged PR; only the version-bump and the `[Release]` commit itself are dropped. Omit any group
 that ends up empty. List the merged PRs with `git log --first-parent --pretty='%s' <prev-tag>..v<version>`,
 then **show the full PR list with its included/excluded group mapping and confirm the grouping with the

--- a/.claude/skills/flink-connector-release/assets/release-note-template.md
+++ b/.claude/skills/flink-connector-release/assets/release-note-template.md
@@ -9,5 +9,14 @@
 **BugFix**
 - <short description> [#<PR>](https://github.com/StarRocks/starrocks-connector-for-apache-flink/pull/<PR>)
 
+**Doc**
+- <short description> [#<PR>](https://github.com/StarRocks/starrocks-connector-for-apache-flink/pull/<PR>)
+
+**Tool**
+- <short description> [#<PR>](https://github.com/StarRocks/starrocks-connector-for-apache-flink/pull/<PR>)
+
+**Other**
+- <short description> [#<PR>](https://github.com/StarRocks/starrocks-connector-for-apache-flink/pull/<PR>)
+
 ## Contributors
 [<handle>](https://github.com/<handle>), [<handle>](https://github.com/<handle>)

--- a/.claude/skills/flink-connector-release/references/release-guide.md
+++ b/.claude/skills/flink-connector-release/references/release-guide.md
@@ -68,7 +68,9 @@ scripts that carry out each step, see `SKILL.md` next to this guide.
 ## The release process
 
 1. **Tag.** Create a release tag, based on the latest `main`, pointing at a commit that has the
-   `-SNAPSHOT` removed from the project version.
+   `-SNAPSHOT` removed from the project version. Before tagging, make sure `main`'s user docs
+   (`docs/content/connector-sink.md` and `connector-source.md`) already list this release in their
+   **Version requirements** table; if not, add the row (or consciously decide to skip it) first.
 2. **Install the SDK from the tag.** Check out the tag, then install the stream-load SDK locally from
    it, so the connector bundles this release's SDK rather than a stale remote one:
 

--- a/.claude/skills/flink-connector-release/scripts/01_tag.sh
+++ b/.claude/skills/flink-connector-release/scripts/01_tag.sh
@@ -37,6 +37,11 @@ srfc="$(pom_srfc_version "$REPO_ROOT")"
 [ -n "$srfc" ] || die "could not read <srfc.version> from pom.xml on origin/main"
 info "pom srfc.version on origin/main is '$srfc'; releasing as '$VERSION'"
 
+# The user docs on main should already list this release in their "Version requirements" table.
+# Check it now (the tree here == origin/main), while a missing row is still cheap to fix. Not a hard
+# error: confirm to proceed, or set CONFIRM_DOCS_VERSION=$VERSION when running non-interactively.
+check_docs_version "$REPO_ROOT" "$VERSION"
+
 # The pom must currently be a -SNAPSHOT; if not, something is off.
 pom_is_snapshot "$REPO_ROOT" \
   || die "the project <version> in pom.xml is not a -SNAPSHOT on origin/main — unexpected; inspect the <version>\${srfc.version}_flink-... line"

--- a/.claude/skills/flink-connector-release/scripts/lib.sh
+++ b/.claude/skills/flink-connector-release/scripts/lib.sh
@@ -67,7 +67,7 @@ check_docs_version() {
   for f in "${DOCS_VERSION_FILES[@]}"; do
     path="$root/$f"
     if [ ! -f "$path" ]; then
-      warn "doc not found: $f — skipping its Version requirements check"; continue
+      warn "doc not found: $f — treating as a missing version row"; missing+=("$f"); continue
     fi
     if awk -v v="$version" -F'|' '
         /^##[[:space:]]+Version requirements/ { inblk=1; next }

--- a/.claude/skills/flink-connector-release/scripts/lib.sh
+++ b/.claude/skills/flink-connector-release/scripts/lib.sh
@@ -50,6 +50,57 @@ pom_is_snapshot() {
   grep -qE '<version>\$\{srfc.version\}_flink-\$\{flink.minor.version\}-SNAPSHOT</version>' "$1/pom.xml"
 }
 
+# The user docs that carry a per-release "Version requirements" table row.
+DOCS_VERSION_FILES=(docs/content/connector-sink.md docs/content/connector-source.md)
+
+# Assert the user docs' "Version requirements" table lists <version>. Each connector release adds a
+# row to these tables; forgetting it ships a release the docs never mention. 01_tag.sh runs this
+# against the release branch's tree (== origin/main at that point), while everything is still
+# reversible. A missing row is NOT a hard error — a maintainer may intentionally skip the doc bump —
+# so we require explicit confirmation (interactive y/N, or CONFIRM_DOCS_VERSION=<version> when
+# non-interactive) and otherwise continue. The match field-splits each table row on "|" and compares
+# the trimmed first data cell to <version> exactly (so a version mentioned in prose, or a longer
+# version sharing the prefix, does not count), and only inside the "## Version requirements" section.
+check_docs_version() {
+  local root="$1" version="$2" f path ans
+  local -a missing=()
+  for f in "${DOCS_VERSION_FILES[@]}"; do
+    path="$root/$f"
+    if [ ! -f "$path" ]; then
+      warn "doc not found: $f — skipping its Version requirements check"; continue
+    fi
+    if awk -v v="$version" -F'|' '
+        /^##[[:space:]]+Version requirements/ { inblk=1; next }
+        inblk && /^##[[:space:]]/            { inblk=0 }
+        inblk && $1=="" && NF>=2 {
+          cell=$2; gsub(/^[[:space:]]+|[[:space:]]+$/, "", cell)
+          if (cell==v) found=1
+        }
+        END { exit found ? 0 : 1 }
+      ' "$path"; then
+      pass "docs: $f Version requirements lists $version"
+    else
+      missing+=("$f")
+    fi
+  done
+
+  [ "${#missing[@]}" -eq 0 ] && return 0
+
+  warn "Version requirements table does NOT list $version in: ${missing[*]}"
+  warn "Usually you add a '$version' row to these tables on main first (e.g. a '[Doc] Add doc for $version' PR) before releasing."
+  if [ -t 0 ]; then
+    printf 'Release %s anyway, without the docs version row? [y/N] ' "$version"; read -r ans
+    case "$ans" in
+      y|Y) warn "proceeding without the docs version row for $version (confirmed)";;
+      *)   die "aborted — add the $version row to the Version requirements table on main, then re-run";;
+    esac
+  else
+    [ "${CONFIRM_DOCS_VERSION:-}" = "$version" ] \
+      || die "non-interactive: docs missing the $version row — add it on main, or set CONFIRM_DOCS_VERSION=$version to release anyway"
+    warn "proceeding without the docs version row for $version (CONFIRM_DOCS_VERSION set)"
+  fi
+}
+
 # Assert HEAD is exactly the release tag v<version> — not merely some clean, de-SNAPSHOTed checkout.
 # git-commit-id stamps HEAD into every jar, and 03's marker is written from HEAD too; so without this
 # a branch that advanced past v<version> (or any other de-SNAPSHOT commit) could pass 03/04 and

--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ For the new features in the snapshot version of the Flink connector, please see 
 * [Read from StarRocks](docs/content/connector-source.md)
 * [Write to StarRocks](docs/content/connector-sink.md)
 
+## Release
+
+Maintainers cut releases to Maven Central with the `flink-connector-release` skill in
+[`.claude/skills/flink-connector-release`](.claude/skills/flink-connector-release/SKILL.md). It wraps
+the repo's `build.sh`/`deploy.sh` with strict per-step verification before the irreversible publish.
+See [`references/release-guide.md`](.claude/skills/flink-connector-release/references/release-guide.md)
+for the full procedure and background.
+
 ## LICENSE
 
 The connector is under the [Apache License 2.0](LICENSE.txt).


### PR DESCRIPTION
## What's Changed

Improvements to the `flink-connector-release` skill, distilled from cutting the 1.2.15 release.

**Release notes (`assets/release-note-template.md`, `SKILL.md`)**
- Add **Doc** / **Tool** / **Other** groups to the template, beyond Features / Enhancements / BugFix.
- Document the commit-prefix → group mapping: `[Feature]`→Features, `[Enhancement]`→Enhancements, `[BugFix]`→BugFix, `[Doc]`→Doc, `[Chore]` (release/CI/skill tooling)→Tool, anything else→Other.
- Instruct the agent to cover **every** merged PR (only the version-bump and `[Release]` commit are dropped), omit empty groups, and confirm the full PR→group mapping with the user **before** creating the draft.

**Pre-release docs check (`scripts/lib.sh`, `scripts/01_tag.sh`)**
- New `check_docs_version()` verifies that `main`'s user docs (`docs/content/connector-sink.md` and `connector-source.md`) list the release in their **Version requirements** table.
- Runs in `01_tag.sh` right after the release branch is cut from `origin/main` (so it checks `main`'s docs, while everything is still reversible).
- A missing row is **non-fatal**: it warns and stops for explicit confirmation — interactive `y/N`, or `CONFIRM_DOCS_VERSION=<version>` when non-interactive.
- Matching is robust: it field-splits each table row on `|` and exact-matches the trimmed first cell, only inside the `## Version requirements` section.

**README (`README.md`)**
- Add a `## Release` section pointing maintainers to the skill and the release guide.

## Testing
- `bash -n` passes on `lib.sh` and `01_tag.sh`.
- `check_docs_version` verified against the real docs: present versions (`1.2.15`, `1.2.14`) → PASS; absent (`1.2.99`) → ABORT without confirmation, and continues with `CONFIRM_DOCS_VERSION` set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)