### PR TITLE
[Chore] Release skill: always require user confirmation for a missing docs version row

### DIFF
--- a/.claude/skills/flink-connector-release/SKILL.md
+++ b/.claude/skills/flink-connector-release/SKILL.md
@@ -64,8 +64,9 @@ Why this order matters:
   numbers and embedded git fingerprints reflect the release commit. 01 also checks that `main`'s
   user docs (`docs/content/connector-sink.md` and `connector-source.md`) already list this release
   in their **Version requirements** table — a forgotten doc bump is caught here, while it is still
-  cheap to fix. A missing row is not fatal: confirm interactively (or set `CONFIRM_DOCS_VERSION=<version>`
-  non-interactively) to release anyway.
+  cheap to fix. A missing row is not fatal, but it **always requires the user's explicit
+  confirmation before you continue** — for every version, RC / pre-release included. Stop and ask
+  the user; never self-confirm it. See "Notes for the agent running this" for exactly how.
 - **02 before 03**: the connector shades the SDK into its jar. Installing the SDK from the tag
   (stage 02) plus re-checking the bundled SDK's commit in every built jar (stage 03) guarantees
   the *tag's* SDK is what ships, not a stale remote `1.1-SNAPSHOT` with a different commit.
@@ -134,9 +135,17 @@ Any failure makes it exit non-zero with a clear `DO NOT DEPLOY` message.
 - Treat every script's non-zero exit as a hard stop; surface its output to the user.
 - Never edit a published artifact or suggest "re-deploying to fix" — explain that Central is
   immutable and the fix is a new version.
-- `scripts/01_tag.sh` warns (and stops) if `main`'s docs do not list the release in their
-  **Version requirements** table. Surface this to the user; only continue if they confirm the doc
-  bump is intentionally skipped — interactively, or by setting `CONFIRM_DOCS_VERSION=<version>`.
+- **A missing docs Version-requirements row ALWAYS requires the user's explicit confirmation — no
+  exceptions.** `scripts/01_tag.sh` stops when `main`'s docs (`connector-sink.md` /
+  `connector-source.md`) do not list the release. When that happens you MUST stop and ask the
+  *user* (use AskUserQuestion) whether to release without the docs row, then wait for their answer.
+  Only set `CONFIRM_DOCS_VERSION=<version>` to relay a "yes" the user actually gave — it is a
+  channel for *their* decision, not a switch you flip yourself. This holds for **every** version,
+  RC / pre-release included: "RCs skip the docs row by convention", "it's obviously intentional",
+  and "the user already said 发版 / release" are NOT substitutes for asking. Deciding it on your own
+  judgment — or telling the user about the skip only after the fact — is a violation. (The user
+  may, of course, pre-authorize skipping it in the same breath as the release request; a clear
+  "release X even though the docs row is missing" counts as the confirmation.)
 - `scripts/04_deploy.sh` is outward-facing and irreversible. Do not bypass its confirmation;
   if running non-interactively, the user must explicitly set `CONFIRM_DEPLOY=<version>`.
 - `scripts/06_upload_release.sh` only creates a **draft** GitHub release — never publish it; a

--- a/.claude/skills/flink-connector-release/scripts/lib.sh
+++ b/.claude/skills/flink-connector-release/scripts/lib.sh
@@ -57,8 +57,10 @@ DOCS_VERSION_FILES=(docs/content/connector-sink.md docs/content/connector-source
 # row to these tables; forgetting it ships a release the docs never mention. 01_tag.sh runs this
 # against the release branch's tree (== origin/main at that point), while everything is still
 # reversible. A missing row is NOT a hard error — a maintainer may intentionally skip the doc bump —
-# so we require explicit confirmation (interactive y/N, or CONFIRM_DOCS_VERSION=<version> when
-# non-interactive) and otherwise continue. The match field-splits each table row on "|" and compares
+# but it ALWAYS requires the user's explicit confirmation, for every version (RC included): interactive
+# y/N, or CONFIRM_DOCS_VERSION=<version> when non-interactive. That env var is a channel for relaying a
+# confirmation the *user* gave; the agent must not set it on its own judgment (see SKILL.md). Otherwise
+# the script aborts. The match field-splits each table row on "|" and compares
 # the trimmed first data cell to <version> exactly (so a version mentioned in prose, or a longer
 # version sharing the prefix, does not count), and only inside the "## Version requirements" section.
 check_docs_version() {
@@ -96,7 +98,7 @@ check_docs_version() {
     esac
   else
     [ "${CONFIRM_DOCS_VERSION:-}" = "$version" ] \
-      || die "non-interactive: docs missing the $version row — add it on main, or set CONFIRM_DOCS_VERSION=$version to release anyway"
+      || die "non-interactive: docs missing the $version row — ASK THE USER whether to release without it. Only if they say yes, set CONFIRM_DOCS_VERSION=$version (it relays THEIR decision; do not set it on your own judgment). Otherwise add the row on main first."
     warn "proceeding without the docs version row for $version (CONFIRM_DOCS_VERSION set)"
   fi
 }


### PR DESCRIPTION
## What & why

The `flink-connector-release` skill's docs-version gate could be silently bypassed by the agent itself. When `01_tag.sh` finds that `main`'s **Version requirements** tables (`docs/content/connector-sink.md` / `connector-source.md`) don't list the release being cut, the old guidance let the agent "surface to the user **or** set `CONFIRM_DOCS_VERSION`". In practice an agent reads the env var as a self-service alternative and skips the human — e.g. rationalizing "RC versions don't get a docs row by convention" — confirming nothing with the user.

This change makes a missing docs row **always require the user's explicit confirmation**, for every version (RC / pre-release included):

- `SKILL.md`: the agent MUST stop and ask the user (AskUserQuestion) and may only set `CONFIRM_DOCS_VERSION` to relay a "yes" the user actually gave. The specific rationalizations that are NOT substitutes for asking are listed inline.
- `scripts/lib.sh`: the non-interactive abort message and the `check_docs_version` comment now state the same contract.

No script logic changes — `CONFIRM_DOCS_VERSION` remains the non-interactive confirmation channel; what changes is the documented contract around *who* decides.

## Testing

Verified with fresh subagents (TDD-for-skills, RED → GREEN → pressure):
- **Baseline (old text):** the agent self-set `CONFIRM_DOCS_VERSION` for an RC and never asked.
- **With the fix:** the agent stops and asks via AskUserQuestion, refusing to self-confirm.
- **Under stacked pressure** (time pressure + sunk cost + RC convention): still asks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)