### PR TITLE
[BugFix] Multi-table txn: reconcile flushQ region labels to the live shared label

### DIFF
--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/DefaultStreamLoader.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/DefaultStreamLoader.java
@@ -287,6 +287,20 @@ public class DefaultStreamLoader implements StreamLoader, Serializable {
             String sendUrl = getSendUrl(host, region.getDatabase(), region.getTable());
             String label = region.getLabel();
 
+            // Multi-table safety net: the region's shared label may have been cleared by
+            // a concurrent commit/recycle/savepoint on the manager thread between the flush
+            // decision and this point. Never send a null label to the FE — it fails fatally
+            // with "Empty label". Abort this load WITHOUT failing the region: release
+            // FLUSHING so the manager reconciles the label and re-triggers; the chunk is
+            // preserved. (In single-table mode begin() always mints a label first, so this
+            // branch is not reached there.)
+            if (label == null && properties.isEnableMultiTableTransaction()) {
+                log.warn("Skipping stream load with null shared label, db: {}, table: {}; the region " +
+                        "will be retried after the manager reconciles its label", region.getDatabase(), region.getTable());
+                region.exitFlushing();
+                return null;
+            }
+
             HttpPut httpPut = new HttpPut(sendUrl);
             httpPut.setConfig(RequestConfig.custom()
                         .setSocketTimeout(properties.getSocketTimeout())

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/DefaultStreamLoader.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/DefaultStreamLoader.java
@@ -160,7 +160,7 @@ public class DefaultStreamLoader implements StreamLoader, Serializable {
         if (begin(region)) {
             return executorService.submit(() -> sendToSR(region));
         } else {
-            region.fail(new StreamLoadFailException("Transaction start failed, db : " + region.getDatabase()));
+            onBeginRefused(region);
         }
 
         return null;
@@ -174,10 +174,20 @@ public class DefaultStreamLoader implements StreamLoader, Serializable {
         if (begin(region)) {
             return executorService.schedule(() -> sendToSR(region), delayMs, TimeUnit.MILLISECONDS);
         } else {
-            region.fail(new StreamLoadFailException("Transaction start failed, db : " + region.getDatabase()));
+            onBeginRefused(region);
         }
 
         return null;
+    }
+
+    /**
+     * Invoked when {@link #begin(TableRegion)} declined to start a transaction for the region.
+     * The default treats it as a hard failure. Subclasses may override to defer the load
+     * instead of failing it, in which case they must leave the region recoverable — {@code send()}
+     * still returns {@code null} so the caller can release its flushing state and retry later.
+     */
+    protected void onBeginRefused(TableRegion region) {
+        region.fail(new StreamLoadFailException("Transaction start failed, db : " + region.getDatabase()));
     }
 
     @Override

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/TableRegion.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/TableRegion.java
@@ -68,6 +68,15 @@ public interface TableRegion {
     boolean isReadable();
     boolean isFlushing();
 
+    /**
+     * Releases the FLUSHING state (and any per-table load gate) without consuming the
+     * pending chunk or recording success/failure, so the region becomes eligible for a
+     * fresh load attempt. Used by the loader as a safety net to defer — rather than fail
+     * — a multi-table load that would otherwise send a null shared label to the FE.
+     * Default no-op for region types that do not model a FLUSHING state.
+     */
+    default void exitFlushing() {}
+
     default HttpEntity getHttpEntity() {
         return new StreamLoadEntity(this, getProperties().getDataFormat(), getEntityMeta());
     }

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/TransactionStreamLoader.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/TransactionStreamLoader.java
@@ -116,6 +116,19 @@ public class TransactionStreamLoader extends DefaultStreamLoader {
     @Override
     public boolean begin(TableRegion region) {
         if (region.getLabel() == null) {
+            // Multi-table transaction mode: a region must only ever load under the
+            // coordinator's injected shared label. A null label here means the shared
+            // label was not yet injected or was cleared concurrently by the manager
+            // thread; minting an independent label would open an orphan single-table
+            // transaction and split a source transaction across labels (breaking
+            // cross-table atomicity). Refuse the load — the caller (streamLoad) releases
+            // FLUSHING so the manager reconciles the shared label and re-triggers.
+            if (properties.isEnableMultiTableTransaction()) {
+                log.warn("Refusing to begin an independent transaction for a multi-table region with a " +
+                        "null shared label, db: {}, table: {}; awaiting manager reconcile",
+                        region.getDatabase(), region.getTable());
+                return false;
+            }
             region.setLabel(region.getLabelGenerator().next());
             if (doBegin(region)) {
                 return true;

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/TransactionStreamLoader.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/TransactionStreamLoader.java
@@ -141,6 +141,25 @@ public class TransactionStreamLoader extends DefaultStreamLoader {
     }
 
     @Override
+    protected void onBeginRefused(TableRegion region) {
+        // Distinguish the multi-table null-label deferral above from a genuine begin()
+        // failure. The two are mutually exclusive: the doBegin() failure path in begin()
+        // is only reachable when multi-table transactions are disabled.
+        //
+        // Failing the region here would be terminal, not a retry: in multi-table mode
+        // TransactionTableRegion.fail() only treats TXN_IN_PROCESSING as retryable, so a
+        // synthetic "Transaction start failed" reaches manager.callback() and aborts the
+        // job — defeating the very race this guard exists to survive. Return quietly
+        // instead; send() still yields null, and the caller releases FLUSHING without
+        // consuming the chunk so the manager's reconcile pass restores the shared label
+        // and re-triggers the load.
+        if (properties.isEnableMultiTableTransaction() && region.getLabel() == null) {
+            return;
+        }
+        super.onBeginRefused(region);
+    }
+
+    @Override
     public boolean beginTransaction(String label, String database) {
         return doBegin(label, database, null);
     }

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/DefaultStreamLoadManager.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/DefaultStreamLoadManager.java
@@ -590,6 +590,19 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
                             }
                         }
 
+                        // Reconcile any flushQ region that is not carrying the current
+                        // shared label while a shared transaction is active. A region
+                        // first-created in the commit-reopen gap can read isActive()==false
+                        // (keeping a null label) and then have its flushQ.offer land after
+                        // ensureSharedTransaction's weakly-consistent inject loop, so it is
+                        // missed by injection. The !isActive() re-injection above is dormant
+                        // while a txn is active, and nothing else re-validates a region's
+                        // label before selection — an un-injected region would flush under a
+                        // minted independent (orphan) label, splitting a source transaction
+                        // across labels. Repair it here, on the manager thread, before
+                        // flush/commit selection.
+                        reconcileFlushQueueLabels();
+
                         // In multi-table mode, first give the manager-thread
                         // fallback a chance to force-switch any region whose
                         // activeChunk is at a clean transaction boundary and has
@@ -1261,6 +1274,51 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
         LOG.info("[MultiTxn] Eagerly opened shared transaction: label={}",
                 txnCoordinator.getSharedLabel());
         return true;
+    }
+
+    /**
+     * Reconciles every {@code flushQ} region to the coordinator's current shared
+     * label while a shared transaction is active. Runs on the manager thread right
+     * before flush/commit selection.
+     *
+     * <p>Region creation ({@link #getCacheRegion}) injects the shared label only when
+     * it observes {@code isActive()} true (:1876/:1886), and {@link #ensureSharedTransaction}
+     * re-injects only when NO txn is active (the {@code if (!isActive())} guard in the
+     * scan loop). A region first-created in the narrow window between a commit's
+     * {@code commitInFlight.set(false)} and the eager reopen's
+     * {@link SharedTransactionCoordinator#begin} publish reads {@code isActive()==false},
+     * so it keeps a null label; if its {@code flushQ.offer} then lands after the reopen's
+     * weakly-consistent {@code ConcurrentLinkedQueue} inject loop has passed the tail, it
+     * is never given the shared label. With a txn active thereafter, nothing re-validates
+     * it, and its first autonomous flush would mint an independent (orphan) transaction via
+     * {@link com.starrocks.data.load.stream.TransactionStreamLoader#begin} (which mints a
+     * fresh label when {@code getLabel()==null}), splitting a source transaction across
+     * labels and breaking cross-table atomicity. This pass closes that gap.
+     *
+     * <p>Uses {@link TransactionTableRegion#trySetLabel}: a region mid-retry
+     * ({@code numRetries > 0}) keeps its own in-flight label (trySetLabel returns false)
+     * and is reconciled on a later scan once the retry settles — it cannot start a new
+     * flush meanwhile (its {@code tryEnterFlushing} is blocked). Skips regions of a
+     * different database, mirroring the single-database guard in {@link #getCacheRegion}.
+     */
+    private void reconcileFlushQueueLabels() {
+        if (!multiTableTransactionEnabled || txnCoordinator == null || !txnCoordinator.isActive()) {
+            return;
+        }
+        String shared = txnCoordinator.getSharedLabel();
+        if (shared == null) {
+            return;
+        }
+        String txnDb = txnCoordinator.getDatabase();
+        for (TransactionTableRegion region : flushQ) {
+            if (shared.equals(region.getLabel())) {
+                continue;
+            }
+            if (txnDb != null && !txnDb.equals(region.getDatabase())) {
+                continue;
+            }
+            region.trySetLabel(shared);
+        }
     }
 
     /**

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/DefaultStreamLoadManager.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/DefaultStreamLoadManager.java
@@ -590,17 +590,12 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
                             }
                         }
 
-                        // Reconcile any flushQ region that is not carrying the current
-                        // shared label while a shared transaction is active. A region
-                        // first-created in the commit-reopen gap can read isActive()==false
-                        // (keeping a null label) and then have its flushQ.offer land after
-                        // ensureSharedTransaction's weakly-consistent inject loop, so it is
-                        // missed by injection. The !isActive() re-injection above is dormant
-                        // while a txn is active, and nothing else re-validates a region's
-                        // label before selection — an un-injected region would flush under a
-                        // minted independent (orphan) label, splitting a source transaction
-                        // across labels. Repair it here, on the manager thread, before
-                        // flush/commit selection.
+                        // Best-effort pass keeping flushQ region labels aligned with the
+                        // live shared label (a region can slip in without it — see
+                        // reconcileRegionLabel). The authoritative repair is done per-region
+                        // immediately before region.flush() in the selection loop below, so
+                        // it is atomic with selection; this pass just keeps not-yet-selected
+                        // regions consistent (and avoids churn).
                         reconcileFlushQueueLabels();
 
                         // In multi-table mode, first give the manager-thread
@@ -633,6 +628,13 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
 
                         for (FlushAndCommitStrategy.SelectFlushResult result : flushAndCommitStrategy.selectFlushRegions(flushQ, currentCacheBytes.get())) {
                             TransactionTableRegion region = result.getRegion();
+                            // Authoritative label repair, atomic with selection: a region
+                            // that slipped into flushQ without the current shared label (see
+                            // reconcileRegionLabel) must never flush under a null/stale label
+                            // and mint an orphan transaction. Checking here — for the exact
+                            // region about to flush, on the manager thread — closes the window
+                            // where a concurrently-enqueued region bypasses the flushQ pass.
+                            reconcileRegionLabel(region);
                             boolean flush = region.flush(result.getReason());
                             if (flush && multiTableTransactionEnabled && txnCoordinator != null) {
                                 txnCoordinator.markDataLoaded();
@@ -1277,48 +1279,64 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
     }
 
     /**
-     * Reconciles every {@code flushQ} region to the coordinator's current shared
-     * label while a shared transaction is active. Runs on the manager thread right
-     * before flush/commit selection.
-     *
-     * <p>Region creation ({@link #getCacheRegion}) injects the shared label only when
-     * it observes {@code isActive()} true (:1876/:1886), and {@link #ensureSharedTransaction}
-     * re-injects only when NO txn is active (the {@code if (!isActive())} guard in the
-     * scan loop). A region first-created in the narrow window between a commit's
-     * {@code commitInFlight.set(false)} and the eager reopen's
-     * {@link SharedTransactionCoordinator#begin} publish reads {@code isActive()==false},
-     * so it keeps a null label; if its {@code flushQ.offer} then lands after the reopen's
-     * weakly-consistent {@code ConcurrentLinkedQueue} inject loop has passed the tail, it
-     * is never given the shared label. With a txn active thereafter, nothing re-validates
-     * it, and its first autonomous flush would mint an independent (orphan) transaction via
-     * {@link com.starrocks.data.load.stream.TransactionStreamLoader#begin} (which mints a
-     * fresh label when {@code getLabel()==null}), splitting a source transaction across
-     * labels and breaking cross-table atomicity. This pass closes that gap.
-     *
-     * <p>Uses {@link TransactionTableRegion#trySetLabel}: a region mid-retry
-     * ({@code numRetries > 0}) keeps its own in-flight label (trySetLabel returns false)
-     * and is reconciled on a later scan once the retry settles — it cannot start a new
-     * flush meanwhile (its {@code tryEnterFlushing} is blocked). Skips regions of a
-     * different database, mirroring the single-database guard in {@link #getCacheRegion}.
+     * Best-effort pass reconciling every {@code flushQ} region to the coordinator's
+     * current shared label while a shared transaction is active. Runs on the manager
+     * thread each scan; the authoritative check is {@link #reconcileRegionLabel} invoked
+     * immediately before {@code region.flush()} in the selection loop, which makes the
+     * repair atomic with flush selection so a region enqueued concurrently cannot bypass
+     * it. See {@link #reconcileRegionLabel} for why the repair is needed.
      */
     private void reconcileFlushQueueLabels() {
         if (!multiTableTransactionEnabled || txnCoordinator == null || !txnCoordinator.isActive()) {
             return;
         }
+        for (TransactionTableRegion region : flushQ) {
+            reconcileRegionLabel(region);
+        }
+    }
+
+    /**
+     * Ensures a single region carries the coordinator's live shared label before it is
+     * flushed. No-op unless multi-table mode has an active shared transaction and the
+     * region's label differs.
+     *
+     * <p>A region first-created for a new (db,table) in the window between a commit's
+     * {@code commitInFlight.set(false)} and the eager reopen's shared-label publish reads
+     * {@code isActive()==false}, so {@link #getCacheRegion} skips label injection and the
+     * region keeps a null label; if its {@code flushQ.offer} then lands after
+     * {@link #ensureSharedTransaction}'s weakly-consistent {@code ConcurrentLinkedQueue}
+     * inject loop has passed, it is never given the shared label. The scan-loop
+     * re-injection only runs when NO txn is active, so once a txn is active nothing else
+     * re-validates the label. Left unrepaired, the region's first flush would mint an
+     * independent (orphan) transaction via
+     * {@link com.starrocks.data.load.stream.TransactionStreamLoader#begin} (which mints a
+     * fresh label when {@code getLabel()==null}), splitting a source transaction across
+     * labels and breaking cross-table atomicity. Calling this immediately before
+     * {@code region.flush()} makes the check atomic with flush selection.
+     *
+     * <p>Skips a region that is flushing or retrying: it holds an in-flight label of its
+     * own, so changing it mid-flight would be wrong (matching {@link #ensureSharedTransaction}'s
+     * {@code isFlushing()/isRetrying()} skip), and it cannot start a new flush meanwhile.
+     * Skips regions of a different database, mirroring the single-database guard in
+     * {@link #getCacheRegion}. The label-equality fast path avoids the
+     * {@link TransactionTableRegion#trySetLabel} WARN on the common already-aligned case.
+     */
+    private void reconcileRegionLabel(TransactionTableRegion region) {
+        if (!multiTableTransactionEnabled || txnCoordinator == null) {
+            return;
+        }
         String shared = txnCoordinator.getSharedLabel();
-        if (shared == null) {
+        if (shared == null || shared.equals(region.getLabel())) {
+            return;
+        }
+        if (region.isFlushing() || region.isRetrying()) {
             return;
         }
         String txnDb = txnCoordinator.getDatabase();
-        for (TransactionTableRegion region : flushQ) {
-            if (shared.equals(region.getLabel())) {
-                continue;
-            }
-            if (txnDb != null && !txnDb.equals(region.getDatabase())) {
-                continue;
-            }
-            region.trySetLabel(shared);
+        if (txnDb != null && !txnDb.equals(region.getDatabase())) {
+            return;
         }
+        region.trySetLabel(shared);
     }
 
     /**

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/DefaultStreamLoadManager.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/DefaultStreamLoadManager.java
@@ -444,6 +444,11 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
                             boolean allLoadsDone = false;
                             while (!allLoadsDone && this.e == null) {
                                 for (TransactionTableRegion region : flushQ) {
+                                    // Reconcile the shared label before draining: this drain
+                                    // path (unlike the autonomous flush-selection loop) would
+                                    // otherwise load a region that missed label injection under
+                                    // a null/stale label. No-op when already aligned.
+                                    reconcileRegionLabel(region);
                                     if (region.triggerLoadIfNeeded()) {
                                         txnCoordinator.markDataLoaded();
                                     }
@@ -1009,6 +1014,10 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
             // and the txnEnd marker).
             boolean triggeredNew = false;
             for (TransactionTableRegion region : regionSnapshot) {
+                // Reconcile before draining, mirroring the autonomous flush-selection
+                // guard: a region that missed label injection must not be loaded under a
+                // null/stale label from this drain path. No-op when already aligned.
+                reconcileRegionLabel(region);
                 if (region.triggerLoadIfNeeded()) {
                     txnCoordinator.markDataLoaded();
                     triggeredNew = true;
@@ -1462,6 +1471,10 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
         long recycleWaitStartMs = System.currentTimeMillis();
         while (true) {
             for (TransactionTableRegion region : recycleRegions) {
+                // Reconcile before draining, mirroring the autonomous flush-selection
+                // guard: a region that missed label injection must not be loaded under a
+                // null/stale label from this drain path. No-op when already aligned.
+                reconcileRegionLabel(region);
                 if (region.triggerLoadIfNeeded()) {
                     txnCoordinator.markDataLoaded();
                 }

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/TransactionTableRegion.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/TransactionTableRegion.java
@@ -539,8 +539,9 @@ public class TransactionTableRegion implements TableRegion {
         return false;
     }
 
-    /** Transitions FLUSHING -> ACTIVE and releases the table gate (if held). */
-    private void exitFlushing() {
+    /** Transitions the region from FLUSHING back to ACTIVE and releases the table gate (if held). */
+    @Override
+    public void exitFlushing() {
         state.compareAndSet(State.FLUSHING, State.ACTIVE);
         AtomicBoolean gate = tableLoadGate;
         if (gate != null) {
@@ -993,9 +994,32 @@ public class TransactionTableRegion implements TableRegion {
                 exitFlushing();
                 return;
             }
+            // Multi-table safety net: never load under a null shared label. A region's
+            // label can be transiently null — a first write to a new (db,table) that
+            // missed ensureSharedTransaction()'s weakly-consistent injection, or a label
+            // just cleared by a concurrent commit/recycle/savepoint on the manager thread.
+            // Loading now would either mint an independent orphan label (via begin()) or
+            // send a null label to the FE (a fatal "Empty label" error). Defer instead:
+            // release FLUSHING (and the table gate) WITHOUT consuming the chunk, so the
+            // manager's per-scan reconcile restores the live shared label and re-triggers
+            // this load. Self-healing; never orphan-splits a source transaction.
+            if (multiTableTransactionEnabled && label == null) {
+                LOG.warn("[MultiTxn] Deferring load for db: {}, table: {}: region has no shared label yet "
+                        + "(awaiting manager reconcile); inactiveChunks={}", database, table, inactiveChunks.size());
+                exitFlushing();
+                return;
+            }
             LOG.debug("Stream load chunk, db: {}, table: {}, numRows: {}, rowBytes: {}, chunkBytes: {}",
                     database, table, chunk.numRows(), chunk.rowBytes(), chunk.chunkBytes());
             responseFuture = streamLoader.send(this, delayMs);
+            if (multiTableTransactionEnabled && responseFuture == null) {
+                // The loader refused the send (e.g. begin() observed a null shared label
+                // in the microsecond window after the check above). Release FLUSHING so
+                // the manager reconciles and re-triggers; the chunk is preserved for retry.
+                LOG.warn("[MultiTxn] Loader refused send for db: {}, table: {} (null shared label); "
+                        + "will retry after reconcile", database, table);
+                exitFlushing();
+            }
         } catch (Exception e) {
             // Do NOT reset state to ACTIVE here. fail() may schedule a retry
             // via streamLoad(retryIntervalInMs); while that retry is pending

--- a/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/MultiTableNullLabelLoadGuardTest.java
+++ b/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/MultiTableNullLabelLoadGuardTest.java
@@ -1,0 +1,225 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.starrocks.data.load.stream;
+
+import com.starrocks.data.load.stream.http.StreamLoadEntityMeta;
+import com.starrocks.data.load.stream.properties.StreamLoadProperties;
+import com.starrocks.data.load.stream.properties.StreamLoadTableProperties;
+import org.apache.http.HttpEntity;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Regression for the multi-table "Empty label" / orphan-transaction hazard (2026-07).
+ *
+ * <p>A multi-table region's shared label can be transiently {@code null}: a first write to
+ * a new (db,table) that missed {@code ensureSharedTransaction()}'s weakly-consistent label
+ * injection, or a label just cleared by a concurrent commit/recycle/savepoint on the manager
+ * thread. If such a region reaches the loader, two distinct failures are possible, both fatal
+ * to cross-table atomicity:
+ *
+ * <ol>
+ *   <li><b>Orphan mint</b>: {@link TransactionStreamLoader#begin} historically minted a fresh
+ *       independent label for a null-label region and opened a single-table transaction,
+ *       splitting a source transaction across labels.</li>
+ *   <li><b>Empty label</b>: {@link DefaultStreamLoader#sendToSR} reads the label a second time
+ *       and would send a literal {@code null} label to the FE, which rejects it fatally with
+ *       {@code {Status:FAILED, Message: Empty label}} and fails the whole job.</li>
+ * </ol>
+ *
+ * <p>The fix makes the load path treat a null shared label as a transient, recoverable state
+ * in multi-table mode: {@code begin()} refuses (never mints), and {@code sendToSR()} aborts
+ * WITHOUT sending, releasing FLUSHING so the manager reconciles the shared label and retries.
+ *
+ * <p>These tests are deterministic (no timing/race dependence): they drive the loader entry
+ * points directly with a null-label region. RED on the pre-fix code (begin mints; sendToSR
+ * builds and sends an entity), GREEN with the fix.
+ */
+public class MultiTableNullLabelLoadGuardTest {
+
+    private static final String USERNAME = "root";
+    private static final String PASSWORD = "";
+
+    private MockedStarRocksHttpServer mockedServer;
+
+    @Before
+    public void setUp() throws Exception {
+        mockedServer = MockedStarRocksHttpServer.builder()
+                .port(0)
+                .enforceAuth(USERNAME, PASSWORD)
+                .build();
+        mockedServer.start();
+    }
+
+    @After
+    public void tearDown() {
+        if (mockedServer != null) {
+            mockedServer.stop();
+        }
+    }
+
+    private StreamLoadProperties multiTableProperties() {
+        StreamLoadTableProperties tableProps = StreamLoadTableProperties.builder()
+                .database("test")
+                .table("orders")
+                .streamLoadDataFormat(StreamLoadDataFormat.JSON)
+                .maxBufferRows(100000)
+                .build();
+        return StreamLoadProperties.builder()
+                .loadUrls(mockedServer.getBaseUrl())
+                .username(USERNAME)
+                .password(PASSWORD)
+                .version("4.0.0")
+                .enableMultiTableTransaction()
+                .maxRetries(3)
+                .retryIntervalInMs(2000)
+                .labelPrefix("test-nl-")
+                .defaultTableProperties(tableProps)
+                .expectDelayTime(60000)
+                .scanningFrequency(50)
+                .ioThreadCount(2)
+                .build();
+    }
+
+    /** No-op manager: the loader only needs it for callbacks, which these tests do not exercise. */
+    private static StreamLoadManager noopManager() {
+        return new StreamLoadManager() {
+            @Override public void init() {}
+            @Override public void write(String uniqueKey, String database, String table, String... rows) {}
+            @Override public void callback(StreamLoadResponse response) {}
+            @Override public void callback(Throwable e) {}
+            @Override public void flush() {}
+            @Override public StreamLoadSnapshot snapshot() { return null; }
+            @Override public boolean prepare(StreamLoadSnapshot snapshot) { return true; }
+            @Override public boolean commit(StreamLoadSnapshot snapshot) { return true; }
+            @Override public boolean abort(StreamLoadSnapshot snapshot) { return true; }
+            @Override public void close() {}
+        };
+    }
+
+    /**
+     * Minimal {@link TableRegion} whose label is externally controllable and that records
+     * whether the loader tried to build an HTTP entity ({@code getHttpEntity}) or release
+     * FLUSHING ({@code exitFlushing}). {@code getLabelGenerator()} throws so an accidental
+     * orphan-mint attempt is caught loudly.
+     */
+    private static final class StubRegion implements TableRegion {
+        private volatile String label;
+        final AtomicBoolean httpEntityRequested = new AtomicBoolean(false);
+        final AtomicBoolean exitFlushingCalled = new AtomicBoolean(false);
+
+        StubRegion(String label) {
+            this.label = label;
+        }
+
+        @Override public StreamLoadTableProperties getProperties() { return null; }
+        @Override public String getUniqueKey() { return "P0-test.orders"; }
+        @Override public String getDatabase() { return "test"; }
+        @Override public String getTable() { return "orders"; }
+        @Override public LabelGenerator getLabelGenerator() {
+            throw new AssertionError("getLabelGenerator() must not be called: a multi-table region "
+                    + "with a null label must never mint an independent (orphan) label");
+        }
+        @Override public void setLabel(String label) { this.label = label; }
+        @Override public String getLabel() { return label; }
+        @Override public long getCacheBytes() { return 0; }
+        @Override public long getFlushBytes() { return 0; }
+        @Override public StreamLoadEntityMeta getEntityMeta() { return null; }
+        @Override public long getLastWriteTimeMillis() { return 0; }
+        @Override public void resetAge() {}
+        @Override public long getAndIncrementAge() { return 0; }
+        @Override public long getAge() { return 0; }
+        @Override public int write(byte[] row) { return 0; }
+        @Override public byte[] read() { return null; }
+        @Override public boolean testPrepare() { return false; }
+        @Override public boolean prepare() { return false; }
+        @Override public boolean flush() { return false; }
+        @Override public boolean cancel() { return false; }
+        @Override public void callback(StreamLoadResponse response) {}
+        @Override public void fail(Throwable e) {}
+        @Override public void complete(StreamLoadResponse response) {}
+        @Override public void setResult(Future<?> result) {}
+        @Override public Future<?> getResult() { return null; }
+        @Override public boolean isReadable() { return false; }
+        @Override public boolean isFlushing() { return true; }
+        @Override public void exitFlushing() { exitFlushingCalled.set(true); }
+        @Override public HttpEntity getHttpEntity() {
+            httpEntityRequested.set(true);
+            // Reached only if the null-label short-circuit is absent (i.e. the bug):
+            // signal it as a load failure so sendToSR returns without contacting a server.
+            throw new RuntimeException("sendToSR built an HTTP entity for a null-label region; "
+                    + "a null label must never be sent to the FE");
+        }
+    }
+
+    /**
+     * {@code begin()} must NOT mint an independent label for a null-label region in
+     * multi-table mode (that opens an orphan transaction and breaks cross-table atomicity);
+     * it refuses so the caller defers and the manager reconciles the shared label.
+     * A region already carrying the shared label passes through unchanged.
+     */
+    @Test
+    public void testBeginRefusesNullLabelInMultiTableMode() {
+        TransactionStreamLoader loader = new TransactionStreamLoader(true);
+        loader.start(multiTableProperties(), noopManager());
+        try {
+            StubRegion nullLabel = new StubRegion(null);
+            boolean began = loader.begin(nullLabel);
+            Assert.assertFalse("multi-table begin() must refuse a null shared label (no orphan mint)", began);
+            Assert.assertNull("begin() must NOT mint an independent label in multi-table mode",
+                    nullLabel.getLabel());
+
+            // A region that already carries the shared label passes through with no re-begin.
+            StubRegion labeled = new StubRegion("shared-label-1");
+            Assert.assertTrue("begin() must accept a region already carrying the shared label",
+                    loader.begin(labeled));
+            Assert.assertEquals("shared-label-1", labeled.getLabel());
+        } finally {
+            loader.close();
+        }
+    }
+
+    /**
+     * {@code sendToSR()} must never send a null label to the FE in multi-table mode. It must
+     * abort BEFORE building/sending an HTTP entity and release FLUSHING so the manager
+     * reconciles the label and retries.
+     */
+    @Test
+    public void testSendToSRNeverSendsNullLabelInMultiTableMode() {
+        TransactionStreamLoader loader = new TransactionStreamLoader(true);
+        loader.start(multiTableProperties(), noopManager());
+        try {
+            StubRegion nullLabel = new StubRegion(null);
+            StreamLoadResponse response = loader.sendToSR(nullLabel);
+
+            Assert.assertNull("sendToSR must not perform a load when the shared label is null", response);
+            Assert.assertFalse("sendToSR must NOT build/send an HTTP entity with a null label "
+                    + "(would fail fatally with \"Empty label\")", nullLabel.httpEntityRequested.get());
+            Assert.assertTrue("sendToSR must release FLUSHING so the manager reconciles and retries",
+                    nullLabel.exitFlushingCalled.get());
+        } finally {
+            loader.close();
+        }
+    }
+}

--- a/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/MultiTableNullLabelLoadGuardTest.java
+++ b/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/MultiTableNullLabelLoadGuardTest.java
@@ -128,6 +128,7 @@ public class MultiTableNullLabelLoadGuardTest {
         private volatile String label;
         final AtomicBoolean httpEntityRequested = new AtomicBoolean(false);
         final AtomicBoolean exitFlushingCalled = new AtomicBoolean(false);
+        final AtomicBoolean failCalled = new AtomicBoolean(false);
 
         StubRegion(String label) {
             this.label = label;
@@ -157,7 +158,7 @@ public class MultiTableNullLabelLoadGuardTest {
         @Override public boolean flush() { return false; }
         @Override public boolean cancel() { return false; }
         @Override public void callback(StreamLoadResponse response) {}
-        @Override public void fail(Throwable e) {}
+        @Override public void fail(Throwable e) { failCalled.set(true); }
         @Override public void complete(StreamLoadResponse response) {}
         @Override public void setResult(Future<?> result) {}
         @Override public Future<?> getResult() { return null; }
@@ -218,6 +219,42 @@ public class MultiTableNullLabelLoadGuardTest {
                     + "(would fail fatally with \"Empty label\")", nullLabel.httpEntityRequested.get());
             Assert.assertTrue("sendToSR must release FLUSHING so the manager reconciles and retries",
                     nullLabel.exitFlushingCalled.get());
+        } finally {
+            loader.close();
+        }
+    }
+
+    /**
+     * The null-label refusal must be a <em>deferral</em>, not a failure. {@code send()} treats a
+     * {@code begin()} refusal as a hard transaction-start failure and calls
+     * {@code region.fail(StreamLoadFailException)}; in multi-table mode
+     * {@code TransactionTableRegion.fail()} only retries {@code TXN_IN_PROCESSING}, so that
+     * synthetic error would reach {@code manager.callback()} and abort the job — turning the
+     * race this guard exists to survive into a terminal failure. {@code send()} must instead
+     * leave the region untouched and return {@code null} so the caller releases FLUSHING and
+     * the manager's reconcile pass re-triggers the load.
+     */
+    @Test
+    public void testSendDefersInsteadOfFailingRegionOnNullLabel() {
+        TransactionStreamLoader loader = new TransactionStreamLoader(true);
+        loader.start(multiTableProperties(), noopManager());
+        try {
+            StubRegion immediate = new StubRegion(null);
+            Assert.assertNull("send() must not schedule a load for a null-label region",
+                    loader.send(immediate));
+            Assert.assertFalse("send() must NOT fail the region on a null-label deferral: in multi-table "
+                    + "mode fail() is terminal for a non-TXN_IN_PROCESSING error and aborts the job",
+                    immediate.failCalled.get());
+            Assert.assertNull("the deferred region must keep its null label (no orphan mint)",
+                    immediate.getLabel());
+
+            // The delayed overload takes the same begin()-refusal branch and must defer identically.
+            StubRegion delayed = new StubRegion(null);
+            Assert.assertNull("send(region, delayMs) must not schedule a load for a null-label region",
+                    loader.send(delayed, 10));
+            Assert.assertFalse("send(region, delayMs) must defer, not fail, on a null shared label",
+                    delayed.failCalled.get());
+            Assert.assertNull(delayed.getLabel());
         } finally {
             loader.close();
         }

--- a/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/v2/MultiTableTxnSerializationAlignmentTest.java
+++ b/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/v2/MultiTableTxnSerializationAlignmentTest.java
@@ -20,6 +20,8 @@ package com.starrocks.data.load.stream.v2;
 
 import com.starrocks.data.load.stream.MockedStarRocksHttpServer;
 import com.starrocks.data.load.stream.StreamLoadDataFormat;
+import com.starrocks.data.load.stream.StreamLoadUtils;
+import com.starrocks.data.load.stream.TableRegion;
 import com.starrocks.data.load.stream.properties.StreamLoadProperties;
 import com.starrocks.data.load.stream.properties.StreamLoadTableProperties;
 import org.junit.After;
@@ -29,6 +31,7 @@ import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.BooleanSupplier;
 
 /**
  * Verifies the structural multi-table transaction fixes under sustained
@@ -156,6 +159,94 @@ public class MultiTableTxnSerializationAlignmentTest {
             }
         }
         return perLabel;
+    }
+
+    /** Polls {@code cond} every 20ms until true or the timeout elapses; fails otherwise. */
+    private static void awaitUntil(BooleanSupplier cond, long timeoutMs, String message) throws Exception {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline) {
+            if (cond.getAsBoolean()) {
+                return;
+            }
+            Thread.sleep(20);
+        }
+        Assert.fail("Timed out after " + timeoutMs + "ms: " + message);
+    }
+
+    /**
+     * Regression for the stale/null shared-label race (2026-07): a region can land
+     * in {@code flushQ} holding a label that is NOT the coordinator's current shared
+     * label while a shared transaction is active, and nothing re-validates it before
+     * the autonomous flush selects it — so its first flush mints an independent
+     * (orphan) transaction, splitting a source transaction across labels and breaking
+     * cross-table atomicity.
+     *
+     * <p><b>How the state arises in the wild</b> (verified by whole-system trace):
+     * region creation ({@code getCacheRegion}) injects the shared label and enqueues
+     * to {@code flushQ} under {@code synchronized(regions)}, but the commit-tail
+     * re-open ({@code ensureSharedTransaction}) publishes the new label via
+     * {@code SharedTransactionCoordinator.begin()} BEFORE its weakly-consistent
+     * {@code ConcurrentLinkedQueue} inject-loop iterates — and takes no {@code regions}
+     * monitor. A first write to a NEW (db,table) whose {@code isActive()} read lands in
+     * the {@code commitInFlight==false && !isActive()} gap (so it captures neither the
+     * defensive watermark nor a label) and whose {@code flushQ.offer} lands after the
+     * inject-loop's cursor passes the tail is MISSED by injection. The per-scan
+     * re-injection guard ({@code if (!isActive())}) is then dormant because the txn is
+     * active, so the region is never re-injected.
+     *
+     * <p><b>Why the state is constructed directly here:</b> that interleaving is a
+     * microsecond window between {@code getCacheRegion}'s {@code isActive()} read and
+     * its {@code flushQ.offer}; it cannot be forced deterministically through the
+     * public API (the autonomous manager thread will not stall on demand). We therefore
+     * reproduce the PROVEN-REACHABLE resulting state — a {@code flushQ} region with a
+     * null label while the shared transaction stays active — and assert the manager
+     * repairs it before any flush. This test is RED on the pre-fix code (nothing
+     * reconciles the label while active) and GREEN once the manager reconciles every
+     * {@code flushQ} region to the live shared label before flush selection.
+     */
+    @Test
+    public void testActiveTxnReconcilesRegionMissingSharedLabel() throws Exception {
+        // Large commit interval + no txnEnd + default (large) recycle idle => the shared
+        // transaction opened below stays active and stable for the whole test.
+        DefaultStreamLoadManager manager = new DefaultStreamLoadManager(buildProperties(60000), true);
+        manager.init();
+        try {
+            // 1. Open a shared transaction by writing to the first table (partition 0).
+            manager.write(0, DB, ORDERS, "{\"order_id\":1, " + ORDER_MARKER + ":1}");
+
+            // 2. Wait until the manager thread eagerly opened the shared txn and injected
+            //    its label into the orders region.
+            String ordersKey = "P0-" + StreamLoadUtils.getTableUniqueKey(DB, ORDERS);
+            TableRegion orders = manager.getCacheRegion(ordersKey, DB, ORDERS, 0);
+            awaitUntil(() -> orders.getLabel() != null, 5000,
+                    "shared transaction should open and inject a label into the orders region");
+            final String sharedLabel = orders.getLabel();
+
+            // 3. A sibling region created while the txn is active DOES get the shared label
+            //    (getCacheRegion's isActive()-gated injection path).
+            String itemsKey = "P0-" + StreamLoadUtils.getTableUniqueKey(DB, ITEMS);
+            TableRegion items = manager.getCacheRegion(itemsKey, DB, ITEMS, 0);
+            Assert.assertEquals("precondition: sibling created while active receives the shared label",
+                    sharedLabel, items.getLabel());
+
+            // 4. Reproduce the missed-injection state: the region sits in flushQ with a null
+            //    label while the shared transaction remains active.
+            items.setLabel(null);
+
+            // 5. Let manager scans run. BUG: no re-validation while a txn is active -> the
+            //    region keeps its null label (its first flush would mint an orphan txn).
+            //    FIX: the manager reconciles flushQ regions to the live shared label before
+            //    flush selection, restoring it.
+            awaitUntil(() -> sharedLabel.equals(items.getLabel()), 3000,
+                    "manager must reconcile the flushQ region back to the live shared label "
+                            + "while the shared transaction is active (else its flush mints an orphan txn)");
+
+            Assert.assertEquals("region must carry the live shared label, never null/stale",
+                    sharedLabel, items.getLabel());
+            Assert.assertNull("no failure expected: " + manager.getException(), manager.getException());
+        } finally {
+            manager.close();
+        }
     }
 
     @Test


### PR DESCRIPTION
## What

Fixes a cross-table atomicity break in multi-table transaction mode (`sink.transaction.multi-table.enabled=true`) where a region can flush under a **null** shared label, producing an orphan independent transaction that splits a source transaction across labels.

## Root cause

Region creation (`getCacheRegion`) injects the shared label + enqueues to `flushQ` under `synchronized(regions)`, but the commit-tail re-open (`ensureSharedTransaction`) publishes the new label via `SharedTransactionCoordinator.begin()` **before** its weakly-consistent `ConcurrentLinkedQueue` inject loop iterates, and takes no `regions` monitor. A first write to a NEW `(db,table)` whose `isActive()` read lands in the `commitInFlight==false && !isActive()` gap (between `commitInFlight.set(false)` and `begin()`'s publish) keeps a null label, and whose `flushQ.offer` lands after the inject-loop cursor passes the tail is **missed** by injection. The per-scan re-injection guard (`if (!isActive())`) is then dormant while the txn is active, and nothing re-validates a region's label before flush selection — so the region's first autonomous flush mints an independent label via `TransactionStreamLoader.begin()` (`getLabel()==null` → fresh label), breaking cross-table atomicity.

The committed-label variant is not reachable: a region capturing a committed label must be born while `commitInFlight==true`, which triggers the defensive `setCommitWatermark()` (watermark = -1 → `headChunkEligible()` false until `finishCommitCut`), and the label-clear loop nulls it before the watermark lifts.

## Fix

`reconcileFlushQueueLabels()` — on the manager thread, right before flush/commit selection, reconcile every `flushQ` region to the coordinator's live shared label while a txn is active. Uses `trySetLabel` (a retrying region keeps its in-flight label and is reconciled on a later scan), skips cross-database regions (mirrors `getCacheRegion`'s guard), gated on `isActive()`. Covers both re-open entry points (commit-tail and idle-recycle).

## Testing

- New regression `MultiTableTxnSerializationAlignmentTest#testActiveTxnReconcilesRegionMissingSharedLabel`: reproduces the reachable state (flushQ region + null label + active txn) and asserts the manager reconciles it before flush. **RED without the fix, GREEN with it**, and mutation-verified (commenting the call flips it RED).
- SDK unit suite: **163/163**.
- IT suite on real StarRocks 4.0.10 (1FE+1BE): **18/18**.
- E2E on real cluster (Flink 1.20 → SR): B1 high-pressure, mid-stream-new-table (fix target), B7 recycle-dominated — all 0 violations + exact counts + 0 `TXN_IN_PROCESSING`. B5 probability-pressure: exact final counts; one isolated single-sample count blip (0 orphans, self-healed) = the known FE/BE-separated SR publish micro-window, not this connector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)