### PR TITLE
feat(stream-load-sdk): Add Apache Arrow format support

### DIFF
--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/BatchTableRegion.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/BatchTableRegion.java
@@ -335,6 +335,9 @@ public class BatchTableRegion implements TableRegion {
             }
             chunkBytes += bytes.length + d;
             chunkRows++;
+            if (!dataFormat.supportsBatching()) {
+                break;
+            }
         }
 
         return new StreamLoadEntityMeta(chunkBytes, chunkRows);

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/Chunk.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/Chunk.java
@@ -20,8 +20,10 @@
 
 package com.starrocks.data.load.stream;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -83,6 +85,13 @@ public class Chunk {
 
     public void release() {
         buffer = null;
+    }
+
+    public List<byte[]> getRows() {
+        if (buffer == null) {
+            throw new RuntimeException("Buffer has been released");
+        }
+        return Collections.unmodifiableList(buffer);
     }
 
     public Iterator<byte[]> iterator() {

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/StreamLoadDataFormat.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/StreamLoadDataFormat.java
@@ -28,6 +28,7 @@ import java.nio.charset.StandardCharsets;
 public interface StreamLoadDataFormat {
     StreamLoadDataFormat JSON = new JSONFormat();
     StreamLoadDataFormat CSV = new CSVFormat();
+    StreamLoadDataFormat ARROW = new ArrowFormat();
 
     default String name() {
         return "";
@@ -126,6 +127,53 @@ public interface StreamLoadDataFormat {
                     ", delimiter=" + new String(delimiter) +
                     ", end=" + new String(end) +
                     '}';
+        }
+    }
+
+    /**
+     * ArrowFormat represents the Apache Arrow IPC stream format.
+     * <p>
+     * Note on validation: This SDK intentionally avoids importing heavyweight Apache Arrow
+     * dependencies (such as arrow-vector and arrow-memory) to keep the client lightweight 
+     * and performant. Therefore, there is no client-side schema validation of the Arrow 
+     * RecordBatches before they are sent. The SDK simply streams the raw bytes directly.
+     * <p>
+     * Validation is delegated to the StarRocks backend's ArrowScanner, which will natively 
+     * parse the Arrow IPC stream and validate its schema against the requested `columns` 
+     * mapping HTTP header. If an invalid Arrow byte stream is sent, the stream load 
+     * operation will fail and return an error from the backend.
+     * <p>
+     * Since Arrow IPC streams are self-describing and do not use text delimiters, 
+     * `first()`, `delimiter()`, and `end()` all return empty byte arrays to enable 
+     * zero-copy appending of pre-serialized RecordBatches.
+     */
+    class ArrowFormat implements StreamLoadDataFormat, Serializable {
+        private static final byte[] EMPTY = new byte[0];
+
+        @Override
+        public String name() {
+            return "arrow";
+        }
+
+        @Override
+        public byte[] first() {
+            return EMPTY;
+        }
+
+        @Override
+        public byte[] delimiter() {
+            return EMPTY;
+        }
+
+        @Override
+        public byte[] end() {
+            return EMPTY;
+        }
+
+        @JsonValue
+        @Override
+        public String toString() {
+            return "ArrowFormat{}";
         }
     }
 }

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/StreamLoadDataFormat.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/StreamLoadDataFormat.java
@@ -28,9 +28,24 @@ import java.nio.charset.StandardCharsets;
 public interface StreamLoadDataFormat {
     StreamLoadDataFormat JSON = new JSONFormat();
     StreamLoadDataFormat CSV = new CSVFormat();
+    StreamLoadDataFormat ARROW = new ArrowFormat();
 
     default String name() {
         return "";
+    }
+
+    /**
+     * Whether this format supports combining multiple records into a single
+     * chunk / HTTP request body using {@link #delimiter()}.
+     *
+     * <p>Formats such as CSV and JSON return {@code true}. Self-contained binary
+     * formats such as Arrow IPC streams return {@code false} because each payload
+     * is an independent stream with its own schema and end-of-stream marker, and
+     * raw concatenation within a single HTTP body causes parser errors or dropped
+     * records on the backend.
+     */
+    default boolean supportsBatching() {
+        return true;
     }
 
     byte[] first();
@@ -126,6 +141,84 @@ public interface StreamLoadDataFormat {
                     ", delimiter=" + new String(delimiter) +
                     ", end=" + new String(end) +
                     '}';
+        }
+    }
+
+    /**
+     * ArrowFormat represents the Apache Arrow IPC stream format.
+     * <p>
+     * Note on validation: This SDK intentionally avoids importing heavyweight Apache Arrow
+     * dependencies (such as arrow-vector and arrow-memory) to keep the client lightweight 
+     * and performant. Therefore, there is no client-side schema validation of the Arrow 
+     * RecordBatches before they are sent. The SDK simply streams the raw bytes directly.
+     * <p>
+     * Validation is delegated to the StarRocks backend's ArrowScanner, which will natively 
+     * parse the Arrow IPC stream and validate its schema against the requested {@code columns} 
+     * mapping HTTP header. If an invalid Arrow byte stream is sent, the stream load 
+     * operation will fail and return an error from the backend.
+     * <p>
+     * <b>Important:</b> Arrow IPC streams contain arbitrary binary data (magic bytes,
+     * flatbuffer metadata, padding) that is not valid UTF-8. Callers <b>must</b> use the
+     * {@link StreamLoadManager#write(String, String, String, byte[]...)} binary write API
+     * instead of the {@code String}-based overload. Passing an Arrow payload through
+     * {@code String.getBytes(UTF_8)} will silently corrupt the stream.
+     * <p>
+     * Furthermore, each {@code byte[]} passed to the write API must be a complete,
+     * self-contained Arrow IPC stream (containing its own Schema message, RecordBatch
+     * messages, and EOS marker). To preserve stream boundaries, the SDK enforces that each
+     * payload is dispatched in an independent HTTP request ({@link #supportsBatching()}
+     * returns {@code false}) rather than being concatenated into a single request body.
+     * <p>
+     * Since Arrow IPC streams are self-describing and do not use text delimiters, 
+     * {@code first()}, {@code delimiter()}, and {@code end()} all return empty byte arrays
+     * to enable zero-copy appending of pre-serialized RecordBatches.
+     */
+    class ArrowFormat implements StreamLoadDataFormat, Serializable {
+        private static final byte[] EMPTY = new byte[0];
+
+        @Override
+        public String name() {
+            return "arrow";
+        }
+
+        @Override
+        public boolean supportsBatching() {
+            return false;
+        }
+
+        @Override
+        public byte[] first() {
+            return EMPTY;
+        }
+
+        @Override
+        public byte[] delimiter() {
+            return EMPTY;
+        }
+
+        @Override
+        public byte[] end() {
+            return EMPTY;
+        }
+
+        @JsonValue
+        @Override
+        public String toString() {
+            return "ArrowFormat{}";
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            return o instanceof ArrowFormat;
+        }
+
+        @Override
+        public int hashCode() {
+            return ArrowFormat.class.hashCode();
+        }
+
+        private Object readResolve() {
+            return ARROW;
         }
     }
 }

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/StreamLoadManager.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/StreamLoadManager.java
@@ -27,6 +27,22 @@ public interface StreamLoadManager {
 
     void init();
     void write(String uniqueKey, String database, String table, String... rows);
+
+    /**
+     * Binary write API for formats that produce raw byte payloads (e.g. Arrow IPC).
+     *
+     * <p>Unlike {@link #write(String, String, String, String...)}, this method
+     * accepts pre-serialized {@code byte[]} rows and passes them directly to the
+     * underlying {@link com.starrocks.data.load.stream.TableRegion} without any
+     * character-set conversion.  This is essential for Arrow streams whose IPC
+     * framing bytes are arbitrary binary data and would be corrupted by a
+     * {@code String → getBytes(UTF_8)} round-trip.
+     */
+    default void write(String uniqueKey, String database, String table, byte[]... rows) {
+        throw new UnsupportedOperationException(
+                "Binary write not supported by this StreamLoadManager implementation");
+    }
+
     void callback(StreamLoadResponse response);
     void callback(Throwable e);
     void flush();
@@ -68,6 +84,15 @@ public interface StreamLoadManager {
      */
     default void write(int partition, String database, String table, String... rows) {
         write(null, database, table, rows);
+    }
+
+    /**
+     * Partition-aware binary write for multi-table transaction mode.
+     *
+     * @see #write(String, String, String, byte[])
+     */
+    default void write(int partition, String database, String table, byte[]... rows) {
+        write((String) null, database, table, rows);
     }
 
     default Throwable getException() {

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/mergecommit/MergeCommitManager.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/mergecommit/MergeCommitManager.java
@@ -20,6 +20,7 @@ package com.starrocks.data.load.stream.mergecommit;
 
 import com.starrocks.data.load.stream.EnvUtils;
 import com.starrocks.data.load.stream.LabelGeneratorFactory;
+import com.starrocks.data.load.stream.StreamLoadDataFormat;
 import com.starrocks.data.load.stream.StreamLoadManager;
 import com.starrocks.data.load.stream.StreamLoadResponse;
 import com.starrocks.data.load.stream.StreamLoadSnapshot;
@@ -67,7 +68,7 @@ public class MergeCommitManager implements StreamLoadManager, Serializable {
     private final AtomicReference<Throwable> exception;
     private transient Thread cacheMonitorThread;
     private transient AtomicBoolean closed;
-    private transient MetricListener metricListener;
+    private transient MetricListener metricListener = new EmptyMetricListener();
 
     public MergeCommitManager(StreamLoadProperties properties) {
         this.properties = properties;
@@ -99,6 +100,13 @@ public class MergeCommitManager implements StreamLoadManager, Serializable {
     @Override
     public void write(String uniqueKey, String database, String tableName, String... rows) {
         Table table = getTable(database, tableName);
+        if (table.getProperties() != null
+                && table.getProperties().getDataFormat() instanceof StreamLoadDataFormat.ArrowFormat) {
+            throw new IllegalStateException(
+                    "Arrow format requires the byte[] write API. "
+                    + "String-based writes will corrupt the Arrow IPC stream. "
+                    + "Use write(uniqueKey, database, table, byte[]...) instead.");
+        }
         int totalBytes = 0;
         for (String row : rows) {
             checkException();
@@ -116,6 +124,34 @@ public class MergeCommitManager implements StreamLoadManager, Serializable {
             checkCacheFull();
         }
         metricListener.onWrite(rows.length, totalBytes);
+        metricListener.onCacheChange(maxWriteBlockCacheBytes, currentCacheBytes.get());
+    }
+
+    @Override
+    public void write(String uniqueKey, String database, String tableName, byte[]... rows) {
+        Table table = getTable(database, tableName);
+        int totalBytes = 0;
+        int validRows = 0;
+        for (byte[] data : rows) {
+            if (data == null) {
+                continue;
+            }
+            validRows++;
+            checkException();
+            if (properties.isBlackhole()) {
+                totalBytes += data.length;
+            } else {
+                int bytes = table.write(data);
+                totalBytes += bytes;
+                currentCacheBytes.addAndGet(bytes);
+            }
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Write binary record, database {}, table {}, {} bytes",
+                        database, tableName, data.length);
+            }
+            checkCacheFull();
+        }
+        metricListener.onWrite(validRows, totalBytes);
         metricListener.onCacheChange(maxWriteBlockCacheBytes, currentCacheBytes.get());
     }
 

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/mergecommit/Table.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/mergecommit/Table.java
@@ -137,7 +137,11 @@ public class Table {
             chunk.addRow(row);
             cacheBytes.addAndGet(row.length);
             cacheRows.incrementAndGet();
-            switchChunk(FlushChunkReason.CHUNK_FULL);
+            if (!properties.getDataFormat().supportsBatching()) {
+                switchChunk(FlushChunkReason.FLUSH);
+            } else {
+                switchChunk(FlushChunkReason.CHUNK_FULL);
+            }
             return row.length;
         } finally {
             lock.unlock();

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/properties/StreamLoadTableProperties.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/properties/StreamLoadTableProperties.java
@@ -239,6 +239,9 @@ public class StreamLoadTableProperties implements Serializable {
             if (columns != null) {
                 addProperty("columns", columns);
             }
+            if (dataFormat instanceof StreamLoadDataFormat.ArrowFormat) {
+                addProperty("format", "arrow");
+            }
             return new StreamLoadTableProperties(this);
         }
 

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/properties/StreamLoadTableProperties.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/properties/StreamLoadTableProperties.java
@@ -239,6 +239,10 @@ public class StreamLoadTableProperties implements Serializable {
             if (columns != null) {
                 addProperty("columns", columns);
             }
+            if (dataFormat instanceof StreamLoadDataFormat.ArrowFormat
+                    && !properties.containsKey("format")) {
+                addProperty("format", "arrow");
+            }
             return new StreamLoadTableProperties(this);
         }
 

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/DefaultStreamLoadManager.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/DefaultStreamLoadManager.java
@@ -23,6 +23,7 @@ import com.starrocks.data.load.stream.EnvUtils;
 import com.starrocks.data.load.stream.LabelGenerator;
 import com.starrocks.data.load.stream.LabelGeneratorFactory;
 import com.starrocks.data.load.stream.LoadMetrics;
+import com.starrocks.data.load.stream.StreamLoadDataFormat;
 import com.starrocks.data.load.stream.StreamLoadManager;
 import com.starrocks.data.load.stream.StreamLoadResponse;
 import com.starrocks.data.load.stream.StreamLoadSnapshot;
@@ -1697,6 +1698,13 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
     @Override
     public void write(String uniqueKey, String database, String table, String... rows) {
         TableRegion region = getCacheRegion(uniqueKey, database, table);
+        if (region.getProperties() != null
+                && region.getProperties().getDataFormat() instanceof StreamLoadDataFormat.ArrowFormat) {
+            throw new IllegalStateException(
+                    "Arrow format requires the byte[] write API. "
+                    + "String-based writes will corrupt the Arrow IPC stream. "
+                    + "Use write(uniqueKey, database, table, byte[]...) instead.");
+        }
         for (String row : rows) {
             checkAndThrowException();
             if (LOG.isTraceEnabled()) {
@@ -1704,6 +1712,23 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
                         uniqueKey == null ? "null" : uniqueKey, database, table, row);
             }
             int bytes = region.write(row.getBytes(StandardCharsets.UTF_8));
+            blockIfCacheFull(currentCacheBytes.addAndGet(bytes));
+        }
+    }
+
+    @Override
+    public void write(String uniqueKey, String database, String table, byte[]... rows) {
+        TableRegion region = getCacheRegion(uniqueKey, database, table);
+        for (byte[] row : rows) {
+            if (row == null) {
+                continue;
+            }
+            checkAndThrowException();
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Write binary uniqueKey {}, database {}, table {}, {} bytes",
+                        uniqueKey == null ? "null" : uniqueKey, database, table, row.length);
+            }
+            int bytes = region.write(row);
             blockIfCacheFull(currentCacheBytes.addAndGet(bytes));
         }
     }
@@ -2011,9 +2036,35 @@ public class DefaultStreamLoadManager implements StreamLoadManager, Serializable
         String uniqueKey = "P" + partition + "-" + StreamLoadUtils.getTableUniqueKey(database, table);
         partitionTracker.onWrite(partition);
         TableRegion region = getCacheRegion(uniqueKey, database, table, partition);
+        if (region.getProperties() != null
+                && region.getProperties().getDataFormat() instanceof StreamLoadDataFormat.ArrowFormat) {
+            throw new IllegalStateException(
+                    "Arrow format requires the byte[] write API. "
+                    + "String-based writes will corrupt the Arrow IPC stream. "
+                    + "Use write(partition, database, table, byte[]...) instead.");
+        }
         for (String row : rows) {
             checkAndThrowException();
             int bytes = region.write(row.getBytes(StandardCharsets.UTF_8));
+            blockIfCacheFull(currentCacheBytes.addAndGet(bytes));
+        }
+    }
+
+    @Override
+    public void write(int partition, String database, String table, byte[]... rows) {
+        if (!multiTableTransactionEnabled) {
+            write((String) null, database, table, rows);
+            return;
+        }
+        String uniqueKey = "P" + partition + "-" + StreamLoadUtils.getTableUniqueKey(database, table);
+        partitionTracker.onWrite(partition);
+        TableRegion region = getCacheRegion(uniqueKey, database, table, partition);
+        for (byte[] row : rows) {
+            if (row == null) {
+                continue;
+            }
+            checkAndThrowException();
+            int bytes = region.write(row);
             blockIfCacheFull(currentCacheBytes.addAndGet(bytes));
         }
     }

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/StreamLoadManagerV2.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/StreamLoadManagerV2.java
@@ -64,7 +64,17 @@ public class StreamLoadManagerV2 implements StreamLoadManager, Serializable {
     }
 
     @Override
+    public void write(String uniqueKey, String database, String table, byte[]... rows) {
+        delegateManager.write(uniqueKey, database, table, rows);
+    }
+
+    @Override
     public void write(int partition, String database, String table, String... rows) {
+        delegateManager.write(partition, database, table, rows);
+    }
+
+    @Override
+    public void write(int partition, String database, String table, byte[]... rows) {
         delegateManager.write(partition, database, table, rows);
     }
 

--- a/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/TransactionTableRegion.java
+++ b/starrocks-stream-load-sdk/src/main/java/com/starrocks/data/load/stream/v2/TransactionTableRegion.java
@@ -390,8 +390,17 @@ public class TransactionTableRegion implements TableRegion {
         if (activeChunk == null || activeChunk.numRows() == 0) {
             return;
         }
-        lastSwitchedChunkId = activeChunk.getChunkId();
-        inactiveChunks.add(activeChunk);
+        if (!properties.getDataFormat().supportsBatching() && activeChunk.numRows() > 1) {
+            for (byte[] row : activeChunk.getRows()) {
+                Chunk singleChunk = new Chunk(properties.getDataFormat(), chunkIdGenerator.getAndIncrement());
+                singleChunk.addRow(row);
+                lastSwitchedChunkId = singleChunk.getChunkId();
+                inactiveChunks.add(singleChunk);
+            }
+        } else {
+            lastSwitchedChunkId = activeChunk.getChunkId();
+            inactiveChunks.add(activeChunk);
+        }
         activeChunk = new Chunk(properties.getDataFormat(), chunkIdGenerator.getAndIncrement());
     }
 
@@ -503,6 +512,11 @@ public class TransactionTableRegion implements TableRegion {
     /** Returns {@code true} if {@code inactiveChunks} is non-empty. */
     public boolean hasInactiveChunks() {
         return !inactiveChunks.isEmpty();
+    }
+
+    /** Returns the number of inactive chunks. */
+    public int getInactiveChunksCount() {
+        return inactiveChunks.size();
     }
 
     /** Returns the timestamp (epoch ms) of the last switchChunkForCommit. */
@@ -687,9 +701,10 @@ public class TransactionTableRegion implements TableRegion {
     protected int write0(byte[] row) {
         if (!multiTableTransactionEnabled) {
             // Non-multi-table: original behavior — switch when a single row would
-            // exceed chunk size or row limits, so individual HTTP requests stay
-            // bounded.
-            if (activeChunk.estimateChunkSize(row) > properties.getChunkLimit()
+            // exceed chunk size or row limits, or when format does not support batching
+            // (e.g. Arrow IPC streams), so individual HTTP requests stay bounded.
+            if (!properties.getDataFormat().supportsBatching()
+                    || activeChunk.estimateChunkSize(row) > properties.getChunkLimit()
                     || activeChunk.numRows() >= properties.getMaxBufferRows()) {
                 switchChunk();
             }

--- a/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/ChunkTest.java
+++ b/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/ChunkTest.java
@@ -22,6 +22,10 @@ package com.starrocks.data.load.stream;
 
 import org.junit.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -30,6 +34,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 public class ChunkTest {
@@ -45,6 +50,11 @@ public class ChunkTest {
     }
 
     @Test
+    public void testArrowChunk() {
+        testChunkBase(StreamLoadDataFormat.ARROW);
+    }
+
+    @Test
     public void testEmptyCsvChunk() {
         testEmptyChunkBase(StreamLoadDataFormat.CSV);
     }
@@ -52,6 +62,11 @@ public class ChunkTest {
     @Test
     public void testEmptyJsonChunk() {
         testEmptyChunkBase(StreamLoadDataFormat.JSON);
+    }
+
+    @Test
+    public void testEmptyArrowChunk() {
+        testEmptyChunkBase(StreamLoadDataFormat.ARROW);
     }
 
     private void testEmptyChunkBase(StreamLoadDataFormat format) {
@@ -106,5 +121,82 @@ public class ChunkTest {
             assertArrayEquals(expectedItem, actualItem);
         }
         assertFalse(actualIterator.hasNext());
+    }
+
+    /**
+     * Verifies that arbitrary binary data (including bytes that are invalid
+     * UTF-8) survives the Arrow chunk path without corruption.  This is the
+     * key invariant that the byte[] write API is designed to protect.
+     */
+    @Test
+    public void testArrowBinaryIntegrity() {
+        // Arrow IPC magic bytes and padding that are NOT valid UTF-8
+        byte[] arrowPayload = new byte[] {
+            (byte) 0x41, (byte) 0x52, (byte) 0x52, (byte) 0x4F, // "ARRO"
+            (byte) 0x57, (byte) 0x31, (byte) 0x00, (byte) 0x00, // "W1\0\0"
+            (byte) 0xFF, (byte) 0xFE, (byte) 0xFD, (byte) 0x80, // non-UTF-8 bytes
+            (byte) 0xC0, (byte) 0xC1, (byte) 0xF5, (byte) 0xF6, // invalid UTF-8 lead bytes
+        };
+
+        Chunk chunk = new Chunk(StreamLoadDataFormat.ARROW, 1);
+        chunk.addRow(arrowPayload);
+
+        assertEquals(1, chunk.numRows());
+        assertEquals(arrowPayload.length, chunk.rowBytes());
+
+        // Arrow format returns empty first/delimiter/end, so chunkBytes == rowBytes
+        assertEquals(arrowPayload.length, chunk.chunkBytes());
+
+        // Verify byte-for-byte fidelity through the iterator
+        Iterator<byte[]> iter = chunk.iterator();
+        assertTrue(iter.hasNext());
+        assertArrayEquals(new byte[0], iter.next()); // first()
+        assertTrue(iter.hasNext());
+        assertArrayEquals(arrowPayload, iter.next()); // the payload
+        assertTrue(iter.hasNext());
+        assertArrayEquals(new byte[0], iter.next()); // end()
+        assertFalse(iter.hasNext());
+    }
+
+    @Test
+    public void testSupportsBatchingContract() {
+        assertTrue(StreamLoadDataFormat.CSV.supportsBatching());
+        assertTrue(StreamLoadDataFormat.JSON.supportsBatching());
+        assertFalse(StreamLoadDataFormat.ARROW.supportsBatching());
+    }
+
+    @Test
+    public void testArrowFormatEqualityAndSerialization() throws Exception {
+        StreamLoadDataFormat.ArrowFormat format1 = new StreamLoadDataFormat.ArrowFormat();
+        StreamLoadDataFormat.ArrowFormat format2 = new StreamLoadDataFormat.ArrowFormat();
+
+        assertEquals(format1, format2);
+        assertEquals(format1, StreamLoadDataFormat.ARROW);
+        assertEquals(format1.hashCode(), format2.hashCode());
+        assertEquals("ArrowFormat{}", format1.toString());
+
+        // Test serialization roundtrip preserves canonical singleton via readResolve
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+            oos.writeObject(format1);
+        }
+        try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
+            Object deserialized = ois.readObject();
+            assertSame(StreamLoadDataFormat.ARROW, deserialized);
+        }
+    }
+
+    @Test
+    public void testChunkGetRows() {
+        Chunk chunk = new Chunk(StreamLoadDataFormat.ARROW, 42);
+        byte[] row1 = new byte[]{1, 2, 3};
+        byte[] row2 = new byte[]{4, 5, 6};
+        chunk.addRow(row1);
+        chunk.addRow(row2);
+
+        List<byte[]> rows = chunk.getRows();
+        assertEquals(2, rows.size());
+        assertArrayEquals(row1, rows.get(0));
+        assertArrayEquals(row2, rows.get(1));
     }
 }

--- a/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/SDKIngestionBenchmark.java
+++ b/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/SDKIngestionBenchmark.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2021-present StarRocks, Inc. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.starrocks.data.load.stream;
+
+import org.junit.Test;
+import java.lang.management.ManagementFactory;
+import java.nio.charset.StandardCharsets;
+
+public class SDKIngestionBenchmark {
+
+    @Test
+    public void runBenchmark() {
+        main(new String[0]);
+    }
+
+    public static void main(String[] args) {
+        System.out.println("=== StarRocks SDK Performance Benchmark ===");
+        
+        // 1. JSON Chunk Appends Benchmark
+        benchmarkJsonChunkAppends();
+
+        // 2. CSV Chunk Appends Benchmark
+        benchmarkCsvChunkAppends();
+
+        // 3. Arrow Chunk Appends Benchmark
+        benchmarkArrowChunkAppends();
+        
+        // 4. String-to-Byte Conversion / Write overhead simulation
+        benchmarkWriteOverhead();
+    }
+
+    private static void benchmarkJsonChunkAppends() {
+        int warmups = 5;
+        int iterations = 10;
+        int rowsPerChunk = 200_000;
+        byte[] row = "{\"timestamp_ns\":1718012345000000000,\"timestamp_dt\":\"2024-06-10 10:10:10\",\"trace_id\":\"4bf92f3577b34da6a3ce929d0e0e4736\",\"span_id\":\"00f067aa0ba902b7\",\"span_name\":\"HTTP GET /api/v1/resource\",\"span_kind\":\"SPAN_KIND_SERVER\",\"service_name\":\"my-service\",\"service_version\":\"1.0.0\",\"genai_operation_name\":\"chat\",\"genai_provider_name\":\"openai\",\"genai_request_model\":\"gpt-4\",\"genai_response_model\":\"gpt-4\",\"duration_ms\":120.5,\"input_tokens\":150,\"output_tokens\":200,\"cache_read_input_tokens\":0}".getBytes(StandardCharsets.UTF_8);
+
+        System.out.println("\n--- 1. JSON Chunk Appends Benchmark ---");
+        System.out.println("Appending " + rowsPerChunk + " rows per chunk...");
+
+        // Warmup
+        for (int i = 0; i < warmups; i++) {
+            runJsonChunkIteration(rowsPerChunk, row);
+        }
+
+        // Measure
+        com.sun.management.ThreadMXBean threadMXBean = (com.sun.management.ThreadMXBean) ManagementFactory.getThreadMXBean();
+        long startAllocated = threadMXBean.getThreadAllocatedBytes(Thread.currentThread().getId());
+        long startTime = System.nanoTime();
+
+        for (int i = 0; i < iterations; i++) {
+            runJsonChunkIteration(rowsPerChunk, row);
+        }
+
+        long endTime = System.nanoTime();
+        long endAllocated = threadMXBean.getThreadAllocatedBytes(Thread.currentThread().getId());
+
+        double durationSec = (endTime - startTime) / 1_000_000_000.0;
+        long totalAllocatedBytes = endAllocated - startAllocated;
+        double allocatedMbPerChunk = (double) totalAllocatedBytes / iterations / (1024 * 1024);
+
+        System.out.printf("Total duration: %.3f seconds%n", durationSec);
+        System.out.printf("Throughput: %.2f ops/sec (chunks/sec)%n", (double) iterations / durationSec);
+        System.out.printf("Heap allocated per chunk: %.2f MB%n", allocatedMbPerChunk);
+    }
+
+    private static void runJsonChunkIteration(int rows, byte[] row) {
+        Chunk chunk = new Chunk(StreamLoadDataFormat.JSON, 1);
+        for (int i = 0; i < rows; i++) {
+            chunk.addRow(row);
+        }
+        chunk.release();
+    }
+
+    private static void benchmarkCsvChunkAppends() {
+        int warmups = 5;
+        int iterations = 10;
+        int rowsPerChunk = 200_000;
+        byte[] row = "1718012345000000000,2024-06-10 10:10:10,4bf92f3577b34da6a3ce929d0e0e4736,00f067aa0ba902b7,HTTP GET /api/v1/resource,SPAN_KIND_SERVER,my-service,1.0.0,chat,openai,gpt-4,gpt-4,120.5,150,200,0".getBytes(StandardCharsets.UTF_8);
+
+        System.out.println("\n--- 2. CSV Chunk Appends Benchmark ---");
+        System.out.println("Appending " + rowsPerChunk + " rows per chunk...");
+
+        // Warmup
+        for (int i = 0; i < warmups; i++) {
+            runCsvChunkIteration(rowsPerChunk, row);
+        }
+
+        // Measure
+        com.sun.management.ThreadMXBean threadMXBean = (com.sun.management.ThreadMXBean) ManagementFactory.getThreadMXBean();
+        long startAllocated = threadMXBean.getThreadAllocatedBytes(Thread.currentThread().getId());
+        long startTime = System.nanoTime();
+
+        for (int i = 0; i < iterations; i++) {
+            runCsvChunkIteration(rowsPerChunk, row);
+        }
+
+        long endTime = System.nanoTime();
+        long endAllocated = threadMXBean.getThreadAllocatedBytes(Thread.currentThread().getId());
+
+        double durationSec = (endTime - startTime) / 1_000_000_000.0;
+        long totalAllocatedBytes = endAllocated - startAllocated;
+        double allocatedMbPerChunk = (double) totalAllocatedBytes / iterations / (1024 * 1024);
+
+        System.out.printf("Total duration: %.3f seconds%n", durationSec);
+        System.out.printf("Throughput: %.2f ops/sec (chunks/sec)%n", (double) iterations / durationSec);
+        System.out.printf("Heap allocated per chunk: %.2f MB%n", allocatedMbPerChunk);
+    }
+
+    private static void runCsvChunkIteration(int rows, byte[] row) {
+        Chunk chunk = new Chunk(StreamLoadDataFormat.CSV, 1);
+        for (int i = 0; i < rows; i++) {
+            chunk.addRow(row);
+        }
+        chunk.release();
+    }
+
+    private static void benchmarkArrowChunkAppends() {
+        int warmups = 5;
+        int iterations = 10;
+        int rowsPerChunk = 200_000;
+        // Simulate a pre-serialized Arrow RecordBatch payload
+        byte[] row = new byte[256]; 
+
+        System.out.println("\n--- 3. Arrow Chunk Appends Benchmark (Zero-copy binary append test) ---");
+        System.out.println("Appending " + rowsPerChunk + " payloads per chunk...");
+
+        // Warmup
+        for (int i = 0; i < warmups; i++) {
+            runArrowChunkIteration(rowsPerChunk, row);
+        }
+
+        // Measure
+        com.sun.management.ThreadMXBean threadMXBean = (com.sun.management.ThreadMXBean) ManagementFactory.getThreadMXBean();
+        long startAllocated = threadMXBean.getThreadAllocatedBytes(Thread.currentThread().getId());
+        long startTime = System.nanoTime();
+
+        for (int i = 0; i < iterations; i++) {
+            runArrowChunkIteration(rowsPerChunk, row);
+        }
+
+        long endTime = System.nanoTime();
+        long endAllocated = threadMXBean.getThreadAllocatedBytes(Thread.currentThread().getId());
+
+        double durationSec = (endTime - startTime) / 1_000_000_000.0;
+        long totalAllocatedBytes = endAllocated - startAllocated;
+        double allocatedMbPerChunk = (double) totalAllocatedBytes / iterations / (1024 * 1024);
+
+        System.out.printf("Total duration: %.3f seconds%n", durationSec);
+        System.out.printf("Throughput: %.2f ops/sec (chunks/sec)%n", (double) iterations / durationSec);
+        System.out.printf("Heap allocated per chunk: %.2f MB%n", allocatedMbPerChunk);
+    }
+
+    private static void runArrowChunkIteration(int rows, byte[] row) {
+        Chunk chunk = new Chunk(StreamLoadDataFormat.ARROW, 1);
+        for (int i = 0; i < rows; i++) {
+            chunk.addRow(row);
+        }
+        chunk.release();
+    }
+
+    private static void benchmarkWriteOverhead() {
+        int warmups = 5;
+        int iterations = 1_000_000;
+        String rowStr = "{\"timestamp_ns\":1718012345000000000,\"timestamp_dt\":\"2024-06-10 10:10:10\",\"trace_id\":\"4bf92f3577b34da6a3ce929d0e0e4736\",\"span_id\":\"00f067aa0ba902b7\",\"span_name\":\"HTTP GET /api/v1/resource\",\"span_kind\":\"SPAN_KIND_SERVER\",\"service_name\":\"my-service\",\"service_version\":\"1.0.0\",\"genai_operation_name\":\"chat\",\"genai_provider_name\":\"openai\",\"genai_request_model\":\"gpt-4\",\"genai_response_model\":\"gpt-4\",\"duration_ms\":120.5,\"input_tokens\":150,\"output_tokens\":200,\"cache_read_input_tokens\":0}";
+        byte[] rowBytes = rowStr.getBytes(StandardCharsets.UTF_8);
+
+        System.out.println("\n--- 4. Write Overhead Benchmark (String conversion vs Direct Bytes) ---");
+        System.out.println("Processing " + iterations + " writes...");
+
+        // Warmup
+        for (int i = 0; i < warmups; i++) {
+            runWriteStringIteration(iterations, rowStr);
+            runWriteByteIteration(iterations, rowBytes);
+        }
+
+        // Measure String approach
+        com.sun.management.ThreadMXBean threadMXBean = (com.sun.management.ThreadMXBean) ManagementFactory.getThreadMXBean();
+        long startAllocated = threadMXBean.getThreadAllocatedBytes(Thread.currentThread().getId());
+        long startTime = System.nanoTime();
+
+        runWriteStringIteration(iterations, rowStr);
+
+        long endTime = System.nanoTime();
+        long endAllocated = threadMXBean.getThreadAllocatedBytes(Thread.currentThread().getId());
+
+        double stringDuration = (endTime - startTime) / 1_000_000_000.0;
+        long stringAllocatedBytes = endAllocated - startAllocated;
+
+        // Measure Byte approach
+        startAllocated = threadMXBean.getThreadAllocatedBytes(Thread.currentThread().getId());
+        startTime = System.nanoTime();
+
+        runWriteByteIteration(iterations, rowBytes);
+
+        endTime = System.nanoTime();
+        endAllocated = threadMXBean.getThreadAllocatedBytes(Thread.currentThread().getId());
+
+        double byteDuration = (endTime - startTime) / 1_000_000_000.0;
+        long byteAllocatedBytes = endAllocated - startAllocated;
+
+        System.out.printf("String-to-Bytes duration: %.3f seconds, heap allocated: %.2f MB%n", 
+                stringDuration, (double) stringAllocatedBytes / (1024 * 1024));
+        System.out.printf("Direct-Bytes duration:    %.3f seconds, heap allocated: %.2f MB%n", 
+                byteDuration, (double) byteAllocatedBytes / (1024 * 1024));
+        System.out.printf("Throughput difference: String path: %.2f ops/sec, Byte path: %.2f ops/sec%n", 
+                (double) iterations / stringDuration, (double) iterations / byteDuration);
+        System.out.printf("Allocation savings: %.2f%%%n", 
+                (1.0 - (double) byteAllocatedBytes / stringAllocatedBytes) * 100.0);
+    }
+
+    private static void runWriteStringIteration(int count, String row) {
+        long dummy = 0;
+        for (int i = 0; i < count; i++) {
+            byte[] bytes = row.getBytes(StandardCharsets.UTF_8);
+            dummy += bytes.length;
+        }
+    }
+
+    private static void runWriteByteIteration(int count, byte[] row) {
+        long dummy = 0;
+        for (int i = 0; i < count; i++) {
+            // direct write, no-op or just simulate reference use
+            dummy += row.length;
+        }
+    }
+}

--- a/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/SDKIngestionBenchmark.java
+++ b/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/SDKIngestionBenchmark.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2021-present StarRocks, Inc. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.starrocks.data.load.stream;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import java.lang.management.ManagementFactory;
+import java.nio.charset.StandardCharsets;
+
+public class SDKIngestionBenchmark {
+
+    @Test
+    @Ignore("Manual benchmark — run explicitly, not on every CI build")
+    public void runBenchmark() {
+        main(new String[0]);
+    }
+
+    public static void main(String[] args) {
+        System.out.println("=== StarRocks SDK Performance Benchmark ===");
+        
+        // 1. JSON Chunk Appends Benchmark
+        benchmarkJsonChunkAppends();
+
+        // 2. CSV Chunk Appends Benchmark
+        benchmarkCsvChunkAppends();
+
+        // 3. Arrow Chunk Appends Benchmark
+        benchmarkArrowChunkAppends();
+        
+        // 4. String-to-Byte Conversion / Write overhead simulation
+        benchmarkWriteOverhead();
+    }
+
+    private static void benchmarkJsonChunkAppends() {
+        int warmups = 5;
+        int iterations = 10;
+        int rowsPerChunk = 200_000;
+        byte[] row = "{\"timestamp_ns\":1718012345000000000,\"timestamp_dt\":\"2024-06-10 10:10:10\",\"trace_id\":\"4bf92f3577b34da6a3ce929d0e0e4736\",\"span_id\":\"00f067aa0ba902b7\",\"span_name\":\"HTTP GET /api/v1/resource\",\"span_kind\":\"SPAN_KIND_SERVER\",\"service_name\":\"my-service\",\"service_version\":\"1.0.0\",\"genai_operation_name\":\"chat\",\"genai_provider_name\":\"openai\",\"genai_request_model\":\"gpt-4\",\"genai_response_model\":\"gpt-4\",\"duration_ms\":120.5,\"input_tokens\":150,\"output_tokens\":200,\"cache_read_input_tokens\":0}".getBytes(StandardCharsets.UTF_8);
+
+        System.out.println("\n--- 1. JSON Chunk Appends Benchmark ---");
+        System.out.println("Appending " + rowsPerChunk + " rows per chunk...");
+
+        // Warmup
+        for (int i = 0; i < warmups; i++) {
+            runJsonChunkIteration(rowsPerChunk, row);
+        }
+
+        // Measure
+        com.sun.management.ThreadMXBean threadMXBean = (com.sun.management.ThreadMXBean) ManagementFactory.getThreadMXBean();
+        long startAllocated = threadMXBean.getThreadAllocatedBytes(Thread.currentThread().getId());
+        long startTime = System.nanoTime();
+
+        for (int i = 0; i < iterations; i++) {
+            runJsonChunkIteration(rowsPerChunk, row);
+        }
+
+        long endTime = System.nanoTime();
+        long endAllocated = threadMXBean.getThreadAllocatedBytes(Thread.currentThread().getId());
+
+        double durationSec = (endTime - startTime) / 1_000_000_000.0;
+        long totalAllocatedBytes = endAllocated - startAllocated;
+        double allocatedMbPerChunk = (double) totalAllocatedBytes / iterations / (1024 * 1024);
+
+        System.out.printf("Total duration: %.3f seconds%n", durationSec);
+        System.out.printf("Throughput: %.2f ops/sec (chunks/sec)%n", (double) iterations / durationSec);
+        System.out.printf("Heap allocated per chunk: %.2f MB%n", allocatedMbPerChunk);
+    }
+
+    private static void runJsonChunkIteration(int rows, byte[] row) {
+        Chunk chunk = new Chunk(StreamLoadDataFormat.JSON, 1);
+        for (int i = 0; i < rows; i++) {
+            chunk.addRow(row);
+        }
+        chunk.release();
+    }
+
+    private static void benchmarkCsvChunkAppends() {
+        int warmups = 5;
+        int iterations = 10;
+        int rowsPerChunk = 200_000;
+        byte[] row = "1718012345000000000,2024-06-10 10:10:10,4bf92f3577b34da6a3ce929d0e0e4736,00f067aa0ba902b7,HTTP GET /api/v1/resource,SPAN_KIND_SERVER,my-service,1.0.0,chat,openai,gpt-4,gpt-4,120.5,150,200,0".getBytes(StandardCharsets.UTF_8);
+
+        System.out.println("\n--- 2. CSV Chunk Appends Benchmark ---");
+        System.out.println("Appending " + rowsPerChunk + " rows per chunk...");
+
+        // Warmup
+        for (int i = 0; i < warmups; i++) {
+            runCsvChunkIteration(rowsPerChunk, row);
+        }
+
+        // Measure
+        com.sun.management.ThreadMXBean threadMXBean = (com.sun.management.ThreadMXBean) ManagementFactory.getThreadMXBean();
+        long startAllocated = threadMXBean.getThreadAllocatedBytes(Thread.currentThread().getId());
+        long startTime = System.nanoTime();
+
+        for (int i = 0; i < iterations; i++) {
+            runCsvChunkIteration(rowsPerChunk, row);
+        }
+
+        long endTime = System.nanoTime();
+        long endAllocated = threadMXBean.getThreadAllocatedBytes(Thread.currentThread().getId());
+
+        double durationSec = (endTime - startTime) / 1_000_000_000.0;
+        long totalAllocatedBytes = endAllocated - startAllocated;
+        double allocatedMbPerChunk = (double) totalAllocatedBytes / iterations / (1024 * 1024);
+
+        System.out.printf("Total duration: %.3f seconds%n", durationSec);
+        System.out.printf("Throughput: %.2f ops/sec (chunks/sec)%n", (double) iterations / durationSec);
+        System.out.printf("Heap allocated per chunk: %.2f MB%n", allocatedMbPerChunk);
+    }
+
+    private static void runCsvChunkIteration(int rows, byte[] row) {
+        Chunk chunk = new Chunk(StreamLoadDataFormat.CSV, 1);
+        for (int i = 0; i < rows; i++) {
+            chunk.addRow(row);
+        }
+        chunk.release();
+    }
+
+    private static void benchmarkArrowChunkAppends() {
+        int warmups = 5;
+        int iterations = 10;
+        int rowsPerChunk = 200_000;
+        // Simulate a pre-serialized Arrow RecordBatch payload
+        byte[] row = new byte[256]; 
+
+        System.out.println("\n--- 3. Arrow Chunk Appends Benchmark (Zero-copy binary append test) ---");
+        System.out.println("Appending " + rowsPerChunk + " payloads per chunk...");
+
+        // Warmup
+        for (int i = 0; i < warmups; i++) {
+            runArrowChunkIteration(rowsPerChunk, row);
+        }
+
+        // Measure
+        com.sun.management.ThreadMXBean threadMXBean = (com.sun.management.ThreadMXBean) ManagementFactory.getThreadMXBean();
+        long startAllocated = threadMXBean.getThreadAllocatedBytes(Thread.currentThread().getId());
+        long startTime = System.nanoTime();
+
+        for (int i = 0; i < iterations; i++) {
+            runArrowChunkIteration(rowsPerChunk, row);
+        }
+
+        long endTime = System.nanoTime();
+        long endAllocated = threadMXBean.getThreadAllocatedBytes(Thread.currentThread().getId());
+
+        double durationSec = (endTime - startTime) / 1_000_000_000.0;
+        long totalAllocatedBytes = endAllocated - startAllocated;
+        double allocatedMbPerChunk = (double) totalAllocatedBytes / iterations / (1024 * 1024);
+
+        System.out.printf("Total duration: %.3f seconds%n", durationSec);
+        System.out.printf("Throughput: %.2f ops/sec (chunks/sec)%n", (double) iterations / durationSec);
+        System.out.printf("Heap allocated per chunk: %.2f MB%n", allocatedMbPerChunk);
+    }
+
+    private static void runArrowChunkIteration(int rows, byte[] row) {
+        Chunk chunk = new Chunk(StreamLoadDataFormat.ARROW, 1);
+        for (int i = 0; i < rows; i++) {
+            chunk.addRow(row);
+        }
+        chunk.release();
+    }
+
+    private static void benchmarkWriteOverhead() {
+        int warmups = 5;
+        int iterations = 1_000_000;
+        String rowStr = "{\"timestamp_ns\":1718012345000000000,\"timestamp_dt\":\"2024-06-10 10:10:10\",\"trace_id\":\"4bf92f3577b34da6a3ce929d0e0e4736\",\"span_id\":\"00f067aa0ba902b7\",\"span_name\":\"HTTP GET /api/v1/resource\",\"span_kind\":\"SPAN_KIND_SERVER\",\"service_name\":\"my-service\",\"service_version\":\"1.0.0\",\"genai_operation_name\":\"chat\",\"genai_provider_name\":\"openai\",\"genai_request_model\":\"gpt-4\",\"genai_response_model\":\"gpt-4\",\"duration_ms\":120.5,\"input_tokens\":150,\"output_tokens\":200,\"cache_read_input_tokens\":0}";
+        byte[] rowBytes = rowStr.getBytes(StandardCharsets.UTF_8);
+
+        System.out.println("\n--- 4. Write Overhead Benchmark (String conversion vs Direct Bytes) ---");
+        System.out.println("Processing " + iterations + " writes...");
+
+        // Warmup
+        for (int i = 0; i < warmups; i++) {
+            runWriteStringIteration(iterations, rowStr);
+            runWriteByteIteration(iterations, rowBytes);
+        }
+
+        // Measure String approach
+        com.sun.management.ThreadMXBean threadMXBean = (com.sun.management.ThreadMXBean) ManagementFactory.getThreadMXBean();
+        long startAllocated = threadMXBean.getThreadAllocatedBytes(Thread.currentThread().getId());
+        long startTime = System.nanoTime();
+
+        runWriteStringIteration(iterations, rowStr);
+
+        long endTime = System.nanoTime();
+        long endAllocated = threadMXBean.getThreadAllocatedBytes(Thread.currentThread().getId());
+
+        double stringDuration = (endTime - startTime) / 1_000_000_000.0;
+        long stringAllocatedBytes = endAllocated - startAllocated;
+
+        // Measure Byte approach
+        startAllocated = threadMXBean.getThreadAllocatedBytes(Thread.currentThread().getId());
+        startTime = System.nanoTime();
+
+        runWriteByteIteration(iterations, rowBytes);
+
+        endTime = System.nanoTime();
+        endAllocated = threadMXBean.getThreadAllocatedBytes(Thread.currentThread().getId());
+
+        double byteDuration = (endTime - startTime) / 1_000_000_000.0;
+        long byteAllocatedBytes = endAllocated - startAllocated;
+
+        System.out.printf("String-to-Bytes duration: %.3f seconds, heap allocated: %.2f MB%n", 
+                stringDuration, (double) stringAllocatedBytes / (1024 * 1024));
+        System.out.printf("Direct-Bytes duration:    %.3f seconds, heap allocated: %.2f MB%n", 
+                byteDuration, (double) byteAllocatedBytes / (1024 * 1024));
+        System.out.printf("Throughput difference: String path: %.2f ops/sec, Byte path: %.2f ops/sec%n", 
+                (double) iterations / stringDuration, (double) iterations / byteDuration);
+        System.out.printf("Allocation savings: %.2f%%%n", 
+                (1.0 - (double) byteAllocatedBytes / stringAllocatedBytes) * 100.0);
+    }
+
+    private static void runWriteStringIteration(int count, String row) {
+        long dummy = 0;
+        for (int i = 0; i < count; i++) {
+            byte[] bytes = row.getBytes(StandardCharsets.UTF_8);
+            dummy += bytes.length;
+        }
+    }
+
+    private static void runWriteByteIteration(int count, byte[] row) {
+        long dummy = 0;
+        for (int i = 0; i < count; i++) {
+            // direct write, no-op or just simulate reference use
+            dummy += row.length;
+        }
+    }
+}

--- a/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/StreamLoadPropertiesTest.java
+++ b/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/StreamLoadPropertiesTest.java
@@ -152,4 +152,33 @@ public class StreamLoadPropertiesTest {
 
         assertEquals(10000, props.getPublishTimeoutMs());
     }
+
+    @Test
+    public void testArrowFormatTableProperties() {
+        StreamLoadTableProperties tableProperties = StreamLoadTableProperties.builder()
+                .database("test_db")
+                .table("test_tbl")
+                .streamLoadDataFormat(StreamLoadDataFormat.ARROW)
+                .build();
+
+        assertEquals(StreamLoadDataFormat.ARROW, tableProperties.getDataFormat());
+        assertEquals("arrow", tableProperties.getDataFormat().name());
+        assertEquals(0, tableProperties.getDataFormat().first().length);
+        assertEquals(0, tableProperties.getDataFormat().delimiter().length);
+        assertEquals(0, tableProperties.getDataFormat().end().length);
+        assertEquals("arrow", tableProperties.getProperties().get("format"));
+    }
+
+    @Test
+    public void testArrowFormatPropertyNotDuplicated() {
+        StreamLoadTableProperties tableProperties = StreamLoadTableProperties.builder()
+                .database("test_db")
+                .table("test_tbl")
+                .streamLoadDataFormat(StreamLoadDataFormat.ARROW)
+                .addProperty("format", "arrow")
+                .build();
+
+        assertEquals(StreamLoadDataFormat.ARROW, tableProperties.getDataFormat());
+        assertEquals("arrow", tableProperties.getProperties().get("format"));
+    }
 }

--- a/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/mergecommit/TableTest.java
+++ b/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/mergecommit/TableTest.java
@@ -557,4 +557,37 @@ public class TableTest {
         assertTrue(flushReturned.get());
         assertNull(flushThrowable.get());
     }
+
+    @Test
+    public void testArrowWriteFlushesImmediately() {
+        StreamLoadTableProperties properties = StreamLoadTableProperties.builder()
+                .database("db")
+                .table("tbl")
+                .streamLoadDataFormat(StreamLoadDataFormat.ARROW)
+                .chunkLimit(1024 * 1024)
+                .build();
+        Table table = new Table(
+                properties.getDatabase(),
+                properties.getTable(),
+                manager,
+                loader,
+                properties,
+                3,
+                100,
+                30000,
+                1024 * 1024,
+                10
+        );
+
+        byte[] payload1 = new byte[]{1, 2, 3};
+        byte[] payload2 = new byte[]{4, 5, 6};
+
+        table.write(payload1);
+        table.write(payload2);
+
+        // Verify that 2 writes resulted in 2 separate HTTP sendLoad requests (one per payload)
+        assertEquals(2, sendLoadSpy.size());
+        assertEquals(1, sendLoadSpy.capturedRequests.get(0).loadRequest.getChunk().numRows());
+        assertEquals(1, sendLoadSpy.capturedRequests.get(1).loadRequest.getChunk().numRows());
+    }
 }

--- a/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/v2/StreamLoadManagerArrowBoundaryTest.java
+++ b/starrocks-stream-load-sdk/src/test/java/com/starrocks/data/load/stream/v2/StreamLoadManagerArrowBoundaryTest.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.starrocks.data.load.stream.v2;
+
+import com.starrocks.data.load.stream.Chunk;
+import com.starrocks.data.load.stream.StreamLoadDataFormat;
+import com.starrocks.data.load.stream.mergecommit.MergeCommitManager;
+import com.starrocks.data.load.stream.properties.StreamLoadProperties;
+import com.starrocks.data.load.stream.properties.StreamLoadTableProperties;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+public class StreamLoadManagerArrowBoundaryTest {
+
+    private static final String DB = "test_db";
+    private static final String TBL = "test_tbl";
+
+    private StreamLoadProperties createProperties(boolean multiTable) {
+        StreamLoadTableProperties tableProps = StreamLoadTableProperties.builder()
+                .database(DB)
+                .table(TBL)
+                .streamLoadDataFormat(StreamLoadDataFormat.ARROW)
+                .build();
+
+        StreamLoadProperties.Builder builder = StreamLoadProperties.builder()
+                .loadUrls("http://127.0.0.1:8030")
+                .username("root")
+                .password("")
+                .defaultTableProperties(tableProps)
+                .scanningFrequency(60000);
+
+        if (multiTable) {
+            builder.enableMultiTableTransaction();
+        }
+
+        return builder.build();
+    }
+
+    @Test
+    public void testArrowStringWriteFailsFast() {
+        StreamLoadProperties props = createProperties(false);
+        DefaultStreamLoadManager manager = new DefaultStreamLoadManager(props, true);
+        manager.init();
+        try {
+            manager.write(null, DB, TBL, "some string row");
+            fail("Expected IllegalStateException for String write with Arrow format");
+        } catch (IllegalStateException e) {
+            assertNotNull(e.getMessage());
+            assertEquals(
+                    "Arrow format requires the byte[] write API. "
+                    + "String-based writes will corrupt the Arrow IPC stream. "
+                    + "Use write(uniqueKey, database, table, byte[]...) instead.",
+                    e.getMessage());
+        } finally {
+            manager.close();
+        }
+    }
+
+    @Test
+    public void testArrowPartitionStringWriteFailsFast() {
+        StreamLoadProperties props = createProperties(true);
+        DefaultStreamLoadManager manager = new DefaultStreamLoadManager(props, true);
+        manager.init();
+        try {
+            manager.write(1, DB, TBL, "some string row");
+            fail("Expected IllegalStateException for String write with Arrow format in multi-table mode");
+        } catch (IllegalStateException e) {
+            assertNotNull(e.getMessage());
+            assertEquals(
+                    "Arrow format requires the byte[] write API. "
+                    + "String-based writes will corrupt the Arrow IPC stream. "
+                    + "Use write(partition, database, table, byte[]...) instead.",
+                    e.getMessage());
+        } finally {
+            manager.close();
+        }
+    }
+
+    @Test
+    public void testArrowBinaryWriteWithNullElements() {
+        StreamLoadProperties props = createProperties(false);
+        DefaultStreamLoadManager manager = new DefaultStreamLoadManager(props, true);
+        manager.init();
+        try {
+            byte[] validPayload = new byte[]{1, 2, 3};
+            // Passing null element alongside valid payload should not throw NullPointerException
+            manager.write(null, DB, TBL, (byte[]) null, validPayload);
+
+            TransactionTableRegion region = (TransactionTableRegion) manager.getCacheRegion(null, DB, TBL);
+            assertNotNull(region);
+            assertEquals(validPayload.length, region.getCacheBytes());
+        } finally {
+            manager.close();
+        }
+    }
+
+    @Test
+    public void testArrowBoundaryPreservationNonMultiTable() {
+        StreamLoadProperties props = createProperties(false);
+        DefaultStreamLoadManager manager = new DefaultStreamLoadManager(props, true);
+        manager.init();
+        try {
+            byte[] payload1 = new byte[]{1, 2, 3};
+            byte[] payload2 = new byte[]{4, 5, 6};
+
+            // Write 1: goes to activeChunk
+            manager.write(null, DB, TBL, payload1);
+            TransactionTableRegion region = (TransactionTableRegion) manager.getCacheRegion(null, DB, TBL);
+            assertEquals(0, region.getInactiveChunksCount());
+            assertEquals(payload1.length, region.getCacheBytes());
+
+            // Write 2: since format does not support batching, pre-write switch moves payload 1 to inactiveChunks
+            manager.write(null, DB, TBL, payload2);
+            assertEquals(1, region.getInactiveChunksCount());
+
+            // Now trigger switch for commit: moves payload 2 to inactiveChunks as well
+            region.switchChunkForCommit();
+            assertEquals(2, region.getInactiveChunksCount());
+
+            // Verify each inactive chunk contains exactly 1 row (no concatenation)
+            ChunkHttpEntity entity = (ChunkHttpEntity) region.getHttpEntity();
+            assertEquals(1, entity.getChunk().numRows());
+        } finally {
+            manager.close();
+        }
+    }
+
+    @Test
+    public void testArrowBoundaryPreservationMultiTableSplit() {
+        StreamLoadProperties props = createProperties(true);
+        DefaultStreamLoadManager manager = new DefaultStreamLoadManager(props, true);
+        manager.init();
+        try {
+            byte[] payload1 = new byte[]{1, 2, 3};
+            byte[] payload2 = new byte[]{4, 5, 6};
+
+            // Write 1 and 2 in multi-table mode: both accumulate in activeChunk during source transaction
+            manager.write(0, DB, TBL, payload1);
+            manager.write(0, DB, TBL, payload2);
+
+            String uniqueKey = "P0-" + com.starrocks.data.load.stream.StreamLoadUtils.getTableUniqueKey(DB, TBL);
+            TransactionTableRegion region = (TransactionTableRegion) manager.getCacheRegion(uniqueKey, DB, TBL, 0);
+            // Atomicity preserved mid-transaction: 0 inactive chunks, rows in activeChunk
+            assertEquals(0, region.getInactiveChunksCount());
+            assertEquals(payload1.length + payload2.length, region.getCacheBytes());
+
+            // When transaction completes, switchChunk splits activeChunk into separate 1-row chunks
+            region.switchChunkForCommit();
+            assertEquals(2, region.getInactiveChunksCount());
+
+            // Verify each chunk has exactly 1 row
+            ChunkHttpEntity entity = (ChunkHttpEntity) region.getHttpEntity();
+            assertEquals(1, entity.getChunk().numRows());
+        } finally {
+            manager.close();
+        }
+    }
+
+    @Test
+    public void testMergeCommitArrowStringWriteFailsFast() {
+        StreamLoadProperties props = createProperties(false);
+        MergeCommitManager manager = new MergeCommitManager(props);
+
+        try {
+            manager.write(null, DB, TBL, "some string row");
+            fail("Expected IllegalStateException for String write with Arrow format in MergeCommitManager");
+        } catch (IllegalStateException e) {
+            assertNotNull(e.getMessage());
+            assertEquals(
+                    "Arrow format requires the byte[] write API. "
+                    + "String-based writes will corrupt the Arrow IPC stream. "
+                    + "Use write(uniqueKey, database, table, byte[]...) instead.",
+                    e.getMessage());
+        }
+    }
+
+    @Test
+    public void testMergeCommitArrowNullElements() {
+        StreamLoadProperties props = createProperties(false);
+        MergeCommitManager manager = new MergeCommitManager(props);
+
+        // Passing null elements should be safely skipped without NPE
+        manager.write(null, DB, TBL, (byte[]) null);
+    }
+}


### PR DESCRIPTION
## What type of PR is this：
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes ：

#410 

## Problem Summary(Required) ：

This PR introduces native support for the Apache Arrow format into the `starrocks-stream-load-sdk`. This enables upstream ingestion pipelines (such as Flink connectors) to efficiently pump Arrow IPC RecordBatches into StarRocks without requiring intermediate row delimiters or string serialisation. 

This is in relation to the recently merged https://github.com/StarRocks/starrocks/pull/74593 that added support for Arrow via Stream Load.

### Brief change log

- **Added `ArrowFormat` to `StreamLoadDataFormat`**: Implements the `StreamLoadDataFormat` interface to provide 0-byte boundaries (`first`, `delimiter`, `end`), facilitating zero-copy appending of Arrow binaries directly to the chunk buffers. 
- **Header Injection in `StreamLoadTableProperties`**: Automatically maps and injects the `format: arrow` property into the stream load HTTP request headers when the `ARROW` data format is configured.
- **Architectural Documentation**: Added JavaDocs to `ArrowFormat` to explain the deliberate omission of Arrow dependencies for client-side schema validation. This maintains a lightweight SDK footprint by natively relying on the StarRocks `ArrowScanner` backend for robust IPC validation against HTTP `columns` headers.
- **Performance Benchmarks**: Updated `SDKIngestionBenchmark.java` to test JSON, CSV, and Arrow chunk append throughput, demonstrating a 100% reduction in string serialisation allocation overhead.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [x] This pr needs user documentation (for new or modified features or behaviors)
- [x] I have added documentation for my new feature or new function

