### PR TITLE
[Enhancement] Skip host probe when only one load URL is configured

### DIFF
--- a/src/main/java/com/starrocks/connector/flink/manager/StarRocksStreamLoadVisitor.java
+++ b/src/main/java/com/starrocks/connector/flink/manager/StarRocksStreamLoadVisitor.java
@@ -212,7 +212,9 @@ public class StarRocksStreamLoadVisitor implements Serializable {
                 host = "http://" + host;
             }
             pos++;
-            if (tryHttpConnection(host)) {
+            // No alternative host to fall back to, so probing is useless: if the only
+            // host is down, the subsequent load request will fail and report it anyway
+            if (hostList.size() == 1 || tryHttpConnection(host)) {
                 return host;
             }
         }
@@ -310,6 +312,7 @@ public class StarRocksStreamLoadVisitor implements Serializable {
             httpPut.setHeader("Authorization", getBasicAuthHeader(sinkOptions.getUsername(), sinkOptions.getPassword()));
             httpPut.setEntity(new ByteArrayEntity(data));
             httpPut.setConfig(RequestConfig.custom()
+                    .setConnectTimeout(sinkOptions.getConnectTimeout())
                     .setSocketTimeout(sinkOptions.getSocketTimeout())
                     .setRedirectsEnabled(true).build());
             try (CloseableHttpResponse resp = httpclient.execute(httpPut)) {

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/DefaultStreamLoader.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/DefaultStreamLoader.java
@@ -289,6 +289,7 @@ public class DefaultStreamLoader implements StreamLoader, Serializable {
 
             HttpPut httpPut = new HttpPut(sendUrl);
             httpPut.setConfig(RequestConfig.custom()
+                        .setConnectTimeout(properties.getConnectTimeout())
                         .setSocketTimeout(properties.getSocketTimeout())
                         .setExpectContinueEnabled(true)
                         .setRedirectsEnabled(true)
@@ -364,6 +365,11 @@ public class DefaultStreamLoader implements StreamLoader, Serializable {
     protected String getAvailableHost() {
         String[] hosts = properties.getLoadUrls();
         int size = hosts.length;
+        // No alternative host to fall back to, so probing is useless: if the only
+        // host is down, the subsequent load request will fail and report it anyway
+        if (size == 1) {
+            return hosts[0];
+        }
         long pos = availableHostPos;
         long tmp = pos + size;
         while (pos < tmp) {
@@ -458,6 +464,9 @@ public class DefaultStreamLoader implements StreamLoader, Serializable {
             try (CloseableHttpClient client = HttpClients.createDefault()) {
                 String url = host + "/api/" + database + "/get_load_state?label=" + label;
                 HttpGet httpGet = new HttpGet(url);
+                httpGet.setConfig(RequestConfig.custom()
+                        .setConnectTimeout(properties.getConnectTimeout())
+                        .build());
                 httpGet.addHeader("Authorization", StreamLoadUtils.getBasicAuthHeader(properties.getUsername(), properties.getPassword()));
                 httpGet.setHeader("Connection", "close");
                 try (CloseableHttpResponse response = client.execute(httpGet)) {
@@ -497,6 +506,9 @@ public class DefaultStreamLoader implements StreamLoader, Serializable {
         log.info("Cancel load via FE, db: {}, table: {}, label: {}, url: {}", db, table, label, url);
 
         HttpPost httpPost = new HttpPost(url);
+        httpPost.setConfig(RequestConfig.custom()
+                .setConnectTimeout(properties.getConnectTimeout())
+                .build());
         httpPost.addHeader("Authorization",
                 StreamLoadUtils.getBasicAuthHeader(properties.getUsername(), properties.getPassword()));
         httpPost.setHeader("Connection", "close");

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/TransactionStreamLoader.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/TransactionStreamLoader.java
@@ -152,6 +152,7 @@ public class TransactionStreamLoader extends DefaultStreamLoader {
         }
 
         httpPost.setConfig(RequestConfig.custom()
+                        .setConnectTimeout(properties.getConnectTimeout())
                         .setSocketTimeout(properties.getSocketTimeout())
                         .setExpectContinueEnabled(true)
                         .setRedirectsEnabled(true)
@@ -210,6 +211,7 @@ public class TransactionStreamLoader extends DefaultStreamLoader {
         }
 
         httpPost.setConfig(RequestConfig.custom()
+                        .setConnectTimeout(properties.getConnectTimeout())
                         .setSocketTimeout(properties.getSocketTimeout())
                         .setExpectContinueEnabled(true)
                         .setRedirectsEnabled(true)
@@ -289,6 +291,7 @@ public class TransactionStreamLoader extends DefaultStreamLoader {
         }
 
         httpPost.setConfig(RequestConfig.custom()
+                        .setConnectTimeout(properties.getConnectTimeout())
                         .setSocketTimeout(properties.getSocketTimeout())
                         .setExpectContinueEnabled(true)
                         .setRedirectsEnabled(true)
@@ -366,6 +369,10 @@ public class TransactionStreamLoader extends DefaultStreamLoader {
         } else {
             httpPost.addHeader("table", transaction.getTable());
         }
+
+        httpPost.setConfig(RequestConfig.custom()
+                        .setConnectTimeout(properties.getConnectTimeout())
+                        .build());
 
         try (CloseableHttpClient client = clientBuilder.build()) {
             String responseBody;


### PR DESCRIPTION
With a single host there is no alternative to fall back to, so probing
the connection before a load only adds latency (and a connect-timeout
stall when the host is temporarily unreachable). Return the host
directly and let the actual load request surface any connection error.

Applies to DefaultStreamLoader.getAvailableHost() (also inherited by
TransactionStreamLoader) and the legacy
StarRocksStreamLoadVisitor.getAvailableHost().

Since the probe was the only place that enforced the configured connect
timeout, also carry setConnectTimeout onto the actual requests (stream
load put, txn begin/prepare/commit/rollback, get_load_state, cancel)
so an unreachable host still fails fast instead of hanging on TCP
connect with OS defaults.


## What type of PR is this：
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required) ：
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

