### PR TITLE
[Tool] Make Claude skills discoverable by Codex

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../.claude/skills


### PR DESCRIPTION
## Summary

- add a version-controlled `.agents/skills` symlink to `../.claude/skills`
- keep `.claude/skills` as the single source of truth for repository skills
- let Claude and Codex discover the same skills immediately after cloning on Linux, macOS, and WSL

## Why

Claude discovers repository skills under `.claude/skills`, while Codex discovers them under `.agents/skills`. Without a repository-level bridge, Codex users must create local links or copy the skills manually.

## Impact

New and existing skills remain maintained only under `.claude/skills`. Because the whole skill root is linked, future skills are also exposed to Codex without adding per-skill configuration.

## Validation

- verified Git records `.agents/skills` as symlink mode `120000`
- verified the link resolves to `../.claude/skills`
- verified `flink-connector-release/SKILL.md` is reachable through `.agents/skills`
- ran `codex debug prompt-input` with Codex CLI 0.146.0 and confirmed `flink-connector-release` appears in the available skills list