### PR TITLE
[BugFix] Fix query plan visitor shared state race

### DIFF
--- a/src/main/java/com/starrocks/connector/flink/manager/StarRocksQueryPlanVisitor.java
+++ b/src/main/java/com/starrocks/connector/flink/manager/StarRocksQueryPlanVisitor.java
@@ -49,13 +49,9 @@ public class StarRocksQueryPlanVisitor implements Serializable {
 
     private static final long serialVersionUID = 1L;
     private static final Logger LOG = LoggerFactory.getLogger(StarRocksQueryPlanVisitor.class);
-    private StarRocksSourceOptions sourceOptions;
+    private final StarRocksSourceOptions sourceOptions;
 
     public StarRocksQueryPlanVisitor(StarRocksSourceOptions sourceOptions) {
-        this.sourceOptions = sourceOptions;
-    }
-
-    public void setSourceOptions(StarRocksSourceOptions sourceOptions) {
         this.sourceOptions = sourceOptions;
     }
 

--- a/src/main/java/com/starrocks/connector/flink/manager/StarRocksQueryVisitor.java
+++ b/src/main/java/com/starrocks/connector/flink/manager/StarRocksQueryVisitor.java
@@ -95,28 +95,29 @@ public class StarRocksQueryVisitor implements Serializable {
     }
 
     private List<Map<String, Object>> executeQuery(String query, String... args) throws ClassNotFoundException, SQLException {
-        PreparedStatement stmt = jdbcConnProvider.getConnection().prepareStatement(query, ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY);
-        for (int i = 0; i < args.length; i++) {
-            stmt.setString(i + 1, args[i]);
-        }
-        ResultSet rs = stmt.executeQuery();
-        rs.next();
-        ResultSetMetaData meta = rs.getMetaData();
-        int columns = meta.getColumnCount();
-        List<Map<String, Object>> list = new ArrayList<>();
-        int currRowIndex = rs.getRow();
-        rs.beforeFirst();
-        while (rs.next()) {
-            Map<String, Object> row = new HashMap<>(columns);
-            for (int i = 1; i <= columns; ++i) {
-                row.put(meta.getColumnName(i), rs.getObject(i));
+        try (PreparedStatement stmt = jdbcConnProvider.getConnection()
+                .prepareStatement(query, ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY)) {
+            for (int i = 0; i < args.length; i++) {
+                stmt.setString(i + 1, args[i]);
             }
-            list.add(row);
+            try (ResultSet rs = stmt.executeQuery()) {
+                rs.next();
+                ResultSetMetaData meta = rs.getMetaData();
+                int columns = meta.getColumnCount();
+                List<Map<String, Object>> list = new ArrayList<>();
+                rs.beforeFirst();
+                while (rs.next()) {
+                    Map<String, Object> row = new HashMap<>(columns);
+                    for (int i = 1; i <= columns; ++i) {
+                        row.put(meta.getColumnName(i), rs.getObject(i));
+                    }
+                    list.add(row);
+                }
+                return list;
+            }
+        } finally {
+            jdbcConnProvider.close();
         }
-        rs.absolute(currRowIndex);
-        rs.close();
-        jdbcConnProvider.close();
-        return list;
     }
 
     public Long getQueryCount(String SQL) {

--- a/src/main/java/com/starrocks/connector/flink/table/source/StarRocksSourceCommonFunc.java
+++ b/src/main/java/com/starrocks/connector/flink/table/source/StarRocksSourceCommonFunc.java
@@ -40,9 +40,6 @@ public class StarRocksSourceCommonFunc {
     
     private static volatile StarRocksQueryVisitor starrocksQueryVisitor;
 
-    private static volatile StarRocksQueryPlanVisitor starRocksQueryPlanVisitor;
-    
-
     private static StarRocksQueryVisitor getStarRocksQueryVisitor(StarRocksSourceOptions sourceOptions) {
         if (null == starrocksQueryVisitor) {
             synchronized(StarRocksSourceCommonFunc.class) {
@@ -59,18 +56,6 @@ public class StarRocksSourceCommonFunc {
             }
         }
         return starrocksQueryVisitor;
-    }
-
-    private static StarRocksQueryPlanVisitor getStarRocksQueryPlanVisitor(StarRocksSourceOptions sourceOptions) {
-        if (null == starRocksQueryPlanVisitor) {
-            synchronized(StarRocksSourceCommonFunc.class) {
-                if (null == starRocksQueryPlanVisitor) {
-                    starRocksQueryPlanVisitor = new StarRocksQueryPlanVisitor(sourceOptions);
-                }
-            }
-        }
-        starRocksQueryPlanVisitor.setSourceOptions(sourceOptions);
-        return starRocksQueryPlanVisitor;
     }
 
     public static List<List<QueryBeXTablets>> splitQueryBeXTablets(int subTaskCount, QueryInfo queryInfo) {
@@ -200,7 +185,7 @@ public class StarRocksSourceCommonFunc {
     }
 
     public static QueryInfo getQueryInfo(StarRocksSourceOptions sourceOptions, String SQL) {
-        StarRocksQueryPlanVisitor starRocksQueryPlanVisitor = getStarRocksQueryPlanVisitor(sourceOptions);
+        StarRocksQueryPlanVisitor starRocksQueryPlanVisitor = new StarRocksQueryPlanVisitor(sourceOptions);
         QueryInfo queryInfo = null;
         try {
             queryInfo = starRocksQueryPlanVisitor.getQueryInfo(SQL);

--- a/src/main/java/com/starrocks/connector/flink/table/source/StarRocksSourceCommonFunc.java
+++ b/src/main/java/com/starrocks/connector/flink/table/source/StarRocksSourceCommonFunc.java
@@ -37,26 +37,6 @@ import java.util.stream.Collectors;
 
 
 public class StarRocksSourceCommonFunc {
-    
-    private static volatile StarRocksQueryVisitor starrocksQueryVisitor;
-
-    private static StarRocksQueryVisitor getStarRocksQueryVisitor(StarRocksSourceOptions sourceOptions) {
-        if (null == starrocksQueryVisitor) {
-            synchronized(StarRocksSourceCommonFunc.class) {
-                if (null == starrocksQueryVisitor) {
-                    StarRocksJdbcConnectionOptions jdbcOptions = new StarRocksJdbcConnectionOptions(
-                        sourceOptions.getJdbcUrl(), sourceOptions.getUsername(), sourceOptions.getPassword()
-                    );
-                    StarRocksJdbcConnectionProvider jdbcConnProvider;
-                    jdbcConnProvider = new StarRocksJdbcConnectionProvider(jdbcOptions);
-                    starrocksQueryVisitor = new StarRocksQueryVisitor(
-                        jdbcConnProvider, sourceOptions.getDatabaseName(), sourceOptions.getTableName()
-                    );
-                }
-            }
-        }
-        return starrocksQueryVisitor;
-    }
 
     public static List<List<QueryBeXTablets>> splitQueryBeXTablets(int subTaskCount, QueryInfo queryInfo) {
         List<List<QueryBeXTablets>> curBeXTabletList = new ArrayList<>();
@@ -140,7 +120,13 @@ public class StarRocksSourceCommonFunc {
 
 
     public static Long getQueryCount(StarRocksSourceOptions sourceOptions, String SQL) {
-        StarRocksQueryVisitor starrocksQueryVisitor = getStarRocksQueryVisitor(sourceOptions);
+        StarRocksJdbcConnectionOptions jdbcOptions = new StarRocksJdbcConnectionOptions(
+            sourceOptions.getJdbcUrl(), sourceOptions.getUsername(), sourceOptions.getPassword()
+        );
+        StarRocksJdbcConnectionProvider jdbcConnProvider = new StarRocksJdbcConnectionProvider(jdbcOptions);
+        StarRocksQueryVisitor starrocksQueryVisitor = new StarRocksQueryVisitor(
+            jdbcConnProvider, sourceOptions.getDatabaseName(), sourceOptions.getTableName()
+        );
         return starrocksQueryVisitor.getQueryCount(SQL);
     }
 

--- a/src/test/java/com/starrocks/connector/flink/manager/source/StarRocksQueryPlanVisitorTest.java
+++ b/src/test/java/com/starrocks/connector/flink/manager/source/StarRocksQueryPlanVisitorTest.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import com.alibaba.fastjson.JSONObject;
 import com.starrocks.connector.flink.it.source.StarRocksSourceBaseTest;
 import com.starrocks.connector.flink.manager.StarRocksQueryPlanVisitor;
+import com.starrocks.connector.flink.manager.StarRocksQueryVisitor;
 import com.starrocks.connector.flink.table.source.StarRocksSourceCommonFunc;
 import com.starrocks.connector.flink.table.source.struct.QueryInfo;
 
@@ -65,11 +66,16 @@ public class StarRocksQueryPlanVisitorTest extends StarRocksSourceBaseTest {
     }
 
     @Test
-    public void testQueryPlanVisitorDoesNotShareMutableSourceOptions() throws NoSuchFieldException {
+    public void testSourceCommonFuncDoesNotShareVisitors() throws NoSuchFieldException {
         boolean hasSharedQueryPlanVisitor = Arrays.stream(StarRocksSourceCommonFunc.class.getDeclaredFields())
                 .anyMatch(field -> Modifier.isStatic(field.getModifiers())
                         && field.getType().equals(StarRocksQueryPlanVisitor.class));
         assertFalse(hasSharedQueryPlanVisitor);
+
+        boolean hasSharedQueryVisitor = Arrays.stream(StarRocksSourceCommonFunc.class.getDeclaredFields())
+                .anyMatch(field -> Modifier.isStatic(field.getModifiers())
+                        && field.getType().equals(StarRocksQueryVisitor.class));
+        assertFalse(hasSharedQueryVisitor);
 
         Field sourceOptions = StarRocksQueryPlanVisitor.class.getDeclaredField("sourceOptions");
         assertTrue(Modifier.isFinal(sourceOptions.getModifiers()));

--- a/src/test/java/com/starrocks/connector/flink/manager/source/StarRocksQueryPlanVisitorTest.java
+++ b/src/test/java/com/starrocks/connector/flink/manager/source/StarRocksQueryPlanVisitorTest.java
@@ -20,10 +20,14 @@
 
 package com.starrocks.connector.flink.manager.source;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -32,6 +36,7 @@ import java.util.Map;
 import com.alibaba.fastjson.JSONObject;
 import com.starrocks.connector.flink.it.source.StarRocksSourceBaseTest;
 import com.starrocks.connector.flink.manager.StarRocksQueryPlanVisitor;
+import com.starrocks.connector.flink.table.source.StarRocksSourceCommonFunc;
 import com.starrocks.connector.flink.table.source.struct.QueryInfo;
 
 import org.junit.Test;
@@ -57,5 +62,18 @@ public class StarRocksQueryPlanVisitorTest extends StarRocksSourceBaseTest {
         for (int i = 0; i < tabletCount; i ++) {
             assertTrue(i == tabletsList.get(i));
         }
+    }
+
+    @Test
+    public void testQueryPlanVisitorDoesNotShareMutableSourceOptions() throws NoSuchFieldException {
+        boolean hasSharedQueryPlanVisitor = Arrays.stream(StarRocksSourceCommonFunc.class.getDeclaredFields())
+                .anyMatch(field -> Modifier.isStatic(field.getModifiers())
+                        && field.getType().equals(StarRocksQueryPlanVisitor.class));
+        assertFalse(hasSharedQueryPlanVisitor);
+
+        Field sourceOptions = StarRocksQueryPlanVisitor.class.getDeclaredField("sourceOptions");
+        assertTrue(Modifier.isFinal(sourceOptions.getModifiers()));
+        assertFalse(Arrays.stream(StarRocksQueryPlanVisitor.class.getDeclaredMethods())
+                .anyMatch(method -> method.getName().equals("setSourceOptions")));
     }
 }


### PR DESCRIPTION
## What type of PR is this：
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
Remove the static shared StarRocksQueryPlanVisitor from StarRocksSourceCommonFunc and create a visitor per getQueryInfo call. Make the visitor sourceOptions final and drop setSourceOptions to prevent concurrent lookup cache refreshes from mixing URL table metadata with SQL from another table.

Add a regression test to guard against reintroducing a shared mutable query plan visitor.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

