### PR TITLE
[BugFix] Multi-table txn: recover a lost commit response instead of hanging/failing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -432,6 +432,7 @@ limitations under the License.
                         <exclude>.cursor/**</exclude>
                         <exclude>starrocks-stream-load-sdk/**</exclude>
                         <exclude>.claude/**</exclude>
+                        <exclude>.agents/**</exclude>
                     </excludes>
                 </configuration>
             </plugin>

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/DefaultStreamLoader.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/DefaultStreamLoader.java
@@ -462,6 +462,10 @@ public class DefaultStreamLoader implements StreamLoader, Serializable {
      * a permanent hang. Any explicit user-configured value is honored as-is — including {@code 0},
      * which the {@code sink.socket.timeout-ms} contract defines as an (opt-in) infinite timeout;
      * only the {@code -1} default (unset) is replaced with the bounded value.
+     *
+     * <p>The derived bound is additionally capped by the manager's own flush budget (see
+     * {@link #managerFlushBudgetMs}): blocking here for longer than the manager is willing to wait
+     * is never useful, because the server-side transaction has already timed out by then.
      */
     static int boundedRpcSocketTimeoutMs(StreamLoadProperties properties) {
         int configured = properties.getSocketTimeout();
@@ -471,10 +475,44 @@ public class DefaultStreamLoader implements StreamLoader, Serializable {
             return configured;
         }
         // No explicit socket timeout: derive a bounded value from the server-side publish
-        // deadline plus margin, capped so it stays well under the manager's flush timeout.
+        // deadline plus margin.
         int publishMs = properties.getPublishTimeoutMs();
         long base = publishMs > 0 ? (long) publishMs : 60_000L;
-        return (int) Math.min(base + 30_000L, 300_000L);
+        long bound = Math.min(base + 30_000L, 300_000L);
+        // Then cap by the manager's flush budget. Without this, a short configured
+        // `sink.properties.timeout` (below ~82s) leaves this read blocking well past the point
+        // where the manager thread has already abandoned the flush — e.g. timeout=1 gives a 1.1s
+        // flush deadline but would otherwise wait 90s here.
+        long flushBudgetMs = managerFlushBudgetMs(properties);
+        if (flushBudgetMs > 0) {
+            bound = Math.min(bound, flushBudgetMs);
+        }
+        return (int) bound;
+    }
+
+    /**
+     * The manager's flush budget in ms, mirroring the {@code flushTimeoutMs = timeoutSec * 1100}
+     * derivation in {@code DefaultStreamLoadManager} from the stream-load {@code timeout} header.
+     *
+     * @return the budget in ms, or {@code -1} when no usable {@code timeout} header is configured
+     *         (in which case the manager keeps its own default and no extra cap applies here).
+     */
+    private static long managerFlushBudgetMs(StreamLoadProperties properties) {
+        Map<String, String> headers = properties.getHeaders();
+        if (headers == null) {
+            return -1L;
+        }
+        String timeoutStr = headers.get("timeout");
+        if (timeoutStr == null) {
+            return -1L;
+        }
+        try {
+            long timeoutSec = Long.parseLong(timeoutStr.trim());
+            return timeoutSec > 0 ? timeoutSec * 1100L : -1L;
+        } catch (NumberFormatException ex) {
+            // Mirrors the manager, which warns and falls back to its default on an unparseable value.
+            return -1L;
+        }
     }
 
     protected String getLabelState(String host, String database, String table, String label, Set<String> retryStates) throws Exception {

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/DefaultStreamLoader.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/DefaultStreamLoader.java
@@ -507,7 +507,11 @@ public class DefaultStreamLoader implements StreamLoader, Serializable {
             return -1L;
         }
         try {
-            long timeoutSec = Long.parseLong(timeoutStr.trim());
+            // Deliberately parses the raw string, exactly as the manager does — no trim(). Being
+            // more lenient here would cap the socket timeout off a budget the manager never adopts:
+            // for a header like " 1 " the manager's parse throws and it keeps its 660s default,
+            // while a trimming parse here would clamp the RPC to 1.1s and fail it prematurely.
+            long timeoutSec = Long.parseLong(timeoutStr);
             return timeoutSec > 0 ? timeoutSec * 1100L : -1L;
         } catch (NumberFormatException ex) {
             // Mirrors the manager, which warns and falls back to its default on an unparseable value.

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/DefaultStreamLoader.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/DefaultStreamLoader.java
@@ -449,6 +449,34 @@ public class DefaultStreamLoader implements StreamLoader, Serializable {
         return TransactionStatus.valueOf(state.toUpperCase());
     }
 
+    /**
+     * Bounded socket-read timeout (ms) for the blocking transaction RPCs that run on the sink's
+     * manager thread (begin / prepare / commit) and for the label-state reconciliation query.
+     *
+     * <p>{@link StreamLoadProperties#getSocketTimeout()} defaults to {@code -1} (infinite in
+     * Apache HttpClient). On these blocking calls that means a lost response — the FE processes
+     * the request but the reply is dropped by an LB/proxy/network — hangs the manager thread
+     * indefinitely, stalling the whole subtask until the transport eventually resets. Bounding
+     * the timeout lets a lost response surface as a {@code SocketTimeoutException} that the caller
+     * reconciles against the real label state (see the commit/prepare recovery paths), instead of
+     * a permanent hang. Any explicit user-configured value is honored as-is — including {@code 0},
+     * which the {@code sink.socket.timeout-ms} contract defines as an (opt-in) infinite timeout;
+     * only the {@code -1} default (unset) is replaced with the bounded value.
+     */
+    static int boundedRpcSocketTimeoutMs(StreamLoadProperties properties) {
+        int configured = properties.getSocketTimeout();
+        if (configured >= 0) {
+            // Honor an explicit value, including 0 (= infinite per the option contract): the user
+            // opted in. Only the unset default (-1) is bounded below.
+            return configured;
+        }
+        // No explicit socket timeout: derive a bounded value from the server-side publish
+        // deadline plus margin, capped so it stays well under the manager's flush timeout.
+        int publishMs = properties.getPublishTimeoutMs();
+        long base = publishMs > 0 ? (long) publishMs : 60_000L;
+        return (int) Math.min(base + 30_000L, 300_000L);
+    }
+
     protected String getLabelState(String host, String database, String table, String label, Set<String> retryStates) throws Exception {
         int totalSleepSecond = 0;
         String lastState = null;
@@ -464,11 +492,14 @@ public class DefaultStreamLoader implements StreamLoader, Serializable {
             try (CloseableHttpClient client = HttpClients.createDefault()) {
                 String url = host + "/api/" + database + "/get_load_state?label=" + label;
                 HttpGet httpGet = new HttpGet(url);
-                httpGet.setConfig(RequestConfig.custom()
-                        .setConnectTimeout(properties.getConnectTimeout())
-                        .build());
                 httpGet.addHeader("Authorization", StreamLoadUtils.getBasicAuthHeader(properties.getUsername(), properties.getPassword()));
                 httpGet.setHeader("Connection", "close");
+                // Bound the read so a lost get_load_state reply cannot hang this reconciliation
+                // query (its outer 60s loop cap only guards between attempts, not a stuck read).
+                httpGet.setConfig(RequestConfig.custom()
+                        .setSocketTimeout(boundedRpcSocketTimeoutMs(properties))
+                        .setConnectTimeout(properties.getConnectTimeout())
+                        .build());
                 try (CloseableHttpResponse response = client.execute(httpGet)) {
                     int responseStatusCode = response.getStatusLine().getStatusCode();
                     String entityContent = EntityUtils.toString(response.getEntity());

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/TransactionStreamLoader.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/TransactionStreamLoader.java
@@ -37,10 +37,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -392,11 +394,27 @@ public class TransactionStreamLoader extends DefaultStreamLoader {
      * label. Verified on a real cluster that a committed multi-table label reports {@code VISIBLE}
      * here (the {@code information_schema.loads} / {@code SHOW STREAM LOAD} {@code PREPARING} display
      * lag is a different FE path; {@code get_load_state} reads the transaction state directly).
+     *
+     * <p>The query is not pinned to the FE that took the commit: the very failure being reconciled
+     * can be that FE going away right after it committed, and {@link #getLabelState} performs no
+     * host selection of its own. The commit host is tried first (it is the most likely to answer),
+     * then every other configured load URL, so a single dead FE cannot turn a durably committed
+     * transaction into a job failure. Only a FAILED query moves on to the next host — any FE that
+     * answers reports the same transaction state, so the first answer is taken as definitive.
      */
     private boolean reconcileLostCommit(String host, StreamLoadSnapshot.Transaction transaction, Exception cause) {
-        try {
-            String labelState = getLabelState(host, transaction.getDatabase(), transaction.getTable(),
-                    transaction.getLabel(), COMMIT_IN_PROGRESS_STATES);
+        Exception lastStateEx = null;
+        for (String candidate : reconciliationHosts(host)) {
+            String labelState;
+            try {
+                labelState = getLabelState(candidate, transaction.getDatabase(), transaction.getTable(),
+                        transaction.getLabel(), COMMIT_IN_PROGRESS_STATES);
+            } catch (Exception stateEx) {
+                lastStateEx = stateEx;
+                log.warn("Commit response lost for label {}; the label-state query via {} failed, " +
+                        "trying the next configured FE if there is one.", transaction.getLabel(), candidate, stateEx);
+                continue;
+            }
             if (TransactionStatus.COMMITTED.isSame(labelState) || TransactionStatus.VISIBLE.isSame(labelState)) {
                 log.warn("Commit response lost for label {} ({}), but the label is already {} server-side; " +
                         "treating the commit as successful.", transaction.getLabel(), cause.toString(), labelState);
@@ -404,11 +422,32 @@ public class TransactionStreamLoader extends DefaultStreamLoader {
             }
             log.error("Commit response lost for label {}, and label state is {} (not committed); failing.",
                     transaction.getLabel(), labelState, cause);
-        } catch (Exception stateEx) {
-            log.error("Commit response lost for label {}, and label-state reconciliation also failed; failing.",
-                    transaction.getLabel(), stateEx);
+            throw new RuntimeException(cause);
         }
+        log.error("Commit response lost for label {}, and the label-state re-check failed on every configured FE; " +
+                "failing.", transaction.getLabel(), lastStateEx);
         throw new RuntimeException(cause);
+    }
+
+    /**
+     * The hosts to try for a lost-commit label-state query: the FE that took the commit first, then
+     * every other configured load URL, de-duplicated. Falls back to the configured URLs alone when
+     * the commit host is unknown (host probing can return {@code null} when every FE failed a probe).
+     */
+    private List<String> reconciliationHosts(String commitHost) {
+        List<String> hosts = new ArrayList<>();
+        if (commitHost != null) {
+            hosts.add(commitHost);
+        }
+        String[] loadUrls = properties.getLoadUrls();
+        if (loadUrls != null) {
+            for (String url : loadUrls) {
+                if (url != null && !hosts.contains(url)) {
+                    hosts.add(url);
+                }
+            }
+        }
+        return hosts;
     }
 
     @Override

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/TransactionStreamLoader.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/TransactionStreamLoader.java
@@ -319,6 +319,15 @@ public class TransactionStreamLoader extends DefaultStreamLoader {
             }
             log.info("Transaction committed, label: {}, body : {}", transaction.getLabel(), responseBody);
             streamLoadBody = objectMapper.readValue(responseBody, StreamLoadResponse.StreamLoadResponseBody.class);
+            if (streamLoadBody == null || streamLoadBody.getStatus() == null) {
+                // Syntactically valid JSON that carries no FE status — e.g. `{}` or a bare `null`
+                // substituted by an intermediary. That is NOT a decision from the FE, so it belongs
+                // with the lost-response cases below rather than on the fail-fast path: the FE may
+                // well have committed. Thrown here so it lands in the reconciliation catch.
+                throw new StreamLoadFailException(String.format("Commit transaction response carries no status. " +
+                        "db: %s, table: %s, label: %s, response body: %s", transaction.getDatabase(),
+                        transaction.getTable(), transaction.getLabel(), responseBody));
+            }
         } catch (Exception e) {
             // No definitive FE commit status was read: socket timeout, connection reset, a non-200
             // from an intermediary (proxy/LB), or an unparseable/absent body. The transaction may
@@ -329,13 +338,9 @@ public class TransactionStreamLoader extends DefaultStreamLoader {
             return reconcileLostCommit(host, transaction, e);
         }
 
-        // A definitive FE response with a parseable status was read below this point.
+        // A definitive FE response with a parseable, non-null status was read below this point
+        // (a missing status was routed to reconciliation above).
         String status = streamLoadBody.getStatus();
-        if (status == null) {
-            throw new StreamLoadFailException(String.format("Commit transaction status is null. db: %s, table: %s, " +
-                    "label: %s, response body: %s", transaction.getDatabase(), transaction.getTable(),
-                    transaction.getLabel(), streamLoadBody));
-        }
         if (StreamLoadConstants.RESULT_STATUS_OK.equals(status)) {
             StreamLoadResponse streamLoadResponse = new StreamLoadResponse();
             streamLoadResponse.setBody(streamLoadBody);

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/TransactionStreamLoader.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/TransactionStreamLoader.java
@@ -37,9 +37,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import static com.starrocks.data.load.stream.StreamLoadConstants.getBeginUrl;
 import static com.starrocks.data.load.stream.StreamLoadConstants.getCommitUrl;
@@ -50,6 +53,14 @@ import static com.starrocks.data.load.stream.StreamLoadUtils.getErrorLog;
 public class TransactionStreamLoader extends DefaultStreamLoader {
 
     private static final Logger log = LoggerFactory.getLogger(TransactionStreamLoader.class);
+
+    /**
+     * Transaction states that mean "commit still in progress" — the reconciliation after a lost
+     * commit response polls (rather than fails) while the label is in one of these, so a commit
+     * that is merely slow (not lost) is not prematurely failed.
+     */
+    private static final Set<String> COMMIT_IN_PROGRESS_STATES = Collections.unmodifiableSet(
+            new HashSet<>(Arrays.asList(TransactionStatus.PREPARE.name(), TransactionStatus.PREPARED.name())));
 
     private final boolean enableAutoCommit;
     private Header[] defaultTxnHeaders;
@@ -153,7 +164,7 @@ public class TransactionStreamLoader extends DefaultStreamLoader {
 
         httpPost.setConfig(RequestConfig.custom()
                         .setConnectTimeout(properties.getConnectTimeout())
-                        .setSocketTimeout(properties.getSocketTimeout())
+                        .setSocketTimeout(boundedRpcSocketTimeoutMs(properties))
                         .setExpectContinueEnabled(true)
                         .setRedirectsEnabled(true)
                         .build());
@@ -212,7 +223,7 @@ public class TransactionStreamLoader extends DefaultStreamLoader {
 
         httpPost.setConfig(RequestConfig.custom()
                         .setConnectTimeout(properties.getConnectTimeout())
-                        .setSocketTimeout(properties.getSocketTimeout())
+                        .setSocketTimeout(boundedRpcSocketTimeoutMs(properties))
                         .setExpectContinueEnabled(true)
                         .setRedirectsEnabled(true)
                         .build());
@@ -292,13 +303,14 @@ public class TransactionStreamLoader extends DefaultStreamLoader {
 
         httpPost.setConfig(RequestConfig.custom()
                         .setConnectTimeout(properties.getConnectTimeout())
-                        .setSocketTimeout(properties.getSocketTimeout())
+                        .setSocketTimeout(boundedRpcSocketTimeoutMs(properties))
                         .setExpectContinueEnabled(true)
                         .setRedirectsEnabled(true)
                         .build());
 
         log.info("Transaction commit, label: {}, request : {}", transaction.getLabel(), httpPost);
 
+        StreamLoadResponse.StreamLoadResponseBody streamLoadBody;
         try (CloseableHttpClient client = clientBuilder.build()) {
             String responseBody;
             try (CloseableHttpResponse response = client.execute(httpPost)) {
@@ -306,52 +318,92 @@ public class TransactionStreamLoader extends DefaultStreamLoader {
                         transaction.getLabel(), response);
             }
             log.info("Transaction committed, label: {}, body : {}", transaction.getLabel(), responseBody);
-
-            StreamLoadResponse streamLoadResponse = new StreamLoadResponse();
-            StreamLoadResponse.StreamLoadResponseBody streamLoadBody =
-                    objectMapper.readValue(responseBody, StreamLoadResponse.StreamLoadResponseBody.class);
-            streamLoadResponse.setBody(streamLoadBody);
-            String status = streamLoadBody.getStatus();
-            if (status == null) {
-                throw new StreamLoadFailException(String.format("Commit transaction status is null. db: %s, table: %s, " +
-                                "label: %s, response body: %s", transaction.getDatabase(), transaction.getTable(), transaction.getLabel(),
-                                        responseBody));
-            }
-
-
-            if (StreamLoadConstants.RESULT_STATUS_OK.equals(status)) {
-                manager.callback(streamLoadResponse);
-                return true;
-            }
-
-            // there are many corner cases that can lead to non-ok status. some of them are
-            // 1. TXN_NOT_EXISTS: transaction timeout and the label is cleanup up
-            // 2. Failed: the error message can be "has no backend", The case is that FE leader restarts, and after
-            //    that commit the transaction repeatedly because flink/spark job continues failover for some reason , but
-            //    the transaction actually success, and this commit should be successful
-            // To reduce the dependency for the returned status type, always check the label state
-            String labelState = getLabelState(host, transaction.getDatabase(), transaction.getTable(), transaction.getLabel(), Collections.emptySet());
-            if (TransactionStatus.COMMITTED.isSame(labelState) || TransactionStatus.VISIBLE.isSame(labelState)) {
-                return true;
-            }
-
-            String errorLog = getErrorLog(streamLoadBody.getErrorURL(), properties.isSanitizeErrorLog());
-            log.error("Transaction commit failed, db: {}, table: {}, label: {}, label state: {}, \nresponseBody: {}\nerrorLog: {}",
-                    transaction.getDatabase(), transaction.getTable(), transaction.getLabel(), labelState, responseBody, errorLog);
-
-            String exceptionMsg = String.format("Transaction commit failed, db: %s, table: %s, label: %s, commit response status: %s," +
-                   " label state: %s", transaction.getDatabase(), transaction.getTable(), transaction.getLabel(), status, labelState);
-            // transaction not exist often happens after transaction timeouts
-            if (StreamLoadConstants.RESULT_STATUS_TRANSACTION_NOT_EXISTED.equals(status) ||
-                TransactionStatus.UNKNOWN.isSame(labelState)) {
-                exceptionMsg += ". commit response status with TXN_NOT_EXISTS or label state with UNKNOWN often happens when transaction" +
-                        " timeouts, and please check StarRocks FE leader's log to confirm it. You can find the transaction id for the label" +
-                        " in the FE log first, and search with the transaction id and the keyword 'expired'";
-            }
-            throw new StreamLoadFailException(exceptionMsg);
+            streamLoadBody = objectMapper.readValue(responseBody, StreamLoadResponse.StreamLoadResponseBody.class);
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            // No definitive FE commit status was read: socket timeout, connection reset, a non-200
+            // from an intermediary (proxy/LB), or an unparseable/absent body. The transaction may
+            // nonetheless have COMMITTED server-side — the FE commits, then the reply is dropped by
+            // the LB/network. Reconcile against the real label state before failing; a committed/
+            // visible label means the commit actually succeeded and we must NOT fail the job (which
+            // would otherwise stall the manager thread up to flushTimeoutMs and then restart-storm).
+            return reconcileLostCommit(host, transaction, e);
         }
+
+        // A definitive FE response with a parseable status was read below this point.
+        String status = streamLoadBody.getStatus();
+        if (status == null) {
+            throw new StreamLoadFailException(String.format("Commit transaction status is null. db: %s, table: %s, " +
+                    "label: %s, response body: %s", transaction.getDatabase(), transaction.getTable(),
+                    transaction.getLabel(), streamLoadBody));
+        }
+        if (StreamLoadConstants.RESULT_STATUS_OK.equals(status)) {
+            StreamLoadResponse streamLoadResponse = new StreamLoadResponse();
+            streamLoadResponse.setBody(streamLoadBody);
+            manager.callback(streamLoadResponse);
+            return true;
+        }
+
+        // Definitive non-OK FE status. Double-check the label state once (a non-OK response can
+        // accompany an actually-committed txn — e.g. FE leader failover, or a repeated commit), but
+        // this IS the FE's decision, so do NOT poll in-progress states here (unlike the lost-response
+        // path above): a genuine rejection (e.g. "disk full") must fail fast, not wait ~60s.
+        // corner cases: TXN_NOT_EXISTS (txn timed out and the label was cleaned up); or a Failed
+        // status whose txn actually succeeded (FE leader restart + job failover re-committing).
+        String labelState;
+        try {
+            labelState = getLabelState(host, transaction.getDatabase(), transaction.getTable(),
+                    transaction.getLabel(), Collections.emptySet());
+        } catch (Exception stateEx) {
+            throw new StreamLoadFailException(String.format("Transaction commit failed, db: %s, table: %s, label: %s, " +
+                    "commit response status: %s; the label-state re-check also failed: %s", transaction.getDatabase(),
+                    transaction.getTable(), transaction.getLabel(), status, stateEx));
+        }
+        if (TransactionStatus.COMMITTED.isSame(labelState) || TransactionStatus.VISIBLE.isSame(labelState)) {
+            return true;
+        }
+
+        String errorLog = getErrorLog(streamLoadBody.getErrorURL(), properties.isSanitizeErrorLog());
+        log.error("Transaction commit failed, db: {}, table: {}, label: {}, label state: {}, \nerrorLog: {}",
+                transaction.getDatabase(), transaction.getTable(), transaction.getLabel(), labelState, errorLog);
+        String exceptionMsg = String.format("Transaction commit failed, db: %s, table: %s, label: %s, commit response status: %s," +
+                " label state: %s", transaction.getDatabase(), transaction.getTable(), transaction.getLabel(), status, labelState);
+        if (StreamLoadConstants.RESULT_STATUS_TRANSACTION_NOT_EXISTED.equals(status) ||
+                TransactionStatus.UNKNOWN.isSame(labelState)) {
+            exceptionMsg += ". commit response status with TXN_NOT_EXISTS or label state with UNKNOWN often happens when transaction" +
+                    " timeouts, and please check StarRocks FE leader's log to confirm it. You can find the transaction id for the label" +
+                    " in the FE log first, and search with the transaction id and the keyword 'expired'";
+        }
+        throw new StreamLoadFailException(exceptionMsg);
+    }
+
+    /**
+     * Reconciles a commit whose response was lost/errored before a definitive FE status could be
+     * read (socket timeout, connection reset, non-200 from an LB/proxy, unparseable body). Polls
+     * the real label state — retrying while the commit is still IN PROGRESS ({@code PREPARE}/
+     * {@code PREPARED}) so a commit that is merely slow (not lost) is not prematurely failed — and
+     * treats {@code COMMITTED}/{@code VISIBLE} as success; otherwise rethrows the original cause.
+     *
+     * <p>Relies on {@code get_load_state} reporting the true terminal state for a (multi-statement)
+     * label. Verified on a real cluster that a committed multi-table label reports {@code VISIBLE}
+     * here (the {@code information_schema.loads} / {@code SHOW STREAM LOAD} {@code PREPARING} display
+     * lag is a different FE path; {@code get_load_state} reads the transaction state directly).
+     */
+    private boolean reconcileLostCommit(String host, StreamLoadSnapshot.Transaction transaction, Exception cause) {
+        try {
+            String labelState = getLabelState(host, transaction.getDatabase(), transaction.getTable(),
+                    transaction.getLabel(), COMMIT_IN_PROGRESS_STATES);
+            if (TransactionStatus.COMMITTED.isSame(labelState) || TransactionStatus.VISIBLE.isSame(labelState)) {
+                log.warn("Commit response lost for label {} ({}), but the label is already {} server-side; " +
+                        "treating the commit as successful.", transaction.getLabel(), cause.toString(), labelState);
+                return true;
+            }
+            log.error("Commit response lost for label {}, and label state is {} (not committed); failing.",
+                    transaction.getLabel(), labelState, cause);
+        } catch (Exception stateEx) {
+            log.error("Commit response lost for label {}, and label-state reconciliation also failed; failing.",
+                    transaction.getLabel(), stateEx);
+        }
+        throw new RuntimeException(cause);
     }
 
     @Override

--- a/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/MockedStarRocksHttpServer.java
+++ b/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/MockedStarRocksHttpServer.java
@@ -122,6 +122,9 @@ public class MockedStarRocksHttpServer {
         public String message = "";
         public boolean includeErrorURL = false;
         public String errorLogContent;
+        /** When set, sent verbatim instead of the generated JSON — models an intermediary
+         *  substituting a body (e.g. {@code {}} or {@code null}) that carries no FE status. */
+        public String rawBody;
     }
 
     private final HttpServer server;
@@ -638,6 +641,10 @@ public class MockedStarRocksHttpServer {
             commitCount.incrementAndGet();
             ResponseOverride override = commitOverride;
             if (override != null) {
+                if (override.rawBody != null) {
+                    sendJson(exchange, override.httpCode, override.rawBody);
+                    return;
+                }
                 if (override.includeErrorURL && override.errorLogContent != null) {
                     errorLogs.put(label, override.errorLogContent);
                 }

--- a/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/MockedStarRocksHttpServer.java
+++ b/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/MockedStarRocksHttpServer.java
@@ -708,7 +708,7 @@ public class MockedStarRocksHttpServer {
             String path = uri.getPath();
             // path starts with /api/
             List<String> segments = split(path);
-            if (segments.size() >= 4 && "api".equals(segments.get(0))) {
+            if (segments.size() >= 3 && "api".equals(segments.get(0))) {
                 String db = segments.get(1);
                 if (segments.size() == 3 && "get_load_state".equals(segments.get(2))) {
                     // /api/{db}/get_load_state

--- a/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/TransactionCommitRecoveryTest.java
+++ b/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/TransactionCommitRecoveryTest.java
@@ -187,6 +187,47 @@ public class TransactionCommitRecoveryTest {
     }
 
     @Test
+    public void testCommitResponseWithoutStatusIsReconciledNotFailed() {
+        // An intermediary can substitute a syntactically valid body that carries no FE status —
+        // `{}` (parses to a body whose status is null) or a bare `null` (parses to null) — AFTER
+        // the FE already committed. Neither is a decision from the FE, so both belong on the
+        // reconciliation path, not the fail-fast one. Previously `{}` threw outside the recovery
+        // catch and `null` NPE'd there, so a committed txn still failed the job.
+        for (String rawBody : new String[]{"{}", "null"}) {
+            TransactionStreamLoader loader = startedLoader(props(-1));
+            String label = "lbl-no-status-" + rawBody.hashCode();
+            MockedStarRocksHttpServer.ResponseOverride ov = new MockedStarRocksHttpServer.ResponseOverride();
+            ov.httpCode = 200;
+            ov.rawBody = rawBody;
+            server.setCommitOverride(ov);
+            server.setLabelState(DB, TABLE, label, TransactionStatus.VISIBLE);
+
+            Assert.assertTrue("a status-less commit body must reconcile to success, body=" + rawBody,
+                    loader.commit(new StreamLoadSnapshot.Transaction(DB, TABLE, label, true)));
+        }
+    }
+
+    @Test
+    public void testCommitResponseWithoutStatusStillFailsWhenNotCommitted() {
+        // The reconciliation must not turn a status-less body into blanket success: if the label
+        // is genuinely not committed, the commit still has to fail.
+        TransactionStreamLoader loader = startedLoader(props(-1));
+        String label = "lbl-no-status-uncommitted";
+        MockedStarRocksHttpServer.ResponseOverride ov = new MockedStarRocksHttpServer.ResponseOverride();
+        ov.httpCode = 200;
+        ov.rawBody = "{}";
+        server.setCommitOverride(ov);
+        server.setLabelState(DB, TABLE, label, TransactionStatus.ABORTED);
+
+        try {
+            loader.commit(new StreamLoadSnapshot.Transaction(DB, TABLE, label, true));
+            Assert.fail("an uncommitted label must still fail even when the body carried no status");
+        } catch (RuntimeException expected) {
+            // expected: reconciliation found a non-committed terminal state and rethrew
+        }
+    }
+
+    @Test
     public void testCommitResponseLostWhileStillCommittingWaitsInsteadOfFailing() throws Exception {
         // The bounded socket timeout can fire WHILE the FE is still committing: the txn is
         // transiently PREPARE, not lost. The reconciliation must poll until it settles, not fail

--- a/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/TransactionCommitRecoveryTest.java
+++ b/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/TransactionCommitRecoveryTest.java
@@ -95,6 +95,26 @@ public class TransactionCommitRecoveryTest {
         return b.build();
     }
 
+    /** Same as {@link #props(int)} but with the stream-load {@code timeout} header set. */
+    private StreamLoadProperties propsWithTimeoutHeader(int socketTimeoutMs, String timeoutSec) {
+        StreamLoadTableProperties table = StreamLoadTableProperties.builder()
+                .database(DB)
+                .table(TABLE)
+                .streamLoadDataFormat(StreamLoadDataFormat.JSON)
+                .build();
+        return StreamLoadProperties.builder()
+                .loadUrls(server.getBaseUrl())
+                .username(USER)
+                .password(PASS)
+                .version("4.0.0")
+                .labelPrefix("test-commit-")
+                .ioThreadCount(2)
+                .defaultTableProperties(table)
+                .socketTimeout(socketTimeoutMs)
+                .addHeader("timeout", timeoutSec)
+                .build();
+    }
+
     private TransactionStreamLoader startedLoader(StreamLoadProperties p) {
         TransactionStreamLoader loader = new TransactionStreamLoader(true);
         loader.start(p, new NoopManager());
@@ -124,6 +144,31 @@ public class TransactionCommitRecoveryTest {
         Assert.assertEquals(7_000, DefaultStreamLoader.boundedRpcSocketTimeoutMs(props(7_000)));
         // An explicit 0 (opt-in infinite per the sink.socket.timeout-ms contract) is honored, NOT bounded.
         Assert.assertEquals(0, DefaultStreamLoader.boundedRpcSocketTimeoutMs(props(0)));
+    }
+
+    @Test
+    public void testBoundedRpcSocketTimeoutStaysWithinManagerFlushBudget() {
+        // DefaultStreamLoadManager derives flushTimeoutMs = timeoutSec * 1100 from the stream-load
+        // `timeout` header. Blocking the manager thread past that budget is never useful: the
+        // server-side transaction is already gone. A short timeout must therefore shrink the bound.
+        Assert.assertEquals("timeout=1 -> 1.1s flush budget must cap the 90s default bound",
+                1_100, DefaultStreamLoader.boundedRpcSocketTimeoutMs(propsWithTimeoutHeader(-1, "1")));
+        Assert.assertEquals("timeout=30 -> 33s flush budget must cap the 90s default bound",
+                33_000, DefaultStreamLoader.boundedRpcSocketTimeoutMs(propsWithTimeoutHeader(-1, "30")));
+
+        // Above the crossover (~82s) the publish-derived bound is already the smaller of the two.
+        Assert.assertEquals("timeout=600 -> 660s flush budget leaves the 90s bound untouched",
+                90_000, DefaultStreamLoader.boundedRpcSocketTimeoutMs(propsWithTimeoutHeader(-1, "600")));
+        // No timeout header at all: the manager keeps its own default, so no extra cap applies.
+        Assert.assertEquals(90_000, DefaultStreamLoader.boundedRpcSocketTimeoutMs(props(-1)));
+
+        // An unparseable or non-positive header must not shrink (or zero out) the bound — the
+        // manager falls back to its default in exactly these cases.
+        Assert.assertEquals(90_000, DefaultStreamLoader.boundedRpcSocketTimeoutMs(propsWithTimeoutHeader(-1, "abc")));
+        Assert.assertEquals(90_000, DefaultStreamLoader.boundedRpcSocketTimeoutMs(propsWithTimeoutHeader(-1, "0")));
+
+        // An explicit socketTimeout still wins over the flush-budget cap: the user opted in.
+        Assert.assertEquals(7_000, DefaultStreamLoader.boundedRpcSocketTimeoutMs(propsWithTimeoutHeader(7_000, "1")));
     }
 
     // ---------- A2 ----------

--- a/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/TransactionCommitRecoveryTest.java
+++ b/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/TransactionCommitRecoveryTest.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.starrocks.data.load.stream;
+
+import com.starrocks.data.load.stream.properties.StreamLoadProperties;
+import com.starrocks.data.load.stream.properties.StreamLoadTableProperties;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Regression for the "commit response lost" failure:
+ *
+ * <ul>
+ *   <li><b>A1 — bounded RPC socket timeout</b>: the blocking transaction RPCs (begin/prepare/
+ *       commit) run on the sink's manager thread; with the default {@code socketTimeout == -1}
+ *       (infinite) a lost response would hang the thread indefinitely. {@code
+ *       DefaultStreamLoader.boundedRpcSocketTimeoutMs} must never return an unbounded value.</li>
+ *   <li><b>A2 — label-state reconciliation on a lost commit response</b>: when the commit HTTP
+ *       fails before a status can be read (socket timeout, connection reset, non-200 from an
+ *       LB/proxy, unparseable body) but the transaction actually committed server-side, {@code
+ *       commit()} must reconcile against the real label state and return success instead of
+ *       failing the job. Previously the {@code catch} block threw without checking label state,
+ *       so a committed-but-response-lost transaction failed the job (then restart-stormed).</li>
+ * </ul>
+ */
+public class TransactionCommitRecoveryTest {
+
+    private static final String USER = "root";
+    private static final String PASS = "";
+    private static final String DB = "test";
+    private static final String TABLE = "orders";
+
+    private MockedStarRocksHttpServer server;
+    private final List<TransactionStreamLoader> loaders = new ArrayList<>();
+
+    @Before
+    public void setUp() throws Exception {
+        server = MockedStarRocksHttpServer.builder().port(0).enforceAuth(USER, PASS).build();
+        server.start();
+    }
+
+    @After
+    public void tearDown() {
+        // Close every loader started by the test so its ScheduledExecutorService threads do not
+        // leak across the suite.
+        for (TransactionStreamLoader loader : loaders) {
+            try {
+                loader.close();
+            } catch (Exception ignored) {
+                // best-effort cleanup
+            }
+        }
+        loaders.clear();
+        if (server != null) {
+            server.stop();
+        }
+    }
+
+    private StreamLoadProperties props(int socketTimeoutMs) {
+        StreamLoadTableProperties table = StreamLoadTableProperties.builder()
+                .database(DB)
+                .table(TABLE)
+                .streamLoadDataFormat(StreamLoadDataFormat.JSON)
+                .build();
+        StreamLoadProperties.Builder b = StreamLoadProperties.builder()
+                .loadUrls(server.getBaseUrl())
+                .username(USER)
+                .password(PASS)
+                .version("4.0.0")
+                .labelPrefix("test-commit-")
+                .ioThreadCount(2)
+                .defaultTableProperties(table)
+                .socketTimeout(socketTimeoutMs); // -1 = default(unset), 0 = explicit infinite, >0 = explicit
+        return b.build();
+    }
+
+    private TransactionStreamLoader startedLoader(StreamLoadProperties p) {
+        TransactionStreamLoader loader = new TransactionStreamLoader(true);
+        loader.start(p, new NoopManager());
+        loaders.add(loader);
+        return loader;
+    }
+
+    private static MockedStarRocksHttpServer.ResponseOverride lostCommitResponse() {
+        // A non-200 from an intermediary makes parseHttpResponse throw *inside* commit()'s try,
+        // landing in the exact catch block A2 fixes — the same block a socket timeout / reset hits.
+        MockedStarRocksHttpServer.ResponseOverride ov = new MockedStarRocksHttpServer.ResponseOverride();
+        ov.httpCode = 500;
+        ov.status = StreamLoadConstants.RESULT_STATUS_FAILED;
+        return ov;
+    }
+
+    // ---------- A1 ----------
+
+    @Test
+    public void testBoundedRpcSocketTimeoutIsNeverInfinite() {
+        // The -1 default (unset) is infinite in Apache HttpClient -> must be bounded.
+        int bounded = DefaultStreamLoader.boundedRpcSocketTimeoutMs(props(-1));
+        Assert.assertTrue("bounded socket timeout must be > 0 (never -1/infinite), was " + bounded, bounded > 0);
+        Assert.assertTrue("bounded socket timeout must stay well under the 660s flush timeout, was " + bounded,
+                bounded <= 300_000);
+        // An explicitly configured positive socketTimeout is honored as-is.
+        Assert.assertEquals(7_000, DefaultStreamLoader.boundedRpcSocketTimeoutMs(props(7_000)));
+        // An explicit 0 (opt-in infinite per the sink.socket.timeout-ms contract) is honored, NOT bounded.
+        Assert.assertEquals(0, DefaultStreamLoader.boundedRpcSocketTimeoutMs(props(0)));
+    }
+
+    // ---------- A2 ----------
+
+    @Test
+    public void testCommitResponseLostButCommittedTreatedAsSuccess() {
+        TransactionStreamLoader loader = startedLoader(props(-1));
+        String label = "lbl-committed-but-response-lost";
+        server.setCommitOverride(lostCommitResponse());
+        // The transaction actually committed server-side (FE committed; the reply was dropped).
+        server.setLabelState(DB, TABLE, label, TransactionStatus.VISIBLE);
+
+        boolean ok = loader.commit(new StreamLoadSnapshot.Transaction(DB, TABLE, label, true));
+        Assert.assertTrue("a committed-but-response-lost transaction must be reconciled to success", ok);
+        Assert.assertTrue("the lost commit response must actually have been exercised", server.getCommitCount() >= 1);
+    }
+
+    @Test
+    public void testCommitResponseLostWhileStillCommittingWaitsInsteadOfFailing() throws Exception {
+        // The bounded socket timeout can fire WHILE the FE is still committing: the txn is
+        // transiently PREPARE, not lost. The reconciliation must poll until it settles, not fail
+        // on the first (in-progress) state read. Model that: label starts PREPARE, then flips to
+        // VISIBLE shortly after (as the FE finishes committing).
+        TransactionStreamLoader loader = startedLoader(props(-1));
+        String label = "lbl-still-committing";
+        server.setCommitOverride(lostCommitResponse());
+        server.setLabelState(DB, TABLE, label, TransactionStatus.PREPARE);
+        Thread flip = new Thread(() -> {
+            try {
+                Thread.sleep(400);
+            } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+            }
+            server.setLabelState(DB, TABLE, label, TransactionStatus.VISIBLE);
+        });
+        flip.setDaemon(true);
+        flip.start();
+
+        boolean ok = loader.commit(new StreamLoadSnapshot.Transaction(DB, TABLE, label, true));
+        Assert.assertTrue("a commit that is still in progress (transient PREPARE) must be waited "
+                + "out and reconciled to success once it settles, not prematurely failed", ok);
+    }
+
+    @Test
+    public void testCommitResponseLostAndNotCommittedStillFails() {
+        TransactionStreamLoader loader = startedLoader(props(-1));
+        String label = "lbl-genuinely-uncommitted";
+        server.setCommitOverride(lostCommitResponse());
+        // The transaction did NOT commit (still UNKNOWN/absent server-side) -> must fail, not mask.
+        server.setLabelState(DB, TABLE, label, TransactionStatus.UNKNOWN);
+
+        try {
+            loader.commit(new StreamLoadSnapshot.Transaction(DB, TABLE, label, true));
+            Assert.fail("a genuinely-uncommitted lost commit must still fail (no false success)");
+        } catch (RuntimeException expected) {
+            // expected
+        }
+    }
+
+    private static class NoopManager implements StreamLoadManager {
+        @Override public void init() {}
+        @Override public void write(String uniqueKey, String database, String table, String... rows) {}
+        @Override public void callback(StreamLoadResponse response) {}
+        @Override public void callback(Throwable e) {}
+        @Override public void flush() {}
+        @Override public StreamLoadSnapshot snapshot() { return null; }
+        @Override public boolean prepare(StreamLoadSnapshot snapshot) { return true; }
+        @Override public boolean commit(StreamLoadSnapshot snapshot) { return true; }
+        @Override public boolean abort(StreamLoadSnapshot snapshot) { return true; }
+        @Override public void close() {}
+    }
+}

--- a/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/TransactionCommitRecoveryTest.java
+++ b/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/TransactionCommitRecoveryTest.java
@@ -169,6 +169,13 @@ public class TransactionCommitRecoveryTest {
         Assert.assertEquals(90_000, DefaultStreamLoader.boundedRpcSocketTimeoutMs(propsWithTimeoutHeader(-1, "abc")));
         Assert.assertEquals(90_000, DefaultStreamLoader.boundedRpcSocketTimeoutMs(propsWithTimeoutHeader(-1, "0")));
 
+        // Whitespace must be treated exactly as the manager treats it. DefaultStreamLoadManager
+        // calls Long.parseLong on the raw header, so " 1 " throws there and it keeps its 660s
+        // default. Parsing more leniently here would cap the RPC at 1.1s against a budget the
+        // manager never adopted, failing begin/prepare/commit prematurely.
+        Assert.assertEquals("a padded header must not shrink the bound: the manager rejects it too",
+                90_000, DefaultStreamLoader.boundedRpcSocketTimeoutMs(propsWithTimeoutHeader(-1, " 1 ")));
+
         // An explicit socketTimeout still wins over the flush-budget cap: the user opted in.
         Assert.assertEquals(7_000, DefaultStreamLoader.boundedRpcSocketTimeoutMs(propsWithTimeoutHeader(7_000, "1")));
     }

--- a/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/TransactionCommitRecoveryTest.java
+++ b/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/TransactionCommitRecoveryTest.java
@@ -50,6 +50,8 @@ public class TransactionCommitRecoveryTest {
     private static final String PASS = "";
     private static final String DB = "test";
     private static final String TABLE = "orders";
+    /** Port 1 is reserved and never listening, so connections are refused immediately. */
+    private static final String DEAD_HOST = "http://127.0.0.1:1";
 
     private MockedStarRocksHttpServer server;
     private final List<TransactionStreamLoader> loaders = new ArrayList<>();
@@ -266,6 +268,75 @@ public class TransactionCommitRecoveryTest {
             Assert.fail("a genuinely-uncommitted lost commit must still fail (no false success)");
         } catch (RuntimeException expected) {
             // expected
+        }
+    }
+
+    @Test
+    public void testCommitResponseLostIsReconciledViaAnotherConfiguredFe() {
+        // The FE that took the commit can be exactly the thing that died: it commits, then becomes
+        // unreachable before the reply is read. getLabelState does no host selection of its own, so
+        // pinning reconciliation to that FE turned a durably committed txn into a job failure even
+        // though another configured FE could answer. The query must fail over to the other hosts.
+        String deadFe = DEAD_HOST;
+        StreamLoadProperties p = StreamLoadProperties.builder()
+                .loadUrls(deadFe, server.getBaseUrl())
+                .username(USER)
+                .password(PASS)
+                .version("4.0.0")
+                .labelPrefix("test-commit-")
+                .ioThreadCount(2)
+                .defaultTableProperties(StreamLoadTableProperties.builder()
+                        .database(DB)
+                        .table(TABLE)
+                        .streamLoadDataFormat(StreamLoadDataFormat.JSON)
+                        .build())
+                .socketTimeout(-1)
+                .build();
+        // Force the commit onto the dead FE, so both the commit and the first label-state query hit
+        // it — the exact "committed, then that FE went away" shape.
+        TransactionStreamLoader loader = new TransactionStreamLoader(true) {
+            @Override
+            protected String getAvailableHost() {
+                return deadFe;
+            }
+        };
+        loader.start(p, new NoopManager());
+        loaders.add(loader);
+
+        String label = "lbl-committed-fe-gone";
+        // The surviving FE reports the truth: the transaction did commit.
+        server.setLabelState(DB, TABLE, label, TransactionStatus.VISIBLE);
+
+        Assert.assertTrue("a commit whose FE died after committing must be reconciled through another "
+                        + "configured FE, not failed",
+                loader.commit(new StreamLoadSnapshot.Transaction(DB, TABLE, label, true)));
+    }
+
+    @Test
+    public void testCommitReconciliationStillFailsWhenNoConfiguredFeAnswers() {
+        // Failover must not become blanket success: if no configured FE can answer, the commit
+        // still fails rather than being assumed committed.
+        StreamLoadProperties p = StreamLoadProperties.builder()
+                .loadUrls(DEAD_HOST)
+                .username(USER)
+                .password(PASS)
+                .version("4.0.0")
+                .labelPrefix("test-commit-")
+                .ioThreadCount(2)
+                .defaultTableProperties(StreamLoadTableProperties.builder()
+                        .database(DB)
+                        .table(TABLE)
+                        .streamLoadDataFormat(StreamLoadDataFormat.JSON)
+                        .build())
+                .socketTimeout(-1)
+                .build();
+        TransactionStreamLoader loader = startedLoader(p);
+
+        try {
+            loader.commit(new StreamLoadSnapshot.Transaction(DB, TABLE, "lbl-no-fe-answers", true));
+            Assert.fail("with no FE able to report the label state the commit must still fail");
+        } catch (RuntimeException expected) {
+            // expected: every candidate host failed, so the original cause is rethrown
         }
     }
 


### PR DESCRIPTION
## What

In multi-table transaction mode, when the commit HTTP fails *before a status can be read* — socket timeout, connection reset, a non-200 from an LB/proxy, or an unparseable body — the transaction may nonetheless have **COMMITTED** server-side (the FE commits, then the reply is dropped by the LB/network). Two defects turned that into a fatal, self-perpetuating stall (observed in production: the commit-in-flight hangs to the flush timeout, then the job restart-storms even though the data is committed & visible).

## Root cause

**A1 — unbounded socket read timeout on manager-thread RPCs.** `begin`/`prepare`/`commit` are blocking HTTP calls on the sink's manager thread and used `RequestConfig.setSocketTimeout(properties.getSocketTimeout())`, whose default is `-1` (infinite in Apache HttpClient). A lost response therefore hangs the manager thread until the transport eventually resets, stalling the whole subtask (and blocking every other flush/commit for that subtask).

**A2 — no label-state reconciliation on a lost commit response.** `TransactionStreamLoader.commit()` already reconciles a *non-OK response* against the real label state via `get_load_state` (treating `COMMITTED`/`VISIBLE` as success). But its `catch` block threw `RuntimeException` **without** that check — so a lost/errored response (the exact "committed-but-reply-dropped" case) failed the job.

## Fix

- `DefaultStreamLoader.boundedRpcSocketTimeoutMs()` derives a bounded read timeout (honors an explicit `socketTimeout > 0`; otherwise `publishTimeout + margin`, capped at 300s, always well under the 660s flush timeout) and is applied to `begin`/`prepare`/`commit` and the `get_load_state` query.
- `commit()`'s `catch` now reconciles against the real label state (mirroring the `prepare()` and non-OK-commit paths): `COMMITTED`/`VISIBLE` ⇒ success; a genuinely uncommitted label still fails.

Also fixes a latent bug in `MockedStarRocksHttpServer`: the `get_load_state` route (3 path segments) was unreachable behind a `segments.size() >= 4` guard, so its own `== 3` branch was dead code (existing tests never hit it because commits succeed).

## Testing

- **Unit** (`TransactionCommitRecoveryTest`): bounded-timeout invariant (A1); committed-but-response-lost ⇒ success (A2, RED without the fix, mutation-verified); genuinely-uncommitted ⇒ still fails. SDK suite 166/166.
- **Real cluster (SR 4.0.10)**:
  - `get_load_state` for a committed multi-statement label returns `VISIBLE` (while `information_schema.loads` shows `PREPARING` — a different, display-only FE path), confirming A2's state source is correct for multi-table.
  - End-to-end via a fault-injecting proxy that lets the FE commit but drops the commit response: the connector hits `SocketTimeoutException` at the bounded timeout, recovers via `get_load_state` (`…label is already VISIBLE server-side; treating the commit as successful.`, ×4), and the job finishes with exact counts (4000/12000) and 0 `TXN_IN_PROCESSING`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)